### PR TITLE
feat: add support for custom anomaly threshold

### DIFF
--- a/macros/edr/data_monitoring/anomaly_detection/get_anomaly_query.sql
+++ b/macros/edr/data_monitoring/anomaly_detection/get_anomaly_query.sql
@@ -1,10 +1,11 @@
-{% macro get_anomaly_query(test_metrics_table_relation, full_monitored_table_name, monitors, column_name = none, columns_only=false) %}
+{% macro get_anomaly_query(test_metrics_table_relation, full_monitored_table_name, monitors, column_name = none, columns_only=false, anomaly_threshold=none) %}
 
     {%- set global_min_bucket_start = elementary.get_global_min_bucket_start_as_datetime() %}
     {%- set metrics_min_time = "'"~ (global_min_bucket_start - modules.datetime.timedelta(elementary.get_config_var('backfill_days_per_run'))).strftime("%Y-%m-%d 00:00:00") ~"'" %}
     {%- set backfill_period = "'-" ~ elementary.get_config_var('backfill_days_per_run') ~ "'" %}
     {%- set test_execution_id = elementary.get_test_execution_id() %}
     {%- set test_unique_id = elementary.get_test_unique_id() %}
+    {%- set anomaly_score_threshold = elementary.get_anomaly_score_threshold(anomaly_threshold) %}
 
     {% set anomaly_query %}
 
@@ -98,7 +99,7 @@
                     when training_stddev = 0 then 0
                     else (metric_value - training_avg) / (training_stddev)
                 end as anomaly_score,
-                {{ elementary.get_config_var('anomaly_score_threshold') }} as anomaly_score_threshold,
+                {{ anomaly_score_threshold }} as anomaly_score_threshold,
                 {{ elementary.anomaly_detection_description() }},
                 source_value as anomalous_value,
                 bucket_start,
@@ -120,7 +121,7 @@
         )
 
         select * from calc_anomaly_score
-        where abs(anomaly_score) > {{ elementary.get_config_var('anomaly_score_threshold') }}
+        where abs(anomaly_score) > {{ anomaly_score_threshold }}
 
     {% endset %}
 

--- a/macros/edr/system/system_utils/get_config_var.sql
+++ b/macros/edr/system/system_utils/get_config_var.sql
@@ -1,7 +1,7 @@
 {% macro get_config_var(var_name) %}
 {% set default_config = {
          'days_back': 14,
-         'anomaly_score_threshold': 3,
+         'anomaly_sensitivity': 3,
          'backfill_days_per_run': 2,
          'alert_dbt_model_fail': true,
          'alert_dbt_model_skip': true,

--- a/macros/edr/tests/test_all_columns_anomalies.sql
+++ b/macros/edr/tests/test_all_columns_anomalies.sql
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 {% test all_columns_anomalies(model, column_anomalies = none, exclude_prefix = none, exclude_regexp = none) %}
+=======
+{% test all_columns_anomalies(model, column_anomalies = none, exclude_prefix = none, exclude_regexp = none, sensitivity=none) %}
+>>>>>>> feat: rename anomaly_threshold to sensitivity, update config var name
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('alerts_data_monitoring') }}
@@ -59,7 +63,11 @@
         {%- endif %}
         {%- set all_columns_monitors = monitors | unique | list %}
         {#- query if there is an anomaly in recent metrics -#}
+<<<<<<< HEAD
         {%- set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, all_columns_monitors, columns_only=true) %}
+=======
+        {%- set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, all_columns_monitors, columns_only=true, sensitivity=sensitivity) %}
+>>>>>>> feat: rename anomaly_threshold to sensitivity, update config var name
         {%- set temp_alerts_table_name = elementary.table_name_with_suffix(test_name_in_graph, '__anomalies') %}
         {{- elementary.debug_log('anomalies table: ' ~ database_name ~ '.' ~ schema_name ~ '.' ~ temp_alerts_table_name) }}
         {%- set anomalies_temp_table_exists, anomalies_temp_table_relation = dbt.get_or_create_relation(database=database_name,

--- a/macros/edr/tests/test_all_columns_anomalies.sql
+++ b/macros/edr/tests/test_all_columns_anomalies.sql
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-{% test all_columns_anomalies(model, column_anomalies = none, exclude_prefix = none, exclude_regexp = none) %}
-=======
 {% test all_columns_anomalies(model, column_anomalies = none, exclude_prefix = none, exclude_regexp = none, sensitivity=none) %}
->>>>>>> feat: rename anomaly_threshold to sensitivity, update config var name
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('alerts_data_monitoring') }}
@@ -63,11 +59,7 @@
         {%- endif %}
         {%- set all_columns_monitors = monitors | unique | list %}
         {#- query if there is an anomaly in recent metrics -#}
-<<<<<<< HEAD
-        {%- set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, all_columns_monitors, columns_only=true) %}
-=======
         {%- set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, all_columns_monitors, columns_only=true, sensitivity=sensitivity) %}
->>>>>>> feat: rename anomaly_threshold to sensitivity, update config var name
         {%- set temp_alerts_table_name = elementary.table_name_with_suffix(test_name_in_graph, '__anomalies') %}
         {{- elementary.debug_log('anomalies table: ' ~ database_name ~ '.' ~ schema_name ~ '.' ~ temp_alerts_table_name) }}
         {%- set anomalies_temp_table_exists, anomalies_temp_table_relation = dbt.get_or_create_relation(database=database_name,

--- a/macros/edr/tests/test_all_columns_anomalies.sql
+++ b/macros/edr/tests/test_all_columns_anomalies.sql
@@ -1,4 +1,4 @@
-{% test all_columns_anomalies(model, column_anomalies = none, exclude_prefix = none, exclude_regexp = none) %}
+{% test all_columns_anomalies(model, column_anomalies = none, exclude_prefix = none, exclude_regexp = none, anomaly_threshold=none) %}
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('alerts_data_monitoring') }}
@@ -59,8 +59,13 @@
         {%- endif %}
         {%- set all_columns_monitors = monitors | unique | list %}
         {#- query if there is an anomaly in recent metrics -#}
+<<<<<<< HEAD
         {%- set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, all_columns_monitors, columns_only=true) %}
         {%- set temp_alerts_table_name = elementary.table_name_with_suffix(test_name_in_graph, '__anomalies') %}
+=======
+        {%- set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, all_columns_monitors, columns_only=true, anomaly_threshold=anomaly_threshold) %}
+        {%- set temp_alerts_table_name = test_name_in_graph ~ '__anomalies' %}
+>>>>>>> feat: add support for custom anomaly threshold
         {{- elementary.debug_log('anomalies table: ' ~ database_name ~ '.' ~ schema_name ~ '.' ~ temp_alerts_table_name) }}
         {%- set anomalies_temp_table_exists, anomalies_temp_table_relation = dbt.get_or_create_relation(database=database_name,
                                                                                    schema=schema_name,

--- a/macros/edr/tests/test_all_columns_anomalies.sql
+++ b/macros/edr/tests/test_all_columns_anomalies.sql
@@ -1,4 +1,4 @@
-{% test all_columns_anomalies(model, column_anomalies = none, exclude_prefix = none, exclude_regexp = none, anomaly_threshold=none) %}
+{% test all_columns_anomalies(model, column_anomalies = none, exclude_prefix = none, exclude_regexp = none) %}
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('alerts_data_monitoring') }}
@@ -59,13 +59,8 @@
         {%- endif %}
         {%- set all_columns_monitors = monitors | unique | list %}
         {#- query if there is an anomaly in recent metrics -#}
-<<<<<<< HEAD
         {%- set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, all_columns_monitors, columns_only=true) %}
         {%- set temp_alerts_table_name = elementary.table_name_with_suffix(test_name_in_graph, '__anomalies') %}
-=======
-        {%- set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, all_columns_monitors, columns_only=true, anomaly_threshold=anomaly_threshold) %}
-        {%- set temp_alerts_table_name = test_name_in_graph ~ '__anomalies' %}
->>>>>>> feat: add support for custom anomaly threshold
         {{- elementary.debug_log('anomalies table: ' ~ database_name ~ '.' ~ schema_name ~ '.' ~ temp_alerts_table_name) }}
         {%- set anomalies_temp_table_exists, anomalies_temp_table_relation = dbt.get_or_create_relation(database=database_name,
                                                                                    schema=schema_name,

--- a/macros/edr/tests/test_column_anomalies.sql
+++ b/macros/edr/tests/test_column_anomalies.sql
@@ -1,4 +1,4 @@
-{% test column_anomalies(model, column_name, column_anomalies) %}
+{% test column_anomalies(model, column_name, column_anomalies, anomaly_threshold=none) %}
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('alerts_data_monitoring') }}
@@ -50,7 +50,7 @@
 
         {#- query if there is an anomaly in recent metrics -#}
         {%- set temp_table_name = elementary.relation_to_full_name(temp_table_relation) %}
-        {% set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, column_monitors, column_name) %}
+        {% set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, column_monitors, column_name, anomaly_threshold=anomaly_threshold) %}
         {{ elementary.debug_log('anomaly_query - \n' ~ anomaly_query) }}
         {%- set temp_alerts_table_name = elementary.table_name_with_suffix(test_name_in_graph, '__anomalies') %}
         {{ elementary.debug_log('anomalies table: ' ~ database_name ~ '.' ~ schema_name ~ '.' ~ temp_alerts_table_name) }}

--- a/macros/edr/tests/test_column_anomalies.sql
+++ b/macros/edr/tests/test_column_anomalies.sql
@@ -1,4 +1,4 @@
-{% test column_anomalies(model, column_name, column_anomalies, anomaly_threshold=none) %}
+{% test column_anomalies(model, column_name, column_anomalies, sensitivity=none) %}
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('alerts_data_monitoring') }}
@@ -50,7 +50,7 @@
 
         {#- query if there is an anomaly in recent metrics -#}
         {%- set temp_table_name = elementary.relation_to_full_name(temp_table_relation) %}
-        {% set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, column_monitors, column_name, anomaly_threshold=anomaly_threshold) %}
+        {% set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, column_monitors, column_name, sensitivity=sensitivity) %}
         {{ elementary.debug_log('anomaly_query - \n' ~ anomaly_query) }}
         {%- set temp_alerts_table_name = elementary.table_name_with_suffix(test_name_in_graph, '__anomalies') %}
         {{ elementary.debug_log('anomalies table: ' ~ database_name ~ '.' ~ schema_name ~ '.' ~ temp_alerts_table_name) }}

--- a/macros/edr/tests/test_table_anomalies.sql
+++ b/macros/edr/tests/test_table_anomalies.sql
@@ -1,4 +1,4 @@
-{% test table_anomalies(model, table_anomalies, freshness_column=none) %}
+{% test table_anomalies(model, table_anomalies, freshness_column=none, anomaly_threshold=none) %}
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('alerts_data_monitoring') }}
@@ -43,7 +43,7 @@
         {%- do elementary.create_or_replace(False, temp_table_relation, table_monitoring_query) %}
 
         {#- query if there is an anomaly in recent metrics -#}
-        {% set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, table_monitors) %}
+        {% set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, table_monitors, anomaly_threshold=anomaly_threshold) %}
         {{ elementary.debug_log('table monitors anomaly query - \n' ~ anomaly_query) }}
         {%- set temp_alerts_table_name = elementary.table_name_with_suffix(test_name_in_graph, '__anomalies') %}
         {{ elementary.debug_log('anomalies table: ' ~ database_name ~ '.' ~ schema_name ~ '.' ~ temp_alerts_table_name) }}

--- a/macros/edr/tests/test_table_anomalies.sql
+++ b/macros/edr/tests/test_table_anomalies.sql
@@ -1,4 +1,4 @@
-{% test table_anomalies(model, table_anomalies, freshness_column=none, anomaly_threshold=none) %}
+{% test table_anomalies(model, table_anomalies, freshness_column=none, sensitivity=none) %}
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('alerts_data_monitoring') }}
@@ -43,7 +43,7 @@
         {%- do elementary.create_or_replace(False, temp_table_relation, table_monitoring_query) %}
 
         {#- query if there is an anomaly in recent metrics -#}
-        {% set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, table_monitors, anomaly_threshold=anomaly_threshold) %}
+        {% set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, table_monitors, sensitivity=sensitivity) %}
         {{ elementary.debug_log('table monitors anomaly query - \n' ~ anomaly_query) }}
         {%- set temp_alerts_table_name = elementary.table_name_with_suffix(test_name_in_graph, '__anomalies') %}
         {{ elementary.debug_log('anomalies table: ' ~ database_name ~ '.' ~ schema_name ~ '.' ~ temp_alerts_table_name) }}

--- a/macros/edr/tests/test_utils/get_anomaly_score_threshold.sql
+++ b/macros/edr/tests/test_utils/get_anomaly_score_threshold.sql
@@ -1,7 +1,0 @@
-{% macro get_anomaly_score_threshold(anomaly_threshold) %}
-    {% if anomaly_threshold %}
-        {{ return(anomaly_threshold) }}
-    {% else %}
-        {{ return(elementary.get_config_var('anomaly_score_threshold')) }}
-    {% endif %}
-{% endmacro %}

--- a/macros/edr/tests/test_utils/get_anomaly_score_threshold.sql
+++ b/macros/edr/tests/test_utils/get_anomaly_score_threshold.sql
@@ -1,0 +1,7 @@
+{% macro get_anomaly_score_threshold(anomaly_threshold) %}
+    {% if anomaly_threshold %}
+        {{ return(anomaly_threshold) }}
+    {% else %}
+        {{ return(elementary.get_config_var('anomaly_score_threshold')) }}
+    {% endif %}
+{% endmacro %}

--- a/macros/edr/tests/test_utils/get_anomaly_sensitivity.sql
+++ b/macros/edr/tests/test_utils/get_anomaly_sensitivity.sql
@@ -1,0 +1,7 @@
+{% macro get_anomaly_sensitivity(sensitivity) %}
+    {% if sensitivity %}
+        {{ return(sensitivity) }}
+    {% else %}
+        {{ return(elementary.get_config_var('anomaly_sensitivity')) }}
+    {% endif %}
+{% endmacro %}

--- a/models/edr/data_monitoring/anomaly_detection/metrics_anomaly_score.sql
+++ b/models/edr/data_monitoring/anomaly_detection/metrics_anomaly_score.sql
@@ -70,7 +70,7 @@ final as (
 
     select *,
         case
-            when abs(z_score) > {{ elementary.get_config_var('anomaly_score_threshold') }} then true
+            when abs(z_score) > {{ elementary.get_config_var('anomaly_sensitivity') }} then true
             else false end
         as is_anomaly
     from metrics_anomaly_score


### PR DESCRIPTION
Aims to implement https://github.com/elementary-data/elementary/issues/71

* Introduces and implements `anomaly_threshold` arg in `get_anomaly_query_macros`
* Refactors logic to get the `anomaly_threshold` from user input (if provided) or config into a separate file under `test_utils/`
* Introduces the arg into `test_` files that use this function

Glad to incorporate any feedback received to help implement this 🚀 
Little fuzzy on how to run SQL integration tests, but happy to learn.