### PR TITLE
support passing backfill_days as a param for a specific test from the schema.yaml

### DIFF
--- a/integration_tests/macros/system/get_test_argument.sql
+++ b/integration_tests/macros/system/get_test_argument.sql
@@ -1,0 +1,6 @@
+{% macro get_test_argument(argument_name, value=none) %}
+  {% if value %}
+    {{ return(value) }}
+  {% else %}
+    {{ return(elementary.get_config_var(argument_name)) }}
+{% endmacro %}

--- a/macros/edr/data_monitoring/anomaly_detection/get_anomaly_query.sql
+++ b/macros/edr/data_monitoring/anomaly_detection/get_anomaly_query.sql
@@ -1,12 +1,12 @@
 {% macro get_anomaly_query(test_metrics_table_relation, full_monitored_table_name, monitors, column_name = none, columns_only=false, sensitivity=none, backfill_days=none) %}
 
-    {% set backfill_days_value = elementary.get_config_var(var_name='backfill_days', value=backfill_days) %}
+    {% set backfill_days_value = elementary.get_test_argument(argument_name='backfill_days', value=backfill_days) %}
     {%- set global_min_bucket_end = elementary.get_global_min_bucket_end_as_datetime() %}
     {%- set metrics_min_time = "'"~ (global_min_bucket_end - modules.datetime.timedelta(backfill_days_value)).strftime("%Y-%m-%d 00:00:00") ~"'" %}
     {%- set backfill_period = "'-" ~ backfill_days_value ~ "'" %}
     {%- set test_execution_id = elementary.get_test_execution_id() %}
     {%- set test_unique_id = elementary.get_test_unique_id() %}
-    {%- set anomaly_sensitivity = elementary.get_config_var(var_name='anomaly_sensitivity', value=sensitivity) %}
+    {%- set anomaly_sensitivity = elementary.get_test_argument(argument_name='anomaly_sensitivity', value=sensitivity) %}
 
     {% set anomaly_query %}
 

--- a/macros/edr/data_monitoring/anomaly_detection/get_anomaly_query.sql
+++ b/macros/edr/data_monitoring/anomaly_detection/get_anomaly_query.sql
@@ -1,11 +1,12 @@
-{% macro get_anomaly_query(test_metrics_table_relation, full_monitored_table_name, monitors, column_name = none, columns_only=false, sensitivity=none) %}
+{% macro get_anomaly_query(test_metrics_table_relation, full_monitored_table_name, monitors, column_name = none, columns_only=false, sensitivity=none, backfill_days=none) %}
 
+    {% set backfill_days_value = elementary.get_config_var(var_name='backfill_days', value=backfill_days) %}
     {%- set global_min_bucket_end = elementary.get_global_min_bucket_end_as_datetime() %}
-    {%- set metrics_min_time = "'"~ (global_min_bucket_end - modules.datetime.timedelta(elementary.get_config_var('backfill_days_per_run'))).strftime("%Y-%m-%d 00:00:00") ~"'" %}
-    {%- set backfill_period = "'-" ~ elementary.get_config_var('backfill_days_per_run') ~ "'" %}
+    {%- set metrics_min_time = "'"~ (global_min_bucket_end - modules.datetime.timedelta(backfill_days_value)).strftime("%Y-%m-%d 00:00:00") ~"'" %}
+    {%- set backfill_period = "'-" ~ backfill_days_value ~ "'" %}
     {%- set test_execution_id = elementary.get_test_execution_id() %}
     {%- set test_unique_id = elementary.get_test_unique_id() %}
-    {%- set anomaly_sensitivity = elementary.get_anomaly_sensitivity(sensitivity) %}
+    {%- set anomaly_sensitivity = elementary.get_config_var(var_name='anomaly_sensitivity', value=sensitivity) %}
 
     {% set anomaly_query %}
 

--- a/macros/edr/data_monitoring/data_monitors_configuration/get_buckets_configuration.sql
+++ b/macros/edr/data_monitoring/data_monitors_configuration/get_buckets_configuration.sql
@@ -19,16 +19,16 @@
     {{ return(max_bucket_end) }}
 {% endmacro %}
 
-{% macro get_backfill_bucket_start() %}
-    {%- set backfill_bucket_start = "'"~ (run_started_at - modules.datetime.timedelta(elementary.get_config_var('backfill_days_per_run'))).strftime("%Y-%m-%d 00:00:00") ~"'" %}
+{% macro get_backfill_bucket_start(backfill_days=none) %}
+    {%- set backfill_bucket_start = "'"~ (run_started_at - modules.datetime.timedelta(elementary.get_config_var(var_name='backfill_days', value=backfill_days))).strftime("%Y-%m-%d 00:00:00") ~"'" %}
     {{ return(backfill_bucket_start) }}
 {% endmacro %}
 
 
-{% macro get_min_bucket_start(full_table_name,monitors=none,column_name=none) %}
+{% macro get_min_bucket_start(full_table_name, monitors=none, column_name=none, backfill_days=none) %}
 
     {%- set global_min_bucket_start = elementary.get_global_min_bucket_start() %}
-    {%- set backfill_bucket_start = elementary.get_backfill_bucket_start() %}
+    {%- set backfill_bucket_start = elementary.get_backfill_bucket_start(backfill_days) %}
 
     {%- if monitors %}
         {%- set monitors_tuple = elementary.strings_list_to_tuple(monitors) %}

--- a/macros/edr/data_monitoring/data_monitors_configuration/get_buckets_configuration.sql
+++ b/macros/edr/data_monitoring/data_monitors_configuration/get_buckets_configuration.sql
@@ -20,7 +20,7 @@
 {% endmacro %}
 
 {% macro get_backfill_bucket_start(backfill_days=none) %}
-    {%- set backfill_bucket_start = "'"~ (run_started_at - modules.datetime.timedelta(elementary.get_config_var(var_name='backfill_days', value=backfill_days))).strftime("%Y-%m-%d 00:00:00") ~"'" %}
+    {%- set backfill_bucket_start = "'"~ (run_started_at - modules.datetime.timedelta(elementary.get_test_argument(argument_name='backfill_days', value=backfill_days))).strftime("%Y-%m-%d 00:00:00") ~"'" %}
     {{ return(backfill_bucket_start) }}
 {% endmacro %}
 

--- a/macros/edr/system/system_utils/get_config_var.sql
+++ b/macros/edr/system/system_utils/get_config_var.sql
@@ -1,22 +1,28 @@
-{% macro get_config_var(var_name) %}
-{% set default_config = {
-         'days_back': 14,
-         'anomaly_sensitivity': 3,
-         'backfill_days_per_run': 2,
-         'alert_dbt_model_fail': true,
-         'alert_dbt_model_skip': true,
-         'elementary_debug_logs': false,
-         'refresh_dbt_artifacts': false,
-         'dbt_artifacts_chunk_size': 50,
-         'edr_cli_run': false,
-         'max_int': 2147483647,
-         'schemas_to_alert_on_new_tables': [],
-         'custom_run_started_at': null,
-         'edr_monitors': {
-           'table': ['schema_changes', 'row_count', 'freshness'],
-           'column_any_type': ['null_count', 'null_percent'],
-           'column_string': ['min_length', 'max_length', 'average_length', 'missing_count', 'missing_percent'],
-           'column_numeric': ['min', 'max', 'zero_count', 'zero_percent', 'average', 'standard_deviation', 'variance']} 
-}%}
-{{ return(var(var_name, default_config.get(var_name))) }}
+{% macro get_config_var(var_name, value=none) %}
+  {% set default_config = {
+    'days_back': 14,
+    'anomaly_sensitivity': 3,
+    'backfill_days': 2,
+    'alert_dbt_model_fail': true,
+    'alert_dbt_model_skip': true,
+    'elementary_debug_logs': false,
+    'refresh_dbt_artifacts': false,
+    'dbt_artifacts_chunk_size': 50,
+    'edr_cli_run': false,
+    'max_int': 2147483647,
+    'schemas_to_alert_on_new_tables': [],
+    'custom_run_started_at': null,
+    'edr_monitors': {
+      'table': ['schema_changes', 'row_count', 'freshness'],
+      'column_any_type': ['null_count', 'null_percent'],
+      'column_string': ['min_length', 'max_length', 'average_length', 'missing_count', 'missing_percent'],
+      'column_numeric': ['min', 'max', 'zero_count', 'zero_percent', 'average', 'standard_deviation', 'variance']
+    } 
+  } %}
+
+  {% if value %}
+    {{ return(value) }}
+  {% else %}}
+    {{ return(var(var_name, default_config.get(var_name))) }}
+  {% endif %}
 {% endmacro %}

--- a/macros/edr/system/system_utils/get_config_var.sql
+++ b/macros/edr/system/system_utils/get_config_var.sql
@@ -1,4 +1,4 @@
-{% macro get_config_var(var_name, value=none) %}
+{% macro get_config_var(var_name) %}
   {% set default_config = {
     'days_back': 14,
     'anomaly_sensitivity': 3,
@@ -20,9 +20,5 @@
     } 
   } %}
 
-  {% if value %}
-    {{ return(value) }}
-  {% else %}}
-    {{ return(var(var_name, default_config.get(var_name))) }}
-  {% endif %}
+  {{ return(var(var_name, default_config.get(var_name))) }}
 {% endmacro %}

--- a/macros/edr/system/system_utils/get_test_argument.sql
+++ b/macros/edr/system/system_utils/get_test_argument.sql
@@ -3,4 +3,5 @@
     {{ return(value) }}
   {% else %}
     {{ return(elementary.get_config_var(argument_name)) }}
+  {% endif %}
 {% endmacro %}

--- a/macros/edr/tests/test_all_columns_anomalies.sql
+++ b/macros/edr/tests/test_all_columns_anomalies.sql
@@ -1,4 +1,4 @@
-{% test all_columns_anomalies(model, column_anomalies = none, exclude_prefix = none, exclude_regexp = none, timestamp_column = none, sensitivity = none) %}
+{% test all_columns_anomalies(model, column_anomalies = none, exclude_prefix = none, exclude_regexp = none, timestamp_column = none, sensitivity = none, backfill_days=none) %}
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('alerts_data_monitoring') }}
@@ -48,7 +48,7 @@
                 {%- set ignore_column = elementary.should_ignore_column(column_name, exclude_regexp, exclude_prefix) -%}
                 {%- if not ignore_column -%}
                     {%- do monitors.extend(column_monitors) -%}
-                    {%- set min_bucket_start = "'" ~ elementary.get_min_bucket_start(full_table_name, column_monitors, column_name) ~ "'" %}
+                    {%- set min_bucket_start = "'" ~ elementary.get_min_bucket_start(full_table_name, column_monitors, column_name, backfill_days) ~ "'" %}
                     {{ elementary.debug_log('min_bucket_start - ' ~ min_bucket_start) }}
                     {{ elementary.test_log('start', full_table_name, column_name) }}
                     {%- set column_monitoring_query = elementary.column_monitoring_query(model_relation, timestamp_column, is_timestamp, min_bucket_start, column_obj, column_monitors) %}
@@ -60,7 +60,7 @@
         {%- endif %}
         {%- set all_columns_monitors = monitors | unique | list %}
         {#- query if there is an anomaly in recent metrics -#}
-        {%- set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, all_columns_monitors, columns_only=true, sensitivity=sensitivity) %}
+        {%- set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, all_columns_monitors, columns_only=true, sensitivity=sensitivity, backfill_days=backfill_days) %}
         {%- set temp_alerts_table_name = elementary.table_name_with_suffix(test_name_in_graph, '__anomalies') %}
         {{- elementary.debug_log('anomalies table: ' ~ database_name ~ '.' ~ schema_name ~ '.' ~ temp_alerts_table_name) }}
         {%- set anomalies_temp_table_exists, anomalies_temp_table_relation = dbt.get_or_create_relation(database=database_name,

--- a/macros/edr/tests/test_column_anomalies.sql
+++ b/macros/edr/tests/test_column_anomalies.sql
@@ -1,4 +1,4 @@
-{% test column_anomalies(model, column_name, column_anomalies, timestamp_column=none, sensitivity=none) %}
+{% test column_anomalies(model, column_name, column_anomalies, timestamp_column=none, sensitivity=none, backfill_days=none) %}
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('alerts_data_monitoring') }}
@@ -41,7 +41,7 @@
         {%- set column_monitors = column_obj_and_monitors['monitors'] -%}
         {%- set column_obj = column_obj_and_monitors['column'] -%}
         {{ elementary.debug_log('column_monitors - ' ~ column_monitors) }}
-        {%- set min_bucket_start = "'" ~ elementary.get_min_bucket_start(full_table_name, column_monitors, column_name) ~ "'" %}
+        {%- set min_bucket_start = "'" ~ elementary.get_min_bucket_start(full_table_name, column_monitors, column_name, backfill_days) ~ "'" %}
         {{ elementary.debug_log('min_bucket_start - ' ~ min_bucket_start) }}
         {#- execute table monitors and write to temp test table -#}
         {{ elementary.test_log('start', full_table_name, column_name) }}
@@ -51,7 +51,7 @@
 
         {#- query if there is an anomaly in recent metrics -#}
         {%- set temp_table_name = elementary.relation_to_full_name(temp_table_relation) %}
-        {% set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, column_monitors, column_name, sensitivity=sensitivity) %}
+        {% set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, column_monitors, column_name, sensitivity=sensitivity, backfill_days=backfill_days) %}
         {{ elementary.debug_log('anomaly_query - \n' ~ anomaly_query) }}
         {%- set temp_alerts_table_name = elementary.table_name_with_suffix(test_name_in_graph, '__anomalies') %}
         {{ elementary.debug_log('anomalies table: ' ~ database_name ~ '.' ~ schema_name ~ '.' ~ temp_alerts_table_name) }}

--- a/macros/edr/tests/test_table_anomalies.sql
+++ b/macros/edr/tests/test_table_anomalies.sql
@@ -1,4 +1,4 @@
-{% test table_anomalies(model, table_anomalies, freshness_column=none, timestamp_column=none, sensitivity=none) %}
+{% test table_anomalies(model, table_anomalies, freshness_column=none, timestamp_column=none, sensitivity=none, backfill_days=none) %}
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('alerts_data_monitoring') }}
@@ -35,7 +35,7 @@
 
         {%- set table_monitors = elementary.get_final_table_monitors(table_anomalies) %}
         {{ elementary.debug_log('table_monitors - ' ~ table_monitors) }}
-        {%- set min_bucket_start = "'" ~ elementary.get_min_bucket_start(full_table_name,table_monitors) ~ "'" %}
+        {%- set min_bucket_start = "'" ~ elementary.get_min_bucket_start(full_table_name, table_monitors, backfill_days=backfill_days) ~ "'" %}
         {{ elementary.debug_log('min_bucket_start - ' ~ min_bucket_start) }}
         {#- execute table monitors and write to temp test table -#}
         {{ elementary.test_log('start', full_table_name) }}
@@ -44,7 +44,7 @@
         {%- do elementary.create_or_replace(False, temp_table_relation, table_monitoring_query) %}
 
         {#- query if there is an anomaly in recent metrics -#}
-        {% set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, table_monitors, sensitivity=sensitivity) %}
+        {% set anomaly_query = elementary.get_anomaly_query(temp_table_relation, full_table_name, table_monitors, sensitivity=sensitivity, backfill_days=backfill_days) %}
         {{ elementary.debug_log('table monitors anomaly query - \n' ~ anomaly_query) }}
         {%- set temp_alerts_table_name = elementary.table_name_with_suffix(test_name_in_graph, '__anomalies') %}
         {{ elementary.debug_log('anomalies table: ' ~ database_name ~ '.' ~ schema_name ~ '.' ~ temp_alerts_table_name) }}

--- a/macros/edr/tests/test_utils/get_anomaly_sensitivity.sql
+++ b/macros/edr/tests/test_utils/get_anomaly_sensitivity.sql
@@ -1,7 +1,0 @@
-{% macro get_anomaly_sensitivity(sensitivity) %}
-    {% if sensitivity %}
-        {{ return(sensitivity) }}
-    {% else %}
-        {{ return(elementary.get_config_var('anomaly_sensitivity')) }}
-    {% endif %}
-{% endmacro %}


### PR DESCRIPTION
- Updated the monitoring test to support getting `backfill_days` param from the `schema.yaml` file
- Updated the `get_config_var` to be more generic and support getting a value as well
- Updated relevant macros to support `backfill_days` param.
- Deleted the `get_anomaly_sensitivity` macro, and replaces the use of it with the improved `get_config_var macro`