### PR TITLE
Query comment

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -19,6 +19,10 @@ clean-targets: # directories to be removed by `dbt clean`
 on-run-end:
   - "{{ elementary.upload_dbt_artifacts(results) }}"
 
+query-comment:
+  comment: "{{ elementary.query_comment(node) }}"
+  append: True
+
 vars:
   days_back: 30
   elementary_debug_logs: false

--- a/macros/edr/metadata_collection/get_query_history_from_information_schema.sql
+++ b/macros/edr/metadata_collection/get_query_history_from_information_schema.sql
@@ -1,0 +1,44 @@
+{% macro get_query_history_from_information_schema(schema_tuple) %}
+    {{ return(adapter.dispatch('get_query_history_from_information_schema','elementary')(schema_tuple)) }}
+{% endmacro %}
+
+{# Snowflake #}
+{% macro default__get_query_history_from_information_schema(schema_tuple) %}
+    {%- set query_comment_string = elementary.get_config_var('query_comment_string') %}
+    {%- set database_name, schema_name = schema_tuple %}
+    {%- set schema_relation = api.Relation.create(database=database_name, schema=schema_name).without_identifier() %}
+
+    (
+
+        with {{ database_name }}_{{ schema_name }}_query_history as (
+
+            select
+                *,
+                {{ elementary.substr_between_two_strings('query_text', query_comment_string) }} as elementary_comment
+            from table( {{ database_name }}.information_schema.query_history())
+            where
+                    query_type not in
+                    ('SHOW', 'COPY', 'COMMIT', 'DESCRIBE', 'ROLLBACK', 'CREATE_STREAM', 'DROP_STREAM', 'PUT_FILES', 'GET_FILES',
+                     'BEGIN_TRANSACTION', 'GRANT', 'ALTER_SESSION', 'USE', 'ALTER_NETWORK_POLICY', 'ALTER_ACCOUNT',
+                     'ALTER_TABLE_DROP_CLUSTERING_KEY', 'ALTER_USER',  'CREATE_CUSTOMER_ACCOUNT', 'CREATE_NETWORK_POLICY',
+                     'CREATE_ROLE', 'CREATE_USER', 'DESCRIBE_QUERY', 'DROP_NETWORK_POLICY', 'DROP_ROLE', 'DROP_USER', 'LIST_FILES',
+                     'REMOVE_FILES', 'REVOKE','UNKNOWN', 'DELETE', 'SELECT')
+              and query_text not ilike '%.query_history%'
+              and (lower(query_text) like lower('%{{ database_name }}%')
+                or lower(database_name) = lower('{{ database_name }}'))
+
+        )
+
+        select
+            *,
+            json_extract_path_text(elementary_comment,'node_unique_id') as node_unique_id,
+            json_extract_path_text(elementary_comment,'node_identifier') as node_identifier,
+            json_extract_path_text(elementary_comment,'resource_type') as resource_type,
+            json_extract_path_text(elementary_comment,'package_name') as package_name,
+            json_extract_path_text(elementary_comment,'profile_name') as profile_name,
+            json_extract_path_text(elementary_comment,'target_name') as target_name
+        from {{ database_name }}_{{ schema_name }}_query_history
+
+    )
+
+{% endmacro %}

--- a/macros/edr/metadata_collection/query_comment.sql
+++ b/macros/edr/metadata_collection/query_comment.sql
@@ -1,0 +1,19 @@
+{% macro query_comment(node) %}
+    {%- set query_comment_string = elementary.get_config_var('query_comment_string') %}
+    {%- set comment_dict = {} -%}
+    {%- do comment_dict.update(
+        profile_name=target.get('profile_name'),
+        target_name=target.get('target_name'),
+    ) -%}
+    {%- if node is not none -%}
+      {%- do comment_dict.update(
+        node_unique_id=node.unique_id,
+        resource_type=node.resource_type,
+        package_name=node.package_name,
+        identifier=node.identifier
+      ) -%}
+    {% else %}
+      {%- do comment_dict.update(node_id='internal') -%}
+    {%- endif -%}
+    {% do return(query_comment_string ~ tojson(comment_dict) ~ query_comment_string) %}
+{% endmacro %}

--- a/macros/edr/system/configuration/get_models_schemas_from_graph.sql
+++ b/macros/edr/system/configuration/get_models_schemas_from_graph.sql
@@ -1,0 +1,12 @@
+{% macro get_models_schemas_from_graph() %}
+    {# Returns a list of tuples (db,schema) of the schemas of all the models in the project #}
+    {% set models_schemas = [] %}
+    {% if execute %}
+        {% for model_node in graph.nodes.values() | selectattr('resource_type', '==', 'model') %}
+            {% if adapter.check_schema_exists(model_node['database'], model_node['schema']) %}
+                {% do models_schemas.append((model_node['database'], model_node['schema'])) %}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+    {{ return(models_schemas | unique | list ) }}
+{% endmacro %}

--- a/macros/edr/system/configuration/get_schemas_for_tests_from_graph.sql
+++ b/macros/edr/system/configuration/get_schemas_for_tests_from_graph.sql
@@ -1,4 +1,4 @@
-{% macro get_configured_schemas_from_graph() %}
+{% macro get_schemas_for_tests_from_graph() %}
     {% set configured_schemas = [] %}
     {% if execute %}
         {% for test_node in graph.nodes.values() | selectattr('resource_type', '==', 'test') %}
@@ -21,4 +21,21 @@
         {% endfor %}
     {% endif %}
     {{ return(configured_schemas | unique | list ) }}
+{% endmacro %}
+
+
+{% macro get_schemas_for_tests_from_graph_as_tuple() %}
+
+    {%- set tests_schemas_tuples = elementary.get_schemas_for_tests_from_graph() %}
+    {%- set schemas_list = [] %}
+
+    {%- for tests_schemas_tuple in tests_schemas_tuples %}
+        {%- set database_name, schema_name = tests_schemas_tuple %}
+        {%- set full_schema_name = database_name | upper ~ '.' ~ schema_name | upper %}
+        {%- do schemas_list.append(full_schema_name) -%}
+    {%- endfor %}
+
+    {% set schemas_tuple = elementary.strings_list_to_tuple(schemas_list) %}
+    {{ return(schemas_tuple) }}
+
 {% endmacro %}

--- a/macros/edr/system/system_utils/full_names.sql
+++ b/macros/edr/system/system_utils/full_names.sql
@@ -65,20 +65,3 @@
     {%- set full_table_name = relation.database | upper ~'.'~ relation.schema | upper ~'.'~ relation.identifier | upper %}
     {{ return(full_table_name) }}
 {% endmacro %}
-
-
-{% macro configured_schemas_from_graph_as_tuple() %}
-
-    {%- set configured_schema_tuples = elementary.get_configured_schemas_from_graph() %}
-    {%- set schemas_list = [] %}
-
-    {%- for configured_schema_tuple in configured_schema_tuples %}
-        {%- set database_name, schema_name = configured_schema_tuple %}
-        {%- set full_schema_name = database_name | upper ~ '.' ~ schema_name | upper %}
-        {%- do schemas_list.append(full_schema_name) -%}
-    {%- endfor %}
-
-    {% set schemas_tuple = elementary.strings_list_to_tuple(schemas_list) %}
-    {{ return(schemas_tuple) }}
-
-{% endmacro %}

--- a/macros/edr/system/system_utils/get_config_var.sql
+++ b/macros/edr/system/system_utils/get_config_var.sql
@@ -16,6 +16,7 @@
     'max_int': 2147483647,
     'schemas_to_alert_on_new_tables': [],
     'custom_run_started_at': null,
+    'query_comment_string': '____elementary_comment____',
     'edr_monitors': {
       'table': ['schema_changes', 'row_count', 'freshness'],
       'column_any_type': ['null_count', 'null_percent'],

--- a/macros/utils/substring_from_column.sql
+++ b/macros/utils/substring_from_column.sql
@@ -1,0 +1,17 @@
+{% macro substr_between_two_strings(column, first_string, second_string) %}
+    {{ return(adapter.dispatch('substr_between_two_strings','elementary')(column, first_string, second_string)) }}
+{% endmacro %}
+
+{# Snowflake #}
+{% macro default__substr_between_two_strings(column, first_string, second_string) %}
+    {%- if not second_string %}
+        {%- set second_string = first_string %}
+    {%- endif %}
+    {%- set first_string_length = first_string | length %}
+    {%- set second_string_length = second_string | length %}
+        case
+            when {{ column }} like '%{{ first_string }}%'
+            then substr({{ column }}, position('{{ first_string }}',query_text)+ {{ first_string_length }},length(substr({{ column }}, position('{{ first_string }}',query_text)+ {{ first_string_length }}))- position(reverse('{{ second_string }}'),reverse(query_text))- {{ second_string_length }}+1)
+            else null
+        end
+{% endmacro %}

--- a/models/edr/data_monitoring/schema_changes/table_changes.sql
+++ b/models/edr/data_monitoring/schema_changes/table_changes.sql
@@ -37,7 +37,7 @@ table_removed as (
     from pre left join cur
         on (cur.full_table_name = pre.full_table_name and cur.full_schema_name = pre.full_schema_name)
     where cur.full_table_name is null
-    and pre.full_schema_name in {{ elementary.configured_schemas_from_graph_as_tuple() }}
+    and pre.full_schema_name in {{ elementary.get_schemas_for_tests_from_graph_as_tuple() }}
 
 ),
 

--- a/models/edr/metadata_store/filtered_information_schema_columns.sql
+++ b/models/edr/metadata_store/filtered_information_schema_columns.sql
@@ -4,7 +4,7 @@
   )
 }}
 
-{% set configured_schemas = elementary.get_configured_schemas_from_graph() %}
+{% set configured_schemas = elementary.get_schemas_for_tests_from_graph() %}
 
 with filtered_information_schema_columns as (
 

--- a/models/edr/metadata_store/filtered_information_schema_tables.sql
+++ b/models/edr/metadata_store/filtered_information_schema_tables.sql
@@ -4,7 +4,7 @@
   )
 }}
 
-{% set configured_schemas = elementary.get_configured_schemas_from_graph() %}
+{% set configured_schemas = elementary.get_schemas_for_tests_from_graph() %}
 
 with filtered_information_schema_tables as (
 

--- a/models/edr/metadata_store/information_schema_query_history.sql
+++ b/models/edr/metadata_store/information_schema_query_history.sql
@@ -1,0 +1,22 @@
+{{
+  config(
+    materialized = 'view',
+    enabled = target.type == 'snowflake' | as_bool()
+  )
+}}
+
+{%- set models_schemas = elementary.get_models_schemas_from_graph() -%}
+
+with information_schema_query_history as (
+
+    {%- if models_schemas | length > 0 -%}
+        {%- set tables_from_info_schema_macro = context['elementary']['get_query_history_from_information_schema'] -%}
+        {{ elementary.run_query_macro_on_list(models_schemas, tables_from_info_schema_macro) }}
+    {%- else %}
+        {{ elementary.empty_table([('full_table_name', 'string'), ('full_schema_name', 'string'), ('database_name', 'string'), ('schema_name', 'string'), ('table_name', 'string')]) }}
+    {%- endif %}
+
+)
+
+select *
+from information_schema_query_history


### PR DESCRIPTION
- Model named 'information_schema_query_history' is a view of query history from all schemas with models. 
- Query comment is added using macro and extracted from query text using 'substr_between_two_strings' macro.
(This works only for Snowflake, but anything platform-specific is called using macros, so we can add later)

@jtalmi 