### PR TITLE
replaced run_started_at with elementary.get_run_started_at across the project

### DIFF
--- a/integration_tests/macros/e2e_tests/tests_validation.sql
+++ b/integration_tests/macros/e2e_tests/tests_validation.sql
@@ -1,6 +1,6 @@
 {% macro tests_validation() %}
     {% if execute %}
-        {%- set max_bucket_end = "'"~ run_started_at.strftime("%Y-%m-%d 00:00:00")~"'" %}
+        {%- set max_bucket_end = "'"~ elementary.get_run_started_at().strftime("%Y-%m-%d 00:00:00")~"'" %}
         -- no validation data which means table freshness and volume should alert
         {% if not elementary.table_exists_in_target('any_type_column_anomalies_validation') %}
             {{ validate_table_anomalies() }}
@@ -75,7 +75,7 @@
 {% endmacro %}
 
 {% macro validate_table_anomalies() %}
-    {%- set max_bucket_end = "'"~ run_started_at.strftime("%Y-%m-%d 00:00:00")~"'" %}
+    {%- set max_bucket_end = "'"~ elementary.get_run_started_at().strftime("%Y-%m-%d 00:00:00")~"'" %}
     -- no validation data which means table freshness and volume should alert
     {% set alerts_relation = get_alerts_table_relation('alerts_data_monitoring') %}
     {% set freshness_validation_query %}
@@ -100,7 +100,7 @@
 {% endmacro %}
 
 {% macro validate_string_column_anomalies() %}
-    {%- set max_bucket_end = "'"~ run_started_at.strftime("%Y-%m-%d 00:00:00")~"'" %}
+    {%- set max_bucket_end = "'"~ elementary.get_run_started_at().strftime("%Y-%m-%d 00:00:00")~"'" %}
     {% set alerts_relation = get_alerts_table_relation('alerts_data_monitoring') %}
     {% set string_column_alerts %}
     select distinct column_name
@@ -114,7 +114,7 @@
 {% endmacro %}
 
 {% macro validate_numeric_column_anomalies() %}
-    {%- set max_bucket_end = "'"~ run_started_at.strftime("%Y-%m-%d 00:00:00")~"'" %}
+    {%- set max_bucket_end = "'"~ elementary.get_run_started_at().strftime("%Y-%m-%d 00:00:00")~"'" %}
     {% set alerts_relation = get_alerts_table_relation('alerts_data_monitoring') %}
     {% set numeric_column_alerts %}
     select distinct column_name
@@ -129,7 +129,7 @@
 
 
 {% macro validate_any_type_column_anomalies() %}
-    {%- set max_bucket_end = "'"~ run_started_at.strftime("%Y-%m-%d 00:00:00")~"'" %}
+    {%- set max_bucket_end = "'"~ elementary.get_run_started_at().strftime("%Y-%m-%d 00:00:00")~"'" %}
     {% set alerts_relation = get_alerts_table_relation('alerts_data_monitoring') %}
     {% set any_type_column_alerts %}
         select column_name, sub_type
@@ -168,7 +168,7 @@
 {% endmacro %}
 
 {% macro validate_no_timestamp_anomalies() %}
-    {%- set max_bucket_end = "'"~ run_started_at.strftime("%Y-%m-%d 00:00:00")~"'" %}
+    {%- set max_bucket_end = "'"~ elementary.get_run_started_at().strftime("%Y-%m-%d 00:00:00")~"'" %}
     {% set alerts_relation = get_alerts_table_relation('alerts_data_monitoring') %}
 
     {# Validating row count for no timestamp table anomaly #}
@@ -218,7 +218,7 @@
                                'group_b':   'type_changed',
                                'key_crosses': 'column_added',
                                'offsides': 'column_removed'} %}
-    {%- set max_bucket_end = "'"~ run_started_at.strftime("%Y-%m-%d 00:00:00")~"'" %}
+    {%- set max_bucket_end = "'"~ elementary.get_run_started_at().strftime("%Y-%m-%d 00:00:00")~"'" %}
     {% set alerts_relation = get_alerts_table_relation('alerts_schema_changes') %}
     {% set schema_changes_alerts %}
     select column_name, sub_type
@@ -248,7 +248,7 @@
 {% endmacro %}
 
 {% macro validate_regular_tests() %}
-    {%- set max_bucket_end = "'"~ run_started_at.strftime("%Y-%m-%d 00:00:00")~"'" %}
+    {%- set max_bucket_end = "'"~ elementary.get_run_started_at().strftime("%Y-%m-%d 00:00:00")~"'" %}
     {% set alerts_relation = get_alerts_table_relation('alerts_dbt_tests') %}
     {% set dbt_test_alerts %}
         select table_name, column_name, test_name

--- a/integration_tests/macros/unit_tests/test_numeric_monitors.sql
+++ b/integration_tests/macros/unit_tests/test_numeric_monitors.sql
@@ -15,7 +15,7 @@
     {% do numeric_monitors.extend(default_all_types) %}
     {% do numeric_monitors.extend(default_numeric_monitors) %}
 
-    {%- set column_monitoring_query = elementary.column_monitoring_query(monitors_inputs_table_relation, none, false, run_started_at, column_object, numeric_monitors) %}
+    {%- set column_monitoring_query = elementary.column_monitoring_query(monitors_inputs_table_relation, none, false, elementary.get_run_started_at(), column_object, numeric_monitors) %}
     {%- set metrics_table_name = table_name ~ '__metrics' %}
     {%- set metrics_table_relation = get_or_create_unit_test_table_relation(metrics_table_name)[1] -%}
     {%- do elementary.create_or_replace(False, metrics_table_relation, column_monitoring_query) %}

--- a/macros/edr/data_monitoring/data_monitors_configuration/get_buckets_configuration.sql
+++ b/macros/edr/data_monitoring/data_monitors_configuration/get_buckets_configuration.sql
@@ -1,26 +1,26 @@
 {% macro get_global_min_bucket_start() %}
-    {%- set global_min_bucket_start = "'"~ (run_started_at - modules.datetime.timedelta(elementary.get_config_var('days_back'))).strftime("%Y-%m-%d 00:00:00") ~"'" %}
+    {%- set global_min_bucket_start = "'"~ (elementary.get_run_started_at() - modules.datetime.timedelta(elementary.get_config_var('days_back'))).strftime("%Y-%m-%d 00:00:00") ~"'" %}
     {{ return(global_min_bucket_start) }}
 {% endmacro %}
 
 {% macro get_global_min_bucket_start_as_datetime() %}
-    {%- set global_min_bucket_start = run_started_at - modules.datetime.timedelta(elementary.get_config_var('days_back')) %}
+    {%- set global_min_bucket_start = elementary.get_run_started_at() - modules.datetime.timedelta(elementary.get_config_var('days_back')) %}
     {{ return(global_min_bucket_start) }}
 {% endmacro %}
 
 {# bucket_end represents the end of the bucket, so we need to add extra day to the timedelta #}
 {% macro get_global_min_bucket_end_as_datetime() %}
-    {%- set global_min_bucket_end = run_started_at - modules.datetime.timedelta(elementary.get_config_var('days_back') + 1) %}
+    {%- set global_min_bucket_end = elementary.get_run_started_at() - modules.datetime.timedelta(elementary.get_config_var('days_back') + 1) %}
     {{ return(global_min_bucket_end) }}
 {% endmacro %}
 
 {% macro get_max_bucket_end() %}
-    {%- set max_bucket_end = "'"~ run_started_at.strftime("%Y-%m-%d 00:00:00")~"'" %}
+    {%- set max_bucket_end = "'"~ elementary.get_run_started_at().strftime("%Y-%m-%d 00:00:00")~"'" %}
     {{ return(max_bucket_end) }}
 {% endmacro %}
 
 {% macro get_backfill_bucket_start(backfill_days) %}
-    {%- set backfill_bucket_start = "'"~ (run_started_at - modules.datetime.timedelta(backfill_days)).strftime("%Y-%m-%d 00:00:00") ~"'" %}
+    {%- set backfill_bucket_start = "'"~ (elementary.get_run_started_at() - modules.datetime.timedelta(backfill_days)).strftime("%Y-%m-%d 00:00:00") ~"'" %}
     {{ return(backfill_bucket_start) }}
 {% endmacro %}
 

--- a/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
+++ b/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
@@ -1,7 +1,7 @@
 {% macro table_monitoring_query(monitored_table_relation, timestamp_column, is_timestamp, min_bucket_start, table_monitors, freshness_column=none) %}
 
     {%- set max_bucket_end = "'"~ elementary.get_run_started_at().strftime("%Y-%m-%d 00:00:00")~"'" %}
-    {%- set max_bucket_start = "'"~ (run_started_at - modules.datetime.timedelta(1)).strftime("%Y-%m-%d 00:00:00")~"'" %}
+    {%- set max_bucket_start = "'"~ (elementary.get_run_started_at() - modules.datetime.timedelta(1)).strftime("%Y-%m-%d 00:00:00")~"'" %}
     {% set full_table_name_str = "'"~ elementary.relation_to_full_name(monitored_table_relation) ~"'" %}
 
     {% if is_timestamp %}

--- a/macros/edr/dbt_artifacts/upload_dbt_artifacts.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_artifacts.sql
@@ -48,7 +48,7 @@
         'invocation_id': invocation_id,
         'unique_id': node.get('unique_id'),
         'name': node.get('name'),
-        'generated_at': run_started_at.strftime('%Y-%m-%d %H:%M:%S'),
+        'generated_at': elementary.get_run_started_at().strftime('%Y-%m-%d %H:%M:%S'),
         'rows_affected': run_result_dict.get('adapter_response', {}).get('rows_affected'),
         'execution_time': run_result_dict.get('execution_time'),
         'status': run_result_dict.get('status'),

--- a/macros/edr/dbt_artifacts/upload_dbt_exposures.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_exposures.sql
@@ -58,7 +58,7 @@
         'package_name': node_dict.get('package_name'),
         'original_path': node_dict.get('original_file_path'),
         'path': node_dict.get('path'),
-        'generated_at': run_started_at.strftime('%Y-%m-%d %H:%M:%S')
+        'generated_at': elementary.get_run_started_at().strftime('%Y-%m-%d %H:%M:%S')
       }%}
     {{ return(flatten_exposure_metadata_dict) }}
 {% endmacro %}

--- a/macros/edr/dbt_artifacts/upload_dbt_metrics.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_metrics.sql
@@ -63,7 +63,7 @@
         'package_name': node_dict.get('package_name'),
         'original_path': node_dict.get('original_file_path'),
         'path': node_dict.get('path'),
-        'generated_at': run_started_at.strftime('%Y-%m-%d %H:%M:%S')
+        'generated_at': elementary.get_run_started_at().strftime('%Y-%m-%d %H:%M:%S')
     }%}
     {{ return(flatten_metrics_metadata_dict) }}
 {% endmacro %}

--- a/macros/edr/dbt_artifacts/upload_dbt_models.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_models.sql
@@ -69,7 +69,7 @@
         'package_name': node_dict.get('package_name'),
         'original_path': node_dict.get('original_file_path'),
         'path': node_dict.get('path'),
-        'generated_at': run_started_at.strftime('%Y-%m-%d %H:%M:%S')
+        'generated_at': elementary.get_run_started_at().strftime('%Y-%m-%d %H:%M:%S')
     }%}
     {{ return(flatten_model_metadata_dict) }}
 {% endmacro %}

--- a/macros/edr/dbt_artifacts/upload_dbt_sources.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_sources.sql
@@ -70,7 +70,7 @@
          'path': node_dict.get('path'),
          'source_description': node_dict.get('source_description'),
          'description': node_dict.get('description'),
-         'generated_at': run_started_at.strftime('%Y-%m-%d %H:%M:%S')
+         'generated_at': elementary.get_run_started_at().strftime('%Y-%m-%d %H:%M:%S')
      }%}
     {{ return(flatten_source_metadata_dict) }}
 {% endmacro %}

--- a/macros/edr/dbt_artifacts/upload_dbt_tests.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_tests.sql
@@ -136,7 +136,7 @@
         'original_path': original_file_path,
         'compiled_sql': node_dict.get('compiled_sql'),
         'path': node_dict.get('path'),
-        'generated_at': run_started_at.strftime('%Y-%m-%d %H:%M:%S')
+        'generated_at': elementary.get_run_started_at().strftime('%Y-%m-%d %H:%M:%S')
     }%}
     {{ return(flatten_test_metadata_dict) }}
 {% endmacro %}

--- a/macros/edr/system/system_utils/daily_buckets_cte.sql
+++ b/macros/edr/system/system_utils/daily_buckets_cte.sql
@@ -4,8 +4,8 @@
 
 
 {% macro default__daily_buckets_cte() -%}
-    {%- set max_bucket_end = "'"~ run_started_at.strftime("%Y-%m-%d 00:00:00") ~"'" %}
-    {%- set min_bucket_end = "'"~ (run_started_at - modules.datetime.timedelta(elementary.get_config_var('days_back'))).strftime("%Y-%m-%d 00:00:00") ~"'" %}
+    {%- set max_bucket_end = "'"~ elementary.get_run_started_at().strftime("%Y-%m-%d 00:00:00") ~"'" %}
+    {%- set min_bucket_end = "'"~ (elementary.get_run_started_at() - modules.datetime.timedelta(elementary.get_config_var('days_back'))).strftime("%Y-%m-%d 00:00:00") ~"'" %}
 
     {%- set daily_buckets_cte %}
         with dates as (
@@ -23,8 +23,8 @@
 
 
 {% macro bigquery__daily_buckets_cte() %}
-    {%- set max_bucket_end = "'"~ run_started_at.strftime("%Y-%m-%d 00:00:00") ~"'" %}
-    {%- set min_bucket_end = "'"~ (run_started_at - modules.datetime.timedelta(elementary.get_config_var('days_back'))).strftime("%Y-%m-%d 00:00:00") ~"'" %}
+    {%- set max_bucket_end = "'"~ elementary.get_run_started_at().strftime("%Y-%m-%d 00:00:00") ~"'" %}
+    {%- set min_bucket_end = "'"~ (elementary.get_run_started_at() - modules.datetime.timedelta(elementary.get_config_var('days_back'))).strftime("%Y-%m-%d 00:00:00") ~"'" %}
 
     {%- set daily_buckets_cte %}
         select edr_daily_bucket
@@ -34,12 +34,12 @@
 {% endmacro %}
 
 {% macro redshift__daily_buckets_cte() %}
-    {%- set max_bucket_end = "'"~ run_started_at.strftime("%Y-%m-%d 00:00:00") ~"'" %}
+    {%- set max_bucket_end = "'"~ elementary.get_run_started_at().strftime("%Y-%m-%d 00:00:00") ~"'" %}
     {%- set days_back = elementary.get_config_var('days_back') %}
 
     {%- set daily_buckets_cte %}
         {%- for i in range(0, days_back+1) %}
-            {%- set daily_bucket = "'"~ (run_started_at - modules.datetime.timedelta(i)).strftime("%Y-%m-%d 00:00:00") ~"'" %}
+            {%- set daily_bucket = "'"~ (elementary.get_run_started_at() - modules.datetime.timedelta(i)).strftime("%Y-%m-%d 00:00:00") ~"'" %}
             select {{ elementary.cast_as_timestamp(daily_bucket) }} as edr_daily_bucket
             {%- if not loop.last %} union all {%- endif %}
         {%- endfor %}

--- a/macros/edr/system/system_utils/timestamp_column.sql
+++ b/macros/edr/system/system_utils/timestamp_column.sql
@@ -1,5 +1,5 @@
 {% macro run_start_column() %}
-    cast ('{{ run_started_at.strftime("%Y-%m-%d %H:%M:%S") }}' as {{ dbt_utils.type_timestamp() }})
+    cast ('{{ elementary.get_run_started_at().strftime("%Y-%m-%d %H:%M:%S") }}' as {{ dbt_utils.type_timestamp() }})
 {% endmacro %}
 
 {% macro current_timestamp_column() %}

--- a/macros/edr/tests/on_run_end/handle_tests_results.sql
+++ b/macros/edr/tests/on_run_end/handle_tests_results.sql
@@ -193,7 +193,7 @@
         'test_execution_id': test_execution_id,
         'test_unique_id': elementary.insensitive_get_dict_value(test_node, 'unique_id'),
         'model_unique_id': elementary.insensitive_get_dict_value(test_node, 'parent_model_unique_id'),
-        'detected_at': run_started_at.strftime('%Y-%m-%d %H:%M:%S'),
+        'detected_at': elementary.get_run_started_at().strftime('%Y-%m-%d %H:%M:%S'),
         'database_name': elementary.insensitive_get_dict_value(test_node, 'database_name'),
         'schema_name': elementary.insensitive_get_dict_value(test_node, 'schema_name'),
         'table_name': parent_model_name,


### PR DESCRIPTION
We created the method `get_run_started_at` in the [following PR](https://github.com/elementary-data/dbt-data-reliability/pull/31) to support passing custom `run_started_at` when testing `no_timestamp` anomalies.

In this PR I replaced all the use of dbt `run_started_at` with elementary `get_run_started_at` to support it across the whole project (for example - overwriting the detected at field of a test run - used in our demo) 