### PR TITLE
add error test to e2e

### DIFF
--- a/integration_tests/macros/e2e_tests/tests_validation.sql
+++ b/integration_tests/macros/e2e_tests/tests_validation.sql
@@ -212,6 +212,21 @@
     {{ assert_lists_contain_same_items(results, ['null_count_str']) }}
 {% endmacro %}
 
+{% macro validate_error_test() %}
+    {%- set max_bucket_end = "'"~ elementary.get_run_started_at().strftime("%Y-%m-%d 00:00:00")~"'" %}
+    {% set alerts_relation = get_alerts_table_relation('alerts_dbt_tests') %}
+
+    {# Validating alert for error test was created #}
+    {% set error_test_validation_query %}
+        select distinct status
+        from {{ alerts_relation }}
+        where status = 'error'
+        and detected_at >= {{ max_bucket_end }}
+    {% endset %}
+    {% set results = elementary.result_column_to_list(error_test_validation_query) %}
+    {{ assert_lists_contain_same_items(results, ['error']) }}
+{% endmacro %}
+
 {% macro validate_schema_changes() %}
     {% set expected_changes = {'red_cards': 'column_added',
                                'group_a':   'column_removed',

--- a/integration_tests/models/error_model.sql
+++ b/integration_tests/models/error_model.sql
@@ -1,0 +1,1 @@
+select 'a's as string

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -40,6 +40,14 @@ models:
               column_anomalies:
                 - null_count
 
+  - name: error_model
+    description: We use this model to create error runs and tests
+    columns:
+      - name: "missing_column"
+        tests:
+          - uniques:
+              tags: ["error_test"]
+
   - name: string_column_anomalies
     meta:
       owner: "@or"

--- a/integration_tests/run_e2e_tests.py
+++ b/integration_tests/run_e2e_tests.py
@@ -197,6 +197,11 @@ def e2e_tests(target, test_types):
                     any_type_column_anomalies_test_results, schema_changes_test_results, regular_test_results,
                     artifacts_results]
     
+    if 'error' in test_types:
+        dbt_runner.test(select='tag:error_test')
+        error_test_results = dbt_runner.run_operation(macro_name='validate_error_test')
+        print_test_result_list(error_test_results)
+    
     # Creates row_count metrics for anomalies detection.
     if 'no_timestamp' in test_types:
         current_time = datetime.now()
@@ -304,7 +309,7 @@ def print_tests_results(table_test_results,
     '--e2e-type', '-e',
     type=str,
     default='all',
-    help="table / column / schema / regular / artifacts / no_timestamp / debug / all (default = all)"
+    help="table / column / schema / regular / artifacts / error / no_timestamp / debug / all (default = all)"
 )
 @click.option(
     '--generate-data', '-g',
@@ -322,7 +327,7 @@ def main(target, e2e_type, generate_data):
         e2e_targets = [target]
 
     if e2e_type == 'all':
-        e2e_types = ['table', 'column', 'schema', 'regular', 'artifacts']
+        e2e_types = ['table', 'column', 'schema', 'regular', 'artifacts', 'error']
     else:
         e2e_types = [e2e_type]
 


### PR DESCRIPTION
Added an error run and an error test to the e2e tests.
Validating that alerts for error runs/tests are created + used to validate that the report supports errors