### PR TITLE
Fix e2e regular test bug

### DIFF
--- a/integration_tests/macros/e2e_tests/tests_validation.sql
+++ b/integration_tests/macros/e2e_tests/tests_validation.sql
@@ -229,12 +229,12 @@
 
 {% macro validate_error_model() %}
     {%- set max_bucket_end = "'" ~ elementary.get_run_started_at().strftime("%Y-%m-%d 00:00:00") ~ "'" %}
-    {% set alerts_relation = get_alerts_table_relation('error_models') %}
+    {% set alerts_relation = get_alerts_table_relation('alerts_dbt_models') %}
 
     {% set error_model_validation_query %}
         select distinct status
         from {{ alerts_relation }}
-        where status = 'error'
+        where status = 'error' and materialization != 'model'
         and detected_at >= {{ max_bucket_end }}
     {% endset %}
     {% set results = elementary.result_column_to_list(error_model_validation_query) %}
@@ -243,7 +243,7 @@
 
 {% macro validate_error_snapshot() %}
     {%- set max_bucket_end = "'" ~ elementary.get_run_started_at().strftime("%Y-%m-%d 00:00:00") ~ "'" %}
-    {% set alerts_relation = get_alerts_table_relation('error_models') %}
+    {% set alerts_relation = get_alerts_table_relation('alerts_dbt_models') %}
 
     {% set error_snapshot_validation_query %}
         select distinct status
@@ -307,7 +307,7 @@
         select table_name, column_name, test_name
         from {{ alerts_relation }}
             where detected_at >= {{ max_bucket_end }}
-        group by 1,2, 3
+        group by 1, 2, 3
     {% endset %}
     {% set alert_rows = run_query(dbt_test_alerts) %}
     {% set found_tables = [] %}

--- a/integration_tests/macros/e2e_tests/tests_validation.sql
+++ b/integration_tests/macros/e2e_tests/tests_validation.sql
@@ -324,9 +324,9 @@
             {% do found_tests.append(row[2]) %}
         {%- endif -%}
     {% endfor %}
-    {{ assert_lists_contain_same_items(found_tables, ['error_model', 'string_column_anomalies', 'numeric_column_anomalies', 'any_type_column_anomalies', 'any_type_column_anomalies_validation', 'numeric_column_anomalies_training']) }}
-    {{ assert_lists_contain_same_items(found_columns, ['missing_column', 'min_length', 'null_count_int']) }}
-    {{ assert_lists_contain_same_items(found_tests, ['uniques', 'relationships', 'singular_test_with_no_ref', 'singular_test_with_one_ref', 'singular_test_with_two_refs', 'singular_test_with_source_ref', 'generic_test_on_model', 'generic_test_on_column']) }}
+    {{ assert_list1_in_list2(['error_model', 'string_column_anomalies', 'numeric_column_anomalies', 'any_type_column_anomalies', 'any_type_column_anomalies_validation', 'numeric_column_anomalies_training'], found_tables) }}
+    {{ assert_list1_in_list2(['missing_column', 'min_length', 'null_count_int'], found_columns) }}
+    {{ assert_list1_in_list2(['uniques', 'relationships', 'singular_test_with_no_ref', 'singular_test_with_one_ref', 'singular_test_with_two_refs', 'singular_test_with_source_ref', 'generic_test_on_model', 'generic_test_on_column'], found_tests) }}
 
 {% endmacro %}
 

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -48,7 +48,7 @@ models:
       - name: "missing_column"
         tests:
           - uniques:
-              tags: ["error_test"]
+              tags: ["error_test", "regular_tests"]
 
   - name: string_column_anomalies
     meta:


### PR DESCRIPTION
- Marked error test as regular test
- switched assertion of list1 contains same items as list 2 to list1 items are in list2 items assertion on the regular tests validation