### PR TITLE
Added raw_sql and compiled_sql to dbt_run_results.

### DIFF
--- a/macros/edr/dbt_artifacts/upload_run_results.sql
+++ b/macros/edr/dbt_artifacts/upload_run_results.sql
@@ -36,7 +36,7 @@
                                                                        ('compile_completed_at', 'string'),
                                                                        ('rows_affected', 'bigint'),
                                                                        ('full_refresh', 'boolean'),
-                                                                       ('compiled_sql', 'string')
+                                                                       ('compiled_sql', 'long_string')
                                                                        ]) %}
     {{ return(dbt_run_results_empty_table_query) }}
 {% endmacro %}

--- a/macros/edr/dbt_artifacts/upload_run_results.sql
+++ b/macros/edr/dbt_artifacts/upload_run_results.sql
@@ -35,7 +35,10 @@
                                                                        ('compile_started_at', 'string'),
                                                                        ('compile_completed_at', 'string'),
                                                                        ('rows_affected', 'bigint'),
-                                                                       ('full_refresh', 'boolean')]) %}
+                                                                       ('full_refresh', 'boolean'),
+                                                                       ('raw_sql', 'string'),
+                                                                       ('compiled_sql', 'string')
+                                                                       ]) %}
     {{ return(dbt_run_results_empty_table_query) }}
 {% endmacro %}
 
@@ -65,7 +68,9 @@
         'execute_completed_at': none,
         'compile_started_at': none,
         'compile_completed_at': none,
-        'full_refresh': flags.FULL_REFRESH
+        'full_refresh': flags.FULL_REFRESH,
+        'raw_sql': node.get('raw_sql'),
+        'compiled_sql': node.get('compiled_sql')
     }%}
 
     {% set timings = elementary.safe_get_with_default(run_result_dict, 'timing', []) %}

--- a/macros/edr/dbt_artifacts/upload_run_results.sql
+++ b/macros/edr/dbt_artifacts/upload_run_results.sql
@@ -36,7 +36,6 @@
                                                                        ('compile_completed_at', 'string'),
                                                                        ('rows_affected', 'bigint'),
                                                                        ('full_refresh', 'boolean'),
-                                                                       ('raw_sql', 'string'),
                                                                        ('compiled_sql', 'string')
                                                                        ]) %}
     {{ return(dbt_run_results_empty_table_query) }}
@@ -69,7 +68,6 @@
         'compile_started_at': none,
         'compile_completed_at': none,
         'full_refresh': flags.FULL_REFRESH,
-        'raw_sql': node.get('raw_sql'),
         'compiled_sql': node.get('compiled_sql')
     }%}
 


### PR DESCRIPTION
Added the `raw_sql` and `compiled_sql` columns to the `dbt_run_results` model.

![image](https://user-images.githubusercontent.com/30181361/185150708-f2b31252-79e2-4d54-8b1f-012529db6eed.png)

The model has `on_schema_change = 'append_new_columns'`.

![image](https://user-images.githubusercontent.com/30181361/185150648-31269181-6cc5-4a89-a9a5-fcd569fafb10.png)
