### PR TITLE
fix - Call get_flatten_metric_callback when creating dbt_metrics table

### DIFF
--- a/macros/edr/dbt_artifacts/upload_dbt_metrics.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_metrics.sql
@@ -2,7 +2,7 @@
     {% set edr_cli_run = elementary.get_config_var('edr_cli_run') %}
     {% if execute and not edr_cli_run %}
         {% set metrics = graph.metrics.values() | selectattr('resource_type', '==', 'metric') %}
-        {% do elementary.upload_artifacts_to_table(this, metrics, elementary.get_flatten_metric_callback) %}
+        {% do elementary.upload_artifacts_to_table(this, metrics, elementary.get_flatten_metric_callback()) %}
     {%- endif -%}
     {{- return('') -}}
 {%- endmacro -%}


### PR DESCRIPTION
Closes #77 