### PR TITLE
Renamed 'elementary_debug_logs' to 'debug_logs'.

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -18,7 +18,7 @@ clean-targets: # directories to be removed by `dbt clean`
 
 vars:
   days_back: 30
-  elementary_debug_logs: false
+  debug_logs: false
 
 models:
   elementary:

--- a/macros/edr/system/system_utils/get_config_var.sql
+++ b/macros/edr/system/system_utils/get_config_var.sql
@@ -10,7 +10,7 @@
     'tests_schema_name': '__tests',
     'alert_dbt_model_fail': true,
     'alert_dbt_model_skip': true,
-    'elementary_debug_logs': false,
+    'debug_logs': false,
     'refresh_dbt_artifacts': false,
     'disable_warn_alerts': false,
     'disable_model_alerts': false,

--- a/macros/edr/system/system_utils/logs.sql
+++ b/macros/edr/system/system_utils/logs.sql
@@ -6,7 +6,7 @@
 
 {% macro debug_log(msg) %}
     {%- if execute %}
-        {% set debug_logs_enabled = elementary.get_config_var('elementary_debug_logs') %}
+        {% set debug_logs_enabled = elementary.get_config_var('debug_logs') %}
         {% if debug_logs_enabled %}
             {{ elementary.edr_log(msg) }}
         {% endif %}


### PR DESCRIPTION
Keeping consistent with not specifying the `elementary` prefix.