### PR TITLE
handle updated tests

### DIFF
--- a/models/edr/run_results/current_tests_run_results.sql
+++ b/models/edr/run_results/current_tests_run_results.sql
@@ -13,7 +13,7 @@ dbt_tests as (
     select * from {{ ref('dbt_tests') }}
 ),
 
-firt_time_test_occurred as (
+first_time_test_occurred as (
     select 
         min(detected_at) as first_time_occurred,
         test_unique_id
@@ -46,4 +46,4 @@ SELECT
     first_occurred.first_time_occurred as test_first_seen_at
 FROM elementary_test_results test_results
 JOIN dbt_tests tests ON test_results.test_unique_id = tests.unique_id
-LEFT JOIN firt_time_test_occurred first_occurred ON test_results.test_unique_id = first_occurred.test_unique_id
+LEFT JOIN first_time_test_occurred first_occurred ON test_results.test_unique_id = first_occurred.test_unique_id

--- a/models/edr/run_results/current_tests_run_results.sql
+++ b/models/edr/run_results/current_tests_run_results.sql
@@ -43,7 +43,7 @@ SELECT
     test_results.test_params,
     test_results.severity,
     test_results.status,
-    first_occurred.first_time_occurred as test_first_seen
+    first_occurred.first_time_occurred as test_first_seen_at
 FROM elementary_test_results test_results
 JOIN dbt_tests tests ON test_results.test_unique_id = tests.unique_id
 LEFT JOIN firt_time_test_occurred first_occurred ON test_results.test_unique_id = first_occurred.test_unique_id

--- a/models/edr/run_results/test_results.sql
+++ b/models/edr/run_results/test_results.sql
@@ -1,0 +1,49 @@
+{{
+  config(
+    materialized = 'view',
+    bind=False
+  )
+}}
+
+with elementary_test_results as (
+    select * from {{ ref('elementary_test_results') }}
+),
+
+dbt_tests as (
+    select * from {{ ref('dbt_tests') }}
+),
+
+firt_time_test_occurred as (
+    select 
+        min(detected_at) as first_time_occurred,
+        test_unique_id
+    from elementary_test_results
+    group by test_unique_id
+)
+
+SELECT
+    test_results.id,
+    test_results.data_issue_id,
+    test_results.test_execution_id,
+    test_results.test_unique_id,
+    test_results.model_unique_id,
+    test_results.detected_at,
+    test_results.database_name,
+    test_results.schema_name,
+    test_results.table_name,
+    test_results.column_name,
+    test_results.test_type,
+    test_results.test_sub_type,
+    test_results.test_results_description,
+    test_results.owners,
+    test_results.tags,
+    test_results.test_results_query,
+    test_results.other,
+    test_results.test_name,
+    test_results.test_params,
+    test_results.severity,
+    test_results.status,
+    first_occurred.first_time_occurred as test_first_seen
+FROM elementary_test_results test_results
+JOIN dbt_tests tests ON test_results.test_unique_id = tests.unique_id
+LEFT JOIN firt_time_test_occurred first_occurred ON test_results.test_unique_id = first_occurred.test_unique_id


### PR DESCRIPTION
Created test results view that joins between `dbt_tests` and `elementary_test_results` tables, causing it show only the test results of the current project tests