### PR TITLE
Issue #300 enhance: add config to not notify skipped models

### DIFF
--- a/macros/edr/system/system_utils/get_config_var.sql
+++ b/macros/edr/system/system_utils/get_config_var.sql
@@ -16,7 +16,7 @@
     'disable_model_alerts': false,
     'disable_test_alerts': false,
     'disable_run_results': false,
-    'disable_skipped_model_alerts': false,
+    'disable_skipped_model_alerts': true,
     'dbt_artifacts_chunk_size': 50,
     'edr_cli_run': false,
     'max_int': 2147483647,

--- a/macros/edr/system/system_utils/get_config_var.sql
+++ b/macros/edr/system/system_utils/get_config_var.sql
@@ -16,6 +16,7 @@
     'disable_model_alerts': false,
     'disable_test_alerts': false,
     'disable_run_results': false,
+    'disable_skipped_model_alerts': false,
     'dbt_artifacts_chunk_size': 50,
     'edr_cli_run': false,
     'max_int': 2147483647,

--- a/models/edr/alerts/alerts_dbt_models.sql
+++ b/models/edr/alerts/alerts_dbt_models.sql
@@ -27,4 +27,4 @@ select model_execution_id as alert_id,
        status,
        full_refresh
 from error_models
-where {{ not elementary.get_config_var('disable_model_alerts') }} and lower(status) != 'success'
+where {{ not elementary.get_config_var('disable_model_alerts') }} and lower(status) != 'success' {%- if elementary.get_config_var('disable_skipped_model_alerts') -%} and lower(status) != 'skipped' {%- endif -%}


### PR DESCRIPTION
Adding the option to disable Slack notification for skipped models through the `disable_skipped_model_alerts` var. 

This PR answers the issue # 300 ([link](https://github.com/elementary-data/elementary/issues/300)) of the main repo.
