### PR TITLE
Changed the query that returns the known columns and tables.

### DIFF
--- a/macros/edr/data_monitoring/schema_changes/get_columns_snapshot_query.sql
+++ b/macros/edr/data_monitoring/schema_changes/get_columns_snapshot_query.sql
@@ -2,14 +2,12 @@
 
     {%- set known_columns_query %}
         select full_column_name from {{ ref('schema_columns_snapshot') }}
-        where detected_at = (select max(detected_at) from {{ ref('schema_columns_snapshot') }})
-        and lower(full_table_name) = lower('{{ full_table_name }}')
+        where lower(full_table_name) = lower('{{ full_table_name }}')
     {% endset %}
 
     {%- set known_tables_query %}
         select distinct full_table_name from {{ ref('schema_columns_snapshot') }}
-        where detected_at = (select max(detected_at) from {{ ref('schema_columns_snapshot') }})
-        and lower(full_table_name) = lower('{{ full_table_name }}')
+        where lower(full_table_name) = lower('{{ full_table_name }}')
     {% endset %}
 
 

--- a/macros/edr/data_monitoring/schema_changes/get_columns_snapshot_query.sql
+++ b/macros/edr/data_monitoring/schema_changes/get_columns_snapshot_query.sql
@@ -2,12 +2,14 @@
 
     {%- set known_columns_query %}
         select full_column_name from {{ ref('schema_columns_snapshot') }}
-        where lower(full_table_name) = lower('{{ full_table_name }}')
+        where detected_at = (select max(detected_at) from {{ ref('schema_columns_snapshot') }} where lower(full_table_name) = lower('{{ full_table_name }}'))
+        and lower(full_table_name) = lower('{{ full_table_name }}')
     {% endset %}
 
     {%- set known_tables_query %}
         select distinct full_table_name from {{ ref('schema_columns_snapshot') }}
-        where lower(full_table_name) = lower('{{ full_table_name }}')
+        where detected_at = (select max(detected_at) from {{ ref('schema_columns_snapshot') }} where lower(full_table_name) = lower('{{ full_table_name }}'))
+        and lower(full_table_name) = lower('{{ full_table_name }}')
     {% endset %}
 
 


### PR DESCRIPTION
Fixed a bug in the query that gets the latest known schema of a table.

The query filters by `detected_at` is applied globally rather than to the tested table.

Impact: When concurrent `schema_changes` tests run, if columns were added to the table, there's a chance the alert will not fail.