### PR TITLE
Fixed current_timestamp() macros.

### DIFF
--- a/macros/utils/cross_db_utils/current_timestamp.sql
+++ b/macros/utils/cross_db_utils/current_timestamp.sql
@@ -1,20 +1,16 @@
-{% macro current_timestamp() -%}
-  {% if dbt_version >= '1.2.0' %}
-        {# This macro is depricated from dbt_utils version 0.9.0, but still hasn't got an equivalent macro at dbt-core #}
-        {# Should be replaced to the equivalent macro once it released #}
-        {{ return(dbt_utils.current_timestamp()) }}
-    {% else %}
-        {{ return(dbt_utils.current_timestamp()) }}
-    {% endif %}
-{%- endmacro %}
+{% macro current_timestamp() %}
+  {% set macro = dbt.current_timestamp_backcompat or dbt_utils.current_timestamp %}
+  {% if not macro %}
+    {{ exceptions.raise_compiler_error("Did not find a current_timestamp macro.") }}
+  {% endif %}
+  {{ return(macro) }}
+{% endmacro %}
 
 
-{% macro current_timestamp_in_utc() -%}
-  {% if dbt_version >= '1.2.0' %}
-        {# This macro is depricated from dbt_utils version 0.9.0, but still hasn't got an equivalent macro at dbt-core #}
-        {# Should be replaced to the equivalent macro once it released #}
-        {{ return(dbt_utils.current_timestamp_in_utc()) }}
-    {% else %}
-        {{ return(dbt_utils.current_timestamp_in_utc()) }}
-    {% endif %}
-{%- endmacro %}
+{% macro current_timestamp_in_utc() %}
+  {% set macro = dbt.current_timestamp_in_utc_backcompat or dbt_utils.current_timestamp_in_utc %}
+  {% if not macro %}
+    {{ exceptions.raise_compiler_error("Did not find a current_timestamp_in_utc macro.") }}
+  {% endif %}
+  {{ return(macro) }}
+{% endmacro %}


### PR DESCRIPTION
This branch is a fork from v0.5.3.
I'll merge it into master but release a new version **not from master**.