### PR TITLE
remove compiled_code from dbt_tests

### DIFF
--- a/models/dbt_artifacts.yml
+++ b/models/dbt_artifacts.yml
@@ -174,10 +174,6 @@ models:
         data_type: string
         description: ""
 
-      - name: compiled_code
-        data_type: string
-        description: ""
-
       - name: path
         data_type: string
         description: ""


### PR DESCRIPTION
I noticed that there is a `compiled_code` column defined in `dbt_tests` model that doesn't show up in the model SQL