### PR TITLE
Fix bug: model_run_results.sql

### DIFF
--- a/models/edr/run_results/model_run_results.sql
+++ b/models/edr/run_results/model_run_results.sql
@@ -38,8 +38,8 @@ SELECT
     models.owner,
     models.alias,
     ROW_NUMBER() OVER (PARTITION BY run_results.unique_id ORDER BY run_results.generated_at DESC) AS model_invocation_reverse_index,
-    CASE WHEN DENSE_RANK() OVER (PARTITION BY {{ elementary.time_trunc('day', 'run_results.generated_at') }} ORDER BY run_results.generated_at ASC) = 1 THEN TRUE ELSE FALSE END AS is_the_first_invocation_of_the_day,
-    CASE WHEN DENSE_RANK() OVER (PARTITION BY {{ elementary.time_trunc('day', 'run_results.generated_at') }} ORDER BY run_results.generated_at DESC) = 1 THEN TRUE ELSE FALSE END AS is_the_last_invocation_of_the_day
+    CASE WHEN DENSE_RANK() OVER (PARTITION BY {{ elementary.time_trunc('day', 'run_results.generated_at') }} ORDER BY {{ elementary.time_trunc('day', 'run_results.generated_at') }} ASC) = 1 THEN TRUE ELSE FALSE END AS is_the_first_invocation_of_the_day,
+    CASE WHEN DENSE_RANK() OVER (PARTITION BY {{ elementary.time_trunc('day', 'run_results.generated_at') }} ORDER BY {{ elementary.time_trunc('day', 'run_results.generated_at') }} DESC) = 1 THEN TRUE ELSE FALSE END AS is_the_last_invocation_of_the_day
     
 FROM dbt_run_results run_results
 JOIN dbt_models models ON run_results.unique_id = models.unique_id


### PR DESCRIPTION
The index for the last and first execution of the dat was not working properly because the sorting was based on the timestamp, not date. 