### PR TITLE
Made test_results_query compatible with result_rows.

### DIFF
--- a/macros/edr/materializations/tests/test.sql
+++ b/macros/edr/materializations/tests/test.sql
@@ -117,38 +117,18 @@
     {% do elementary.edr_log("Not enough data to calculate anomaly scores on `{}`".format(test_unique_id)) %}
   {% endif %}
   {% set test_results_query %}
-      with anomaly_scores as (
-          select * from {{ elementary.get_elementary_test_table(flattened_test.name, 'anomaly_scores') }}
-      ),
-      anomaly_scores_with_is_anomalous as (
-      select  *,
-              case when abs(anomaly_score) > {{ sensitivity }}
-              and bucket_end >= {{ elementary.timeadd('day', backfill_period, elementary.get_max_bucket_end()) }}
-              and training_set_size >= {{ elementary.get_config_var('days_back') -1 }} then TRUE else FALSE end as is_anomalous
-          from anomaly_scores
-          where anomaly_score is not null
-      )
-      select metric_value as value,
-             training_avg as average,
-             case when is_anomalous = TRUE then
-              lag(min_metric_value) over (partition by full_table_name, column_name, metric_name, dimension, dimension_value order by bucket_end)
-             else min_metric_value end as min_value,
-             case when is_anomalous = TRUE then
-              lag(max_metric_value) over (partition by full_table_name, column_name, metric_name, dimension, dimension_value order by bucket_end)
-              else max_metric_value end as max_value,
-             bucket_start as start_time,
-             bucket_end as end_time,
-             is_anomalous,
-             dimension,
-             dimension_value,
-             metric_id
-      from anomaly_scores_with_is_anomalous
-      where upper(full_table_name) = upper({{ elementary.const_as_string(full_table_name) }})
-            and metric_name = {{ elementary.const_as_string(metric_name) }}
-           {%- if column_name %}
-              and upper(column_name) = upper({{ elementary.const_as_string(column_name) }})
-           {%- endif %}
-      order by bucket_end, dimension_value
+    with anomaly_scores as (
+      {{ elementary.get_read_anomaly_scores_query(flattened_test) }}
+    )
+    select *
+    from anomaly_scores
+    where
+      upper(full_table_name) = upper({{ elementary.const_as_string(full_table_name) }})
+      and metric_name = {{ elementary.const_as_string(metric_name) }}
+      {%- if column_name %}
+        and upper(column_name) = upper({{ elementary.const_as_string(column_name) }})
+      {%- endif %}
+    order by bucket_end, dimension_value
   {%- endset -%}
   {% set test_results_description %}
       {% if has_anomaly_score %}

--- a/macros/edr/tests/test_utils/get_anomaly_query.sql
+++ b/macros/edr/tests/test_utils/get_anomaly_query.sql
@@ -51,12 +51,12 @@
         training_end,
         dimension,
         dimension_value,
+        is_anomalous,
+        {{ elementary.anomaly_detection_description() }},
         metric_value as value,
         training_avg as average,
         bucket_start as start_time,
         bucket_end as end_time,
-        is_anomalous,
-        {{ elementary.anomaly_detection_description() }},
         case when is_anomalous = TRUE then
          lag(min_metric_value) over (partition by full_table_name, column_name, metric_name, dimension, dimension_value order by bucket_end)
         else min_metric_value end as min_value,

--- a/macros/edr/tests/test_utils/get_anomaly_query.sql
+++ b/macros/edr/tests/test_utils/get_anomaly_query.sql
@@ -3,10 +3,9 @@
     {% set flattened_test = elementary.flatten_test(model) %}
   {% endif %}
 
-  {% set sensitivity = elementary.get_test_argument(argument_name='anomaly_sensitivity', value=flattened_test.test_params.sensitivity) %}
   {%- set query -%}
     select * from ({{ elementary.get_read_anomaly_scores_query(flattened_test) }})
-    where abs(anomaly_score) > {{ sensitivity }}
+    where is_anomalous = true
   {%- endset -%}
   {{- return(query) -}}
 {%- endmacro -%}
@@ -16,18 +15,60 @@
       {% set flattened_test = elementary.flatten_test(model) %}
     {% endif %}
 
+    {% set sensitivity = elementary.get_test_argument(argument_name='anomaly_sensitivity', value=flattened_test.test_params.sensitivity) %}
     {% set backfill_days = elementary.get_test_argument(argument_name='backfill_days', value=flattened_test.test_params.backfill_days) %}
     {%- set backfill_period = "'-" ~ backfill_days ~ "'" %}
     {%- set anomaly_query -%}
-        select
-            *,
-            {{ elementary.anomaly_detection_description() }}
-        from {{ elementary.get_elementary_test_table(flattened_test.name, 'anomaly_scores') }}
-        where
-            {# get anomalies only for a limited period called the backfill period #}
-            bucket_end >= {{ elementary.timeadd('day', backfill_period, elementary.get_max_bucket_end()) }} and
-            {# to avoid false positives return only anomaly scores that were calculated with a big enough training set #}
-            training_set_size >= {{ elementary.get_config_var('days_back') -1 }}
+      with anomaly_scores as (
+          select * from {{ elementary.get_elementary_test_table(flattened_test.name, 'anomaly_scores') }}
+      ),
+      anomaly_scores_with_is_anomalous as (
+      select
+        *,
+        case when abs(anomaly_score) > {{ sensitivity }}
+        and bucket_end >= {{ elementary.timeadd('day', backfill_period, elementary.get_max_bucket_end()) }}
+        and training_set_size >= {{ elementary.get_config_var('days_back') -1 }} then TRUE else FALSE end as is_anomalous
+      from anomaly_scores
+      where anomaly_score is not null
+      )
+      select
+        id,
+        metric_id,
+        test_execution_id,
+        test_unique_id,
+        detected_at,
+        full_table_name,
+        column_name,
+        metric_name,
+        anomaly_score,
+        anomaly_score_threshold,
+        anomalous_value,
+        min_metric_value,
+        max_metric_value,
+        training_stddev,
+        training_set_size,
+        training_start,
+        training_end,
+        dimension,
+        dimension_value,
+        metric_value as value,
+        training_avg as average,
+        bucket_start as start_time,
+        bucket_end as end_time,
+        is_anomalous,
+        {{ elementary.anomaly_detection_description() }},
+        case when is_anomalous = TRUE then
+         lag(min_metric_value) over (partition by full_table_name, column_name, metric_name, dimension, dimension_value order by bucket_end)
+        else min_metric_value end as min_value,
+        case when is_anomalous = TRUE then
+         lag(max_metric_value) over (partition by full_table_name, column_name, metric_name, dimension, dimension_value order by bucket_end)
+         else max_metric_value end as max_value
+      from anomaly_scores_with_is_anomalous
+      where
+        {# get anomalies only for a limited period called the backfill period #}
+        bucket_end >= {{ elementary.timeadd('day', backfill_period, elementary.get_max_bucket_end()) }} and
+        {# to avoid false positives return only anomaly scores that were calculated with a big enough training set #}
+        training_set_size >= {{ elementary.get_config_var('days_back') -1 }}
     {%- endset -%}
     {{- return(anomaly_query) -}}
 {% endmacro %}


### PR DESCRIPTION
The added `result_rows` column of `elementary_test_results` return different column names than `test_results_query`.
This change make then return the same table format.