### PR TITLE
Modular alerts

### DIFF
--- a/macros/edr/alerts/get_alert_fields.sql
+++ b/macros/edr/alerts/get_alert_fields.sql
@@ -1,0 +1,13 @@
+{% macro get_alert_fields(test_meta = none) %}
+    {% set default_alert_fields = elementary.get_config_var('alert_fields') %}
+    {% set test_alert_fields = none %}
+    {% if test_meta %}
+        {% set test_alert_fields = elementary.safe_get_with_default(test_meta, 'alert_fields', none) %}
+    {% endif %}
+
+    {% if test_alert_fields %}
+        {{ return(test_alert_fields) }}
+    {% else %}
+        {{ return(default_alert_fields) }}
+    {% endif %}
+{% endmacro %}

--- a/macros/edr/dbt_artifacts/upload_dbt_tests.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_tests.sql
@@ -47,6 +47,12 @@
     {% set meta_dict = elementary.safe_get_with_default(node_dict, 'meta', {}) %}
     {% do meta_dict.update(config_meta_dict) %}
 
+    {# If alerts field is provided using global var, we want to add it to the test meta #}
+    {% set alert_fields = elementary.get_alert_fields(meta_dict) %}
+    {% if alert_fields %}
+        {% do  meta_dict.update({'alert_fields': alert_fields}) %}
+    {% endif %}
+
     {% set config_tags = elementary.safe_get_with_default(config_dict, 'tags', []) %}
     {% set global_tags = elementary.safe_get_with_default(node_dict, 'tags', []) %}
     {% set meta_tags = elementary.safe_get_with_default(meta_dict, 'tags', []) %}

--- a/macros/edr/system/system_utils/get_config_var.sql
+++ b/macros/edr/system/system_utils/get_config_var.sql
@@ -34,7 +34,24 @@
     'collect_model_sql': true,
     'model_sql_max_size': 10240,
     'query_max_size': 1000000,
-    'insert_rows_method': 'max_query_size'
+    'insert_rows_method': 'max_query_size',
+    'alert_fields': [
+      'table_name',
+      'deteceted_at',
+      'status'
+      'name',
+      'type',
+      'description',
+      'owners',
+      'tags',
+      'subscribers',
+      'error_message',
+      'test_column',
+      'anomalous values',
+      'test_params',
+      'test_query',
+      'results_sample'
+    ] 
   } %}
 
   {{ return(var(var_name, default_config.get(var_name))) }}

--- a/macros/edr/system/system_utils/get_config_var.sql
+++ b/macros/edr/system/system_utils/get_config_var.sql
@@ -34,24 +34,7 @@
     'collect_model_sql': true,
     'model_sql_max_size': 10240,
     'query_max_size': 1000000,
-    'insert_rows_method': 'max_query_size',
-    'alert_fields': [
-      'table_name',
-      'deteceted_at',
-      'status'
-      'name',
-      'type',
-      'description',
-      'owners',
-      'tags',
-      'subscribers',
-      'error_message',
-      'test_column',
-      'anomalous values',
-      'test_params',
-      'test_query',
-      'results_sample'
-    ] 
+    'insert_rows_method': 'max_query_size'
   } %}
 
   {{ return(var(var_name, default_config.get(var_name))) }}


### PR DESCRIPTION
Supporting an `alert_fields` var for tests.
Could be defined using meta, or by defining a global var called `alert_fields` which will be the default `alert_fields`.

In case a global var was defined, we add it to the tests meta fields (so it would be passed to the CLI)