### PR TITLE
render_value() stringifies the value by default.

### DIFF
--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -98,14 +98,12 @@
 
 {%- macro render_value(value) -%}
     {%- if value is defined and value is not none -%}
-        {%- if value is number -%}
-            {{- value -}}
-        {%- elif value is string -%}
+        {%- if value is string -%}
             '{{- elementary.escape_special_chars(value) -}}'
         {%- elif value is mapping or value is sequence -%}
             '{{- elementary.escape_special_chars(tojson(value)) -}}'
         {%- else -%}
-            NULL
+            {{- value -}}
         {%- endif -%}
     {%- else -%}
         NULL


### PR DESCRIPTION
Fixes [this issue](https://elementary-community.slack.com/archives/C02CTC89LAX/p1669723248255899).