### PR TITLE
Getting the actual version rather than the one specified in packages.yml

### DIFF
--- a/macros/edr/system/system_utils/get_elementary_package_version.sql
+++ b/macros/edr/system/system_utils/get_elementary_package_version.sql
@@ -1,14 +1,4 @@
-{# The macro only works if using `package` in `packages.yml`, rather than `git`, `local`, etc. #}
 {% macro get_elementary_package_version() %}
   {% set conf = elementary.get_runtime_config() %}
-  {% set packages = conf.packages and conf.packages.packages %}
-  {% if not packages %}
-    {{ return(none) }}
-  {% endif %}
-  {% for pkg in packages %}
-    {% if pkg.package == 'elementary-data/elementary' %}
-      {{ return(pkg.version) }}
-    {% endif %}
-  {% endfor %}
-  {{ return(none) }}
+  {% do return(conf.dependencies["elementary"].version) %}
 {% endmacro %}


### PR DESCRIPTION
The previous check returned the range (for instance, `version: [">=0.7.0", "<0.8.0"]`),
the new code returns the one that is actually installed.