### PR TITLE
fix databricks create table as bug

### DIFF
--- a/integration_tests/run_e2e_tests.py
+++ b/integration_tests/run_e2e_tests.py
@@ -393,7 +393,7 @@ def e2e_tests(target, test_types, clear_tests) -> TestResults:
         test_results.extend(results)
 
     if "create_table" in test_types:
-        # If there is a ptoblem with create_or_replace macro, it will crash the test.
+        # If there is a problem with create_or_replace macro, it will crash the test.
         dbt_runner.test(select="tag:table_anomalies")
         dbt_runner.test(select="tag:table_anomalies")
 

--- a/integration_tests/run_e2e_tests.py
+++ b/integration_tests/run_e2e_tests.py
@@ -392,6 +392,11 @@ def e2e_tests(target, test_types, clear_tests) -> TestResults:
         ]
         test_results.extend(results)
 
+    if "create_table" in test_types:
+        # If there is a ptoblem with create_or_replace macro, it will crash the test.
+        dbt_runner.test(select="tag:table_anomalies")
+        dbt_runner.test(select="tag:table_anomalies")
+
     if "error_test" in test_types:
         dbt_runner.test(select="tag:error_test")
         results = [
@@ -545,7 +550,7 @@ def print_failed_test_results(e2e_target: str, failed_test_results: List[TestRes
     "-e",
     type=str,
     default="all",
-    help="table / column / schema / regular / artifacts / error_test / error_model / error_snapshot / dimension / no_timestamp / debug / all (default = all)",
+    help="table / column / schema / regular / artifacts / error_test / error_model / error_snapshot / dimension / create_table / no_timestamp / debug / all (default = all)",
 )
 @click.option(
     "--generate-data",
@@ -580,6 +585,7 @@ def main(target, e2e_type, generate_data, clear_tests):
             "error_model",
             "error_snapshot",
             "dimension",
+            "create_table",
         ]
     else:
         e2e_types = [e2e_type]

--- a/macros/utils/table_operations/create_or_replace.sql
+++ b/macros/utils/table_operations/create_or_replace.sql
@@ -12,3 +12,9 @@
     {%- do run_query(dbt.create_table_as(temporary, relation, sql_query)) %}
     {% do adapter.commit() %}
 {% endmacro %}
+
+{% macro spark__create_or_replace(temporary, relation, sql_query) %}
+    {%- do dbt.drop_relation_if_exists(relation) -%}
+    {%- do run_query(dbt.create_table_as(temporary, relation, sql_query)) %}
+    {% do adapter.commit() %}
+{% endmacro %}


### PR DESCRIPTION
dbt-spark doesn't have an adapter for `create_table_as`.
This means that every time we run `create_or_replace` macro on spark, we use the default `create_table_as` which only uses create.
This causing a bug when running a test twice, we try and create an existing table and gets an error.
The fix is to drop the table if exists before creating it (same as we do in redshift)