### PR TITLE
Removed the Jinja rendering from `packages.yml`.

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,9 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: |
-      {%- set minor_to_utils_range_map = {
-        "0": [">=0.8.0", "<0.9.0"],
-        "1": [">=0.8.0", "<0.9.0"],
-        "2": [">=0.8.0", "<1.0.0"],
-      } -%}
-      {{- minor_to_utils_range_map.get(dbt_version.split('.')[1], [">=0.8.0", "<2.0.0"]) -}}
+    version: [">=0.8.0", "<2.0.0"]


### PR DESCRIPTION
Upon running `dbt deps` against the registry,
dbt validates that the `version` is a valid `semver`.
It doesn't do so when using `local` method.