### PR TITLE
rename dbt alike macro names

### DIFF
--- a/macros/edr/data_monitoring/anomaly_detection/get_anomaly_scores_query.sql
+++ b/macros/edr/data_monitoring/anomaly_detection/get_anomaly_scores_query.sql
@@ -126,7 +126,7 @@
                 metric_id,
                 {{ elementary.const_as_string(test_execution_id) }} as test_execution_id,
                 {{ elementary.const_as_string(test_unique_id) }} as test_unique_id,
-                {{ elementary.elementary_current_timestamp_column() }} as detected_at,
+                {{ elementary.current_timestamp_column() }} as detected_at,
                 full_table_name,
                 column_name,
                 metric_name,

--- a/macros/edr/data_monitoring/anomaly_detection/get_anomaly_scores_query.sql
+++ b/macros/edr/data_monitoring/anomaly_detection/get_anomaly_scores_query.sql
@@ -119,14 +119,14 @@
         anomaly_scores as (
 
             select
-                {{ elementary.generate_surrogate_key([
+                {{ elementary.elementary_generate_surrogate_key([
                  'metric_id',
                  elementary.const_as_string(test_execution_id)
                 ]) }} as id,
                 metric_id,
                 {{ elementary.const_as_string(test_execution_id) }} as test_execution_id,
                 {{ elementary.const_as_string(test_unique_id) }} as test_unique_id,
-                {{ elementary.current_timestamp_column() }} as detected_at,
+                {{ elementary.elementary_current_timestamp_column() }} as detected_at,
                 full_table_name,
                 column_name,
                 metric_name,

--- a/macros/edr/data_monitoring/monitors/column_numeric_monitors.sql
+++ b/macros/edr/data_monitoring/monitors/column_numeric_monitors.sql
@@ -1,17 +1,17 @@
 {% macro max(column_name) -%}
-    max(cast({{ column_name }} as {{ elementary.type_float() }}))
+    max(cast({{ column_name }} as {{ elementary.elementary_type_float() }}))
 {%- endmacro %}
 
 {% macro min(column_name) -%}
-    min(cast({{ column_name }} as {{ elementary.type_float() }}))
+    min(cast({{ column_name }} as {{ elementary.elementary_type_float() }}))
 {%- endmacro %}
 
 {% macro average(column_name) -%}
-    avg(cast({{ column_name }} as {{ elementary.type_float() }}))
+    avg(cast({{ column_name }} as {{ elementary.elementary_type_float() }}))
 {%- endmacro %}
 
 {% macro zero_count(column_name) %}
-    coalesce(sum(case when {{ column_name }} is null then 1 when cast({{ column_name }} as {{ elementary.type_float() }}) = 0 then 1 else 0 end), 0)
+    coalesce(sum(case when {{ column_name }} is null then 1 when cast({{ column_name }} as {{ elementary.elementary_type_float() }}) = 0 then 1 else 0 end), 0)
 {% endmacro %}
 
 {% macro zero_percent(column_name) %}
@@ -19,9 +19,9 @@
 {% endmacro %}
 
 {% macro standard_deviation(column_name) -%}
-    stddev(cast({{ column_name }} as {{ elementary.type_float() }}))
+    stddev(cast({{ column_name }} as {{ elementary.elementary_type_float() }}))
 {%- endmacro %}
 
 {% macro variance(column_name) -%}
-    variance(cast({{ column_name }} as {{ elementary.type_float() }}))
+    variance(cast({{ column_name }} as {{ elementary.elementary_type_float() }}))
 {%- endmacro %}

--- a/macros/edr/data_monitoring/monitors_query/column_monitoring_query.sql
+++ b/macros/edr/data_monitoring/monitors_query/column_monitoring_query.sql
@@ -88,7 +88,7 @@
     )
 
     select
-        {{ elementary.generate_surrogate_key([
+        {{ elementary.elementary_generate_surrogate_key([
             'full_table_name',
             'column_name',
             'metric_name',
@@ -102,7 +102,7 @@
         bucket_start,
         bucket_end,
         bucket_duration_hours,
-        {{ elementary.current_timestamp_in_utc() }} as updated_at,
+        {{ elementary.elementary_current_timestamp_in_utc() }} as updated_at,
         dimension,
         dimension_value
     from metrics_final

--- a/macros/edr/data_monitoring/monitors_query/dimension_monitoring_query.sql
+++ b/macros/edr/data_monitoring/monitors_query/dimension_monitoring_query.sql
@@ -114,7 +114,7 @@
             dimension_value
         from
             row_count
-        where (metric_value is not null and cast(metric_value as {{ elementary.type_int() }}) < {{ elementary.get_config_var('max_int') }}) or
+        where (metric_value is not null and cast(metric_value as {{ elementary.elementary_type_int() }}) < {{ elementary.get_config_var('max_int') }}) or
             metric_value is null
         )
 
@@ -238,7 +238,7 @@
     {% endif %}
 
     select
-        {{ elementary.generate_surrogate_key([
+        {{ elementary.elementary_generate_surrogate_key([
             'full_table_name',
             'column_name',
             'metric_name',
@@ -254,7 +254,7 @@
         bucket_start,
         bucket_end,
         bucket_duration_hours,
-        {{ elementary.current_timestamp_in_utc() }} as updated_at,
+        {{ elementary.elementary_current_timestamp_in_utc() }} as updated_at,
         dimension,
         dimension_value
     from metrics_final

--- a/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
+++ b/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
@@ -91,7 +91,7 @@
             {{ elementary.null_string() }} as dimension_value
         from
             union_metrics
-        where (metric_value is not null and cast(metric_value as {{ elementary.type_int() }}) < {{ elementary.get_config_var('max_int') }}) or
+        where (metric_value is not null and cast(metric_value as {{ elementary.elementary_type_int() }}) < {{ elementary.get_config_var('max_int') }}) or
             metric_value is null
         )
     {% else %}
@@ -126,7 +126,7 @@
     {% endif %}
 
     select
-        {{ elementary.generate_surrogate_key([
+        {{ elementary.elementary_generate_surrogate_key([
             'full_table_name',
             'column_name',
             'metric_name',
@@ -140,7 +140,7 @@
         bucket_start,
         bucket_end,
         bucket_duration_hours,
-        {{ elementary.current_timestamp_in_utc() }} as updated_at,
+        {{ elementary.elementary_current_timestamp_in_utc() }} as updated_at,
         dimension,
         dimension_value
     from metrics_final

--- a/macros/edr/data_monitoring/schema_changes/get_columns_changes_query.sql
+++ b/macros/edr/data_monitoring/schema_changes/get_columns_changes_query.sql
@@ -146,7 +146,7 @@
 
         {# This is the query that is creating the test results table, by formatting a description and adding id + detection time #}
         select
-            {{ elementary.generate_surrogate_key(['full_table_name', 'column_name', 'change', 'detected_at']) }} as data_issue_id,
+            {{ elementary.elementary_generate_surrogate_key(['full_table_name', 'column_name', 'change', 'detected_at']) }} as data_issue_id,
             {{ elementary.datetime_now_utc_as_timestamp_column() }} as detected_at,
             {{ elementary.full_name_split('database_name') }},
             {{ elementary.full_name_split('schema_name') }},
@@ -169,7 +169,7 @@
     )
 
         {# Creating a unique id for each row in the table, and adding execution id #}
-    select {{ elementary.generate_surrogate_key([
+    select {{ elementary.elementary_generate_surrogate_key([
                      'data_issue_id',
                      elementary.const_as_string(test_execution_id)
                 ]) }} as id,

--- a/macros/edr/data_monitoring/schema_changes/get_columns_snapshot_query.sql
+++ b/macros/edr/data_monitoring/schema_changes/get_columns_snapshot_query.sql
@@ -28,7 +28,7 @@
             schema_name,
             table_name,
             column_name,
-            cast(data_type as {{ elementary.type_string() }}) as data_type,
+            cast(data_type as {{ elementary.elementary_type_string() }}) as data_type,
             {{ elementary.datetime_now_utc_as_timestamp_column() }} as detected_at,
             case when
                     {{ elementary.full_column_name() }} not in ({{ known_columns_query }})
@@ -43,7 +43,7 @@
     columns_snapshot_with_id as (
 
         select
-            {{ elementary.generate_surrogate_key([
+            {{ elementary.elementary_generate_surrogate_key([
               'full_table_name',
               'column_name',
               'data_type'

--- a/macros/edr/system/system_utils/data_monitors_end.sql
+++ b/macros/edr/system/system_utils/data_monitors_end.sql
@@ -2,7 +2,7 @@
 
     {%- set monitors_run_end_query %}
         update {{ ref('elementary_runs') }}
-            set monitors_run_end = {{ elementary.current_timestamp_in_utc() }}
+            set monitors_run_end = {{ elementary.elementary_current_timestamp_in_utc() }}
         where run_id = '{{ invocation_id }}'
     {%- endset %}
 

--- a/macros/edr/system/system_utils/empty_table.sql
+++ b/macros/edr/system/system_utils/empty_table.sql
@@ -95,19 +95,19 @@
     {%- set dummy_values = elementary.dummy_values() %}
 
     {%- if data_type == 'boolean' %}
-        cast ({{ dummy_values['boolean'] }} as {{ elementary.type_bool()}}) as {{ column_name }}
+        cast ({{ dummy_values['boolean'] }} as {{ elementary.elementary_type_bool()}}) as {{ column_name }}
     {%- elif data_type == 'timestamp' -%}
-        cast('{{ dummy_values['timestamp'] }}' as {{ elementary.type_timestamp() }}) as {{ column_name }}
+        cast('{{ dummy_values['timestamp'] }}' as {{ elementary.elementary_type_timestamp() }}) as {{ column_name }}
     {%- elif data_type == 'int' %}
-        cast({{ dummy_values['int'] }} as {{ elementary.type_int() }}) as {{ column_name }}
+        cast({{ dummy_values['int'] }} as {{ elementary.elementary_type_int() }}) as {{ column_name }}
     {%- elif data_type == 'bigint' %}
-        cast({{ dummy_values['bigint'] }} as {{ elementary.type_bigint() }}) as {{ column_name }}
+        cast({{ dummy_values['bigint'] }} as {{ elementary.elementary_type_bigint() }}) as {{ column_name }}
     {%- elif data_type == 'float' %}
-        cast({{ dummy_values['float'] }} as {{ elementary.type_float() }}) as {{ column_name }}
+        cast({{ dummy_values['float'] }} as {{ elementary.elementary_type_float() }}) as {{ column_name }}
     {%- elif data_type == 'long_string' %}
-        cast('{{ dummy_values['long_string'] }}' as {{ elementary.type_long_string() }}) as {{ column_name }}
+        cast('{{ dummy_values['long_string'] }}' as {{ elementary.elementary_type_long_string() }}) as {{ column_name }}
     {%- else %}
-        cast('{{ dummy_values['string'] }}' as {{ elementary.type_string() }}) as {{ column_name }}
+        cast('{{ dummy_values['string'] }}' as {{ elementary.elementary_type_string() }}) as {{ column_name }}
     {%- endif %}
 
 {% endmacro %}

--- a/macros/edr/system/system_utils/timestamp_column.sql
+++ b/macros/edr/system/system_utils/timestamp_column.sql
@@ -1,11 +1,11 @@
 {% macro run_start_column() %}
-    cast ('{{ elementary.get_run_started_at().strftime("%Y-%m-%d %H:%M:%S") }}' as {{ elementary.type_timestamp() }})
+    cast ('{{ elementary.get_run_started_at().strftime("%Y-%m-%d %H:%M:%S") }}' as {{ elementary.elementary_type_timestamp() }})
 {% endmacro %}
 
 {% macro current_timestamp_column() %}
-    cast ({{elementary.current_timestamp_in_utc()}} as {{ elementary.type_timestamp() }})
+    cast ({{elementary.elementary_current_timestamp_in_utc()}} as {{ elementary.elementary_type_timestamp() }})
 {% endmacro %}
 
 {% macro datetime_now_utc_as_timestamp_column() %}
-    cast ('{{ elementary.datetime_now_utc_as_string() }}' as {{ elementary.type_timestamp() }})
+    cast ('{{ elementary.datetime_now_utc_as_string() }}' as {{ elementary.elementary_type_timestamp() }})
 {% endmacro %}

--- a/macros/utils/cross_db_utils/current_timestamp.sql
+++ b/macros/utils/cross_db_utils/current_timestamp.sql
@@ -1,4 +1,4 @@
-{% macro current_timestamp() -%}
+{% macro elementary_current_timestamp() -%}
     {% set macro = dbt.current_timestamp_backcompat or dbt_utils.current_timestamp %}
     {% if not macro %}
         {{ exceptions.raise_compiler_error("Did not find a `current_timestamp` macro.") }}
@@ -7,7 +7,7 @@
 {%- endmacro %}
 
 
-{% macro current_timestamp_in_utc() -%}
+{% macro elementary_current_timestamp_in_utc() -%}
     {% set macro = dbt.current_timestamp_in_utc_backcompat or dbt_utils.current_timestamp_in_utc %}
     {% if not macro %}
         {{ exceptions.raise_compiler_error("Did not find a `current_timestamp_in_utc` macro.") }}

--- a/macros/utils/cross_db_utils/date_trunc.sql
+++ b/macros/utils/cross_db_utils/date_trunc.sql
@@ -1,4 +1,4 @@
-{% macro date_trunc(datepart, date) %}
+{% macro elementary_date_trunc(datepart, date) %}
     {% set macro = dbt.date_trunc or dbt_utils.date_trunc %}
     {% if not macro %}
         {{ exceptions.raise_compiler_error("Did not find a `date_trunc` macro.") }}

--- a/macros/utils/cross_db_utils/dateadd.sql
+++ b/macros/utils/cross_db_utils/dateadd.sql
@@ -1,4 +1,4 @@
-{% macro dateadd(datepart, interval, from_date_or_timestamp) %}
+{% macro elementary_dateadd(datepart, interval, from_date_or_timestamp) %}
     {% set macro = dbt.dateadd or dbt_utils.dateadd %}
     {% if not macro %}
         {{ exceptions.raise_compiler_error("Did not find a `dateadd` macro.") }}

--- a/macros/utils/cross_db_utils/datediff.sql
+++ b/macros/utils/cross_db_utils/datediff.sql
@@ -1,4 +1,4 @@
-{% macro datediff(first_date, second_date, datepart) %}
+{% macro elementary_datediff(first_date, second_date, datepart) %}
     {% set macro = dbt.datediff or dbt_utils.datediff %}
     {% if not macro %}
         {{ exceptions.raise_compiler_error("Did not find a `datediff` macro.") }}

--- a/macros/utils/cross_db_utils/generate_surrogate_key.sql
+++ b/macros/utils/cross_db_utils/generate_surrogate_key.sql
@@ -15,7 +15,7 @@
 #}
 
 
-{%- macro generate_surrogate_key(fields) -%}
+{%- macro elementary_generate_surrogate_key(fields) -%}
   {% set concat_macro = dbt.concat or dbt_utils.concat %}
   {% set hash_macro = dbt.hash or dbt_utils.hash %}
 
@@ -23,7 +23,7 @@
   {%- set field_sqls = [] -%}
   {%- for field in fields -%}
     {%- do field_sqls.append(
-        "coalesce(cast(" ~ field ~ " as " ~ elementary.type_string() ~ "), '" ~ default_null_value  ~"')"
+        "coalesce(cast(" ~ field ~ " as " ~ elementary.elementary_type_string() ~ "), '" ~ default_null_value  ~"')"
     ) -%}
     {%- if not loop.last %}
         {%- do field_sqls.append("'-'") -%}

--- a/macros/utils/cross_db_utils/safe_cast.sql
+++ b/macros/utils/cross_db_utils/safe_cast.sql
@@ -1,8 +1,8 @@
-{% macro safe_cast(field, type) %}
-    {{ return(adapter.dispatch('safe_cast', 'elementary') (field, type)) }}
+{% macro elementary_safe_cast(field, type) %}
+    {{ return(adapter.dispatch('elementary_safe_cast', 'elementary') (field, type)) }}
 {% endmacro %}
 
-{% macro default__safe_cast(field, type) %}
+{% macro default__elementary_safe_cast(field, type) %}
     {% set macro = dbt.safe_cast or dbt_utils.safe_cast %}
     {% if not macro %}
         {{ exceptions.raise_compiler_error("Did not find a `safe_cast` macro.") }}
@@ -10,6 +10,6 @@
     {{ return(macro(field, type)) }}
 {% endmacro %}
 
-{% macro spark__safe_cast(field, type) %}
+{% macro spark__elementary_safe_cast(field, type) %}
     try_cast({{field}} as {{type}})
 {% endmacro %}

--- a/macros/utils/cross_db_utils/time_trunc.sql
+++ b/macros/utils/cross_db_utils/time_trunc.sql
@@ -4,7 +4,7 @@
 {%- endmacro %}
 
 {% macro default__time_trunc(date_part, date_expression) %}
-    date_trunc('{{date_part}}', cast({{ date_expression }} as {{ elementary.type_timestamp() }}))
+    elementary.elementary_date_trunc('{{date_part}}', cast({{ date_expression }} as {{ elementary.elementary_type_timestamp() }}))
 {% endmacro %}
 
 {% macro bigquery__time_trunc(date_part, date_expression) %}

--- a/macros/utils/cross_db_utils/time_trunc.sql
+++ b/macros/utils/cross_db_utils/time_trunc.sql
@@ -4,7 +4,7 @@
 {%- endmacro %}
 
 {% macro default__time_trunc(date_part, date_expression) %}
-    elementary.elementary_date_trunc('{{date_part}}', cast({{ date_expression }} as {{ elementary.elementary_type_timestamp() }}))
+    date_trunc('{{date_part}}', cast({{ date_expression }} as {{ elementary.elementary_type_timestamp() }}))
 {% endmacro %}
 
 {% macro bigquery__time_trunc(date_part, date_expression) %}

--- a/macros/utils/cross_db_utils/timeadd.sql
+++ b/macros/utils/cross_db_utils/timeadd.sql
@@ -5,7 +5,7 @@
 
 {# Snowflake and Redshift #}
 {% macro default__timeadd(date_part, number, timestamp_expression) %}
-    dateadd({{ date_part }}, {{ number }}, {{ elementary.cast_as_timestamp(timestamp_expression) }})
+    elementary.elementary_dateadd({{ date_part }}, {{ number }}, {{ elementary.cast_as_timestamp(timestamp_expression) }})
 {% endmacro %}
 
 {% macro bigquery__timeadd(date_part, number, timestamp_expression) %}

--- a/macros/utils/cross_db_utils/timeadd.sql
+++ b/macros/utils/cross_db_utils/timeadd.sql
@@ -5,7 +5,7 @@
 
 {# Snowflake and Redshift #}
 {% macro default__timeadd(date_part, number, timestamp_expression) %}
-    elementary.elementary_dateadd({{ date_part }}, {{ number }}, {{ elementary.cast_as_timestamp(timestamp_expression) }})
+    dateadd({{ date_part }}, {{ number }}, {{ elementary.cast_as_timestamp(timestamp_expression) }})
 {% endmacro %}
 
 {% macro bigquery__timeadd(date_part, number, timestamp_expression) %}

--- a/macros/utils/cross_db_utils/timediff.sql
+++ b/macros/utils/cross_db_utils/timediff.sql
@@ -5,7 +5,7 @@
 
 {# Snowflake and Redshift #}
 {% macro default__timediff(timepart, first_timestamp, second_timestamp) %}
-    elementary.elementary_datediff({{ timepart }}, {{ first_timestamp }}, {{ second_timestamp }})
+    datediff({{ timepart }}, {{ first_timestamp }}, {{ second_timestamp }})
 {% endmacro %}
 
 {% macro bigquery__timediff(timepart, first_timestamp, second_timestamp) %}

--- a/macros/utils/cross_db_utils/timediff.sql
+++ b/macros/utils/cross_db_utils/timediff.sql
@@ -5,7 +5,7 @@
 
 {# Snowflake and Redshift #}
 {% macro default__timediff(timepart, first_timestamp, second_timestamp) %}
-    datediff({{ timepart }}, {{ first_timestamp }}, {{ second_timestamp }})
+    elementary.elementary_datediff({{ timepart }}, {{ first_timestamp }}, {{ second_timestamp }})
 {% endmacro %}
 
 {% macro bigquery__timediff(timepart, first_timestamp, second_timestamp) %}

--- a/macros/utils/data_types/cast_column.sql
+++ b/macros/utils/data_types/cast_column.sql
@@ -1,23 +1,23 @@
 {%- macro cast_as_timestamp(timestamp_field) -%}
-    cast({{ timestamp_field }} as {{ elementary.type_timestamp() }})
+    cast({{ timestamp_field }} as {{ elementary.elementary_type_timestamp() }})
 {%- endmacro -%}
 
 {%- macro cast_as_float(column) -%}
-    cast({{ column }} as {{ elementary.type_float() }})
+    cast({{ column }} as {{ elementary.elementary_type_float() }})
 {%- endmacro -%}
 
 {%- macro cast_as_string(column) -%}
-    cast({{ column }} as {{ elementary.type_string() }})
+    cast({{ column }} as {{ elementary.elementary_type_string() }})
 {%- endmacro -%}
 
 {%- macro cast_as_long_string(column) -%}
-    cast({{ column }} as {{ elementary.type_long_string() }})
+    cast({{ column }} as {{ elementary.elementary_type_long_string() }})
 {%- endmacro -%}
 
 {%- macro cast_as_bool(column) -%}
-    cast({{ column }} as {{ elementary.type_bool() }})
+    cast({{ column }} as {{ elementary.elementary_type_bool() }})
 {%- endmacro -%}
 
 {%- macro const_as_string(string) -%}
-    cast('{{ string }}' as {{ elementary.type_string() }})
+    cast('{{ string }}' as {{ elementary.elementary_type_string() }})
 {%- endmacro -%}

--- a/macros/utils/data_types/data_type.sql
+++ b/macros/utils/data_types/data_type.sql
@@ -7,65 +7,65 @@
   ) %}
 {% endmacro %}
 
-{%- macro type_bool() -%}
-    {{ return(adapter.dispatch('type_bool', 'elementary')()) }}
+{%- macro elementary_type_bool() -%}
+    {{ return(adapter.dispatch('elementary_type_bool', 'elementary')()) }}
 {%- endmacro -%}
 
-{% macro default__type_bool() %}
+{% macro default__elementary_type_bool() %}
     {% do return("boolean") %}
 {% endmacro %}
 
-{% macro bigquery__type_bool() %}
+{% macro bigquery__elementary_type_bool() %}
     {% do return("BOOL") %}
 {% endmacro %}
 
 
-{%- macro type_string() -%}
-    {{ return(adapter.dispatch('type_string', 'elementary')()) }}
+{%- macro elementary_type_string() -%}
+    {{ return(adapter.dispatch('elementary_type_string', 'elementary')()) }}
 {%- endmacro -%}
 
-{% macro default__type_string() %}
+{% macro default__elementary_type_string() %}
     {# Redshift and Postgres #}
     {% do return("varchar(4096)") %}
 {% endmacro %}
 
-{% macro snowflake__type_string() %}
+{% macro snowflake__elementary_type_string() %}
     {# Default max varchar size in Snowflake is 16MB #}
     {% do return("varchar") %}
 {% endmacro %}
 
-{% macro bigquery__type_string() %}
+{% macro bigquery__elementary_type_string() %}
     {# Default max string size in Bigquery is 65K #}
     {% do return("string") %}
 {% endmacro %}
 
-{% macro spark__type_string() %}
+{% macro spark__elementary_type_string() %}
     {% do return("string") %}
 {% endmacro %}
 
 
 
-{%- macro type_long_string() -%}
-    {{ return(adapter.dispatch('type_long_string', 'elementary')()) }}
+{%- macro elementary_type_long_string() -%}
+    {{ return(adapter.dispatch('elementary_type_long_string', 'elementary')()) }}
 {%- endmacro -%}
 
-{%- macro default__type_long_string() -%}
+{%- macro default__elementary_type_long_string() -%}
     {# Snowflake, Bigquery, Databricks #}
-    {% do return(elementary.type_string()) %}
+    {% do return(elementary.elementary_type_string()) %}
 {%- endmacro -%}
 
-{%- macro redshift__type_long_string() -%}
+{%- macro redshift__elementary_type_long_string() -%}
     {% set long_string = 'varchar(' ~ elementary.get_config_var('long_string_size') ~ ')' %}
     {{ return(long_string) }}
 {%- endmacro -%}
 
-{%- macro postgres__type_long_string() -%}
+{%- macro postgres__elementary_type_long_string() -%}
     {% set long_string = 'varchar(' ~ elementary.get_config_var('long_string_size') ~ ')' %}
     {{ return(long_string) }}
 {%- endmacro -%}
 
 
-{% macro type_bigint() %}
+{% macro elementary_type_bigint() %}
     {% set macro = dbt.type_bigint or dbt_utils.type_bigint %}
     {% if not macro %}
         {{ exceptions.raise_compiler_error("Did not find a `type_bigint` macro.") }}
@@ -74,7 +74,7 @@
 {% endmacro %}
 
 
-{% macro type_float() %}
+{% macro elementary_type_float() %}
     {% set macro = dbt.type_float or dbt_utils.type_float %}
     {% if not macro %}
         {{ exceptions.raise_compiler_error("Did not find a `type_float` macro.") }}
@@ -83,7 +83,7 @@
 {% endmacro %}
 
 
-{% macro type_int() %}
+{% macro elementary_type_int() %}
     {% set macro = dbt.type_int or dbt_utils.type_int %}
     {% if not macro %}
         {{ exceptions.raise_compiler_error("Did not find a `type_int` macro.") }}
@@ -92,8 +92,8 @@
 {% endmacro %}
 
 
-{% macro type_timestamp() %}
-    {% set macro = dbt.type_timestamp or dbt_utils.type_timestamp %}
+{% macro elementary_type_timestamp() %}
+    {% set macro = dbt.type_timestamp %}
     {% if not macro %}
         {{ exceptions.raise_compiler_error("Did not find a `type_timestamp` macro.") }}
     {% endif %}

--- a/macros/utils/data_types/data_type.sql
+++ b/macros/utils/data_types/data_type.sql
@@ -93,7 +93,7 @@
 
 
 {% macro elementary_type_timestamp() %}
-    {% set macro = dbt.type_timestamp %}
+    {% set macro = dbt.type_timestamp or dbt_utils.type_timestamp %}
     {% if not macro %}
         {{ exceptions.raise_compiler_error("Did not find a `type_timestamp` macro.") }}
     {% endif %}

--- a/macros/utils/data_types/null_as.sql
+++ b/macros/utils/data_types/null_as.sql
@@ -1,15 +1,15 @@
 {%- macro null_int() -%}
-    cast(null as {{ elementary.type_int() }})
+    cast(null as {{ elementary.elementary_type_int() }})
 {%- endmacro -%}
 
 {%- macro null_timestamp() -%}
-    cast(null as {{ elementary.type_timestamp() }})
+    cast(null as {{ elementary.elementary_type_timestamp() }})
 {%- endmacro -%}
 
 {%- macro null_float() -%}
-    cast(null as {{ elementary.type_float() }})
+    cast(null as {{ elementary.elementary_type_float() }})
 {%- endmacro -%}
 
 {% macro null_string() %}
-    cast(null as {{ elementary.type_string() }})
+    cast(null as {{ elementary.elementary_type_string() }})
 {% endmacro %}

--- a/macros/utils/data_types/try_cast_column_to_timestamp.sql
+++ b/macros/utils/data_types/try_cast_column_to_timestamp.sql
@@ -5,7 +5,7 @@
 {% macro default__try_cast_column_to_timestamp(table_relation, timestamp_column) %}
     {# We try casting for Snowflake, Bigquery and Databricks as these support safe cast and the query will not fail if the cast fails #}
     {%- set query %}
-        select {{ elementary.safe_cast(timestamp_column, elementary.type_timestamp()) }} as timestamp_column
+        select {{ elementary.elementary_safe_cast(timestamp_column, elementary.elementary_type_timestamp()) }} as timestamp_column
         from {{ table_relation }}
         where {{ timestamp_column }} is not null
         limit 1

--- a/macros/utils/percent_query.sql
+++ b/macros/utils/percent_query.sql
@@ -1,3 +1,3 @@
 {% macro percent(value, total) %}
-    round(cast({{ value }} as {{ elementary.type_float() }}) / nullif(cast({{ total }} as {{ elementary.type_float() }}), 0) * 100.0, 3)
+    round(cast({{ value }} as {{ elementary.elementary_type_float() }}) / nullif(cast({{ total }} as {{ elementary.elementary_type_float() }}), 0) * 100.0, 3)
 {% endmacro %}

--- a/models/edr/data_monitoring/anomaly_detection/metrics_anomaly_score.sql
+++ b/models/edr/data_monitoring/anomaly_detection/metrics_anomaly_score.sql
@@ -72,7 +72,7 @@ metrics_anomaly_score as (
             metric_value is not null
             and training_avg is not null
             and training_set_size >= {{ elementary.get_config_var('days_back') - 1 }}
-            and bucket_end >= {{ elementary.timeadd('day', '-7', elementary.date_trunc('day', elementary.current_timestamp())) }}
+            and bucket_end >= {{ elementary.timeadd('day', '-7', elementary.date_trunc('day', elementary.elementary_current_timestamp())) }}
     {{ dbt_utils.group_by(15) }}
     order by bucket_end desc
 

--- a/models/edr/data_monitoring/anomaly_detection/metrics_anomaly_score.sql
+++ b/models/edr/data_monitoring/anomaly_detection/metrics_anomaly_score.sql
@@ -72,7 +72,7 @@ metrics_anomaly_score as (
             metric_value is not null
             and training_avg is not null
             and training_set_size >= {{ elementary.get_config_var('days_back') - 1 }}
-            and bucket_end >= {{ elementary.timeadd('day', '-7', elementary.date_trunc('day', elementary.elementary_current_timestamp())) }}
+            and bucket_end >= {{ elementary.timeadd('day', '-7', elementary.elementary_date_trunc('day', elementary.elementary_current_timestamp())) }}
     {{ dbt_utils.group_by(15) }}
     order by bucket_end desc
 


### PR DESCRIPTION
We have a problem where another package is calling macros from dbt like `type_timestamp`.
In that case, for some reason (probably dbt bug - needs to investigate) it tries and use our macro that uses that uses dbt utils.
Because the other package doesn't use dbt_utils, it get compilation error even though dbt_utils is installed by us.

To prevent those from happen in the future, I renamed all of our dbt alike macros to `elementary_<macro_name>`