### PR TITLE
Freshness v2

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -24,7 +24,7 @@ vars:
   disable_dbt_artifacts_autoupload: true
 
 seeds:
-  +schema: test_seeds_freshness_v2
+  +schema: test_seeds_v2
 
 models:
   elementary:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -24,7 +24,7 @@ vars:
   disable_dbt_artifacts_autoupload: true
 
 seeds:
-  +schema: test_seeds
+  +schema: test_seeds_freshness_v2
 
 models:
   elementary:

--- a/integration_tests/generate_data.py
+++ b/integration_tests/generate_data.py
@@ -50,6 +50,7 @@ def generate_string_anomalies_training_and_validation_files(rows_count_per_day=1
     def get_training_row(date, row_index, rows_count):
         return {
             "updated_at": date.strftime("%Y-%m-%d %H:%M:%S"),
+            "occurred_at": (date - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M:%S"),
             "min_length": "".join(
                 random.choices(string.ascii_lowercase, k=random.randint(5, 10))
             ),
@@ -68,6 +69,7 @@ def generate_string_anomalies_training_and_validation_files(rows_count_per_day=1
     def get_validation_row(date, row_index, rows_count):
         return {
             "updated_at": date.strftime("%Y-%m-%d %H:%M:%S"),
+            "occurred_at": (date - timedelta(hours=7)).strftime("%Y-%m-%d %H:%M:%S"),
             "min_length": "".join(
                 random.choices(string.ascii_lowercase, k=random.randint(1, 10))
             ),
@@ -120,6 +122,7 @@ def generate_numeric_anomalies_training_and_validation_files(rows_count_per_day=
     def get_training_row(date, row_index, rows_count):
         return {
             "updated_at": date.strftime("%Y-%m-%d %H:%M:%S"),
+            "occurred_at": (date - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M:%S"),
             "min": random.randint(100, 200),
             "max": random.randint(100, 200),
             "zero_count": 0
@@ -137,6 +140,7 @@ def generate_numeric_anomalies_training_and_validation_files(rows_count_per_day=
         row_index += -(rows_count / 2)
         return {
             "updated_at": date.strftime("%Y-%m-%d %H:%M:%S"),
+            "occurred_at": (date - timedelta(hours=7)).strftime("%Y-%m-%d %H:%M:%S"),
             "min": random.randint(10, 200),
             "max": random.randint(100, 300),
             "zero_count": 0
@@ -187,6 +191,7 @@ def generate_any_type_anomalies_training_and_validation_files(rows_count_per_day
     def get_training_row(date, row_index, rows_count):
         return {
             "updated_at": date.strftime("%Y-%m-%d %H:%M:%S"),
+            "occurred_at": (date - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M:%S"),
             "null_count_str": None
             if row_index < (3 / 100 * rows_count)
             else "".join(random.choices(string.ascii_lowercase, k=5)),
@@ -216,6 +221,7 @@ def generate_any_type_anomalies_training_and_validation_files(rows_count_per_day
     def get_validation_row(date, row_index, rows_count):
         return {
             "updated_at": date.strftime("%Y-%m-%d %H:%M:%S"),
+            "occurred_at": (date - timedelta(hours=7)).strftime("%Y-%m-%d %H:%M:%S"),
             "null_count_str": None
             if row_index < (80 / 100 * rows_count)
             else "".join(random.choices(string.ascii_lowercase, k=5)),

--- a/integration_tests/generate_data.py
+++ b/integration_tests/generate_data.py
@@ -89,6 +89,7 @@ def generate_string_anomalies_training_and_validation_files(rows_count_per_day=1
 
     string_columns = [
         "updated_at",
+        "occurred_at",
         "min_length",
         "max_length",
         "average_length",
@@ -156,6 +157,7 @@ def generate_numeric_anomalies_training_and_validation_files(rows_count_per_day=
 
     numeric_columns = [
         "updated_at",
+        "occurred_at",
         "min",
         "max",
         "zero_count",
@@ -250,6 +252,7 @@ def generate_any_type_anomalies_training_and_validation_files(rows_count_per_day
 
     any_type_columns = [
         "updated_at",
+        "occurred_at",
         "null_count_str",
         "null_percent_str",
         "null_count_float",

--- a/integration_tests/macros/e2e_tests/tests_validation.sql
+++ b/integration_tests/macros/e2e_tests/tests_validation.sql
@@ -59,7 +59,7 @@
     {% set freshness_validation_query %}
         select distinct table_name
         from {{ alerts_relation }}
-        where status in ('fail', 'warn') and sub_type = 'freshness'
+        where status in ('fail', 'warn') and sub_type = 'freshness_v2'
     {% endset %}
     {% set results = elementary.result_column_to_list(freshness_validation_query) %}
     {{ assert_lists_contain_same_items(results, ['string_column_anomalies',

--- a/integration_tests/macros/e2e_tests/tests_validation.sql
+++ b/integration_tests/macros/e2e_tests/tests_validation.sql
@@ -59,7 +59,7 @@
     {% set freshness_validation_query %}
         select distinct table_name
         from {{ alerts_relation }}
-        where status in ('fail', 'warn') and sub_type = 'freshness_v2'
+        where status in ('fail', 'warn') and sub_type = 'freshness'
     {% endset %}
     {% set results = elementary.result_column_to_list(freshness_validation_query) %}
     {{ assert_lists_contain_same_items(results, ['string_column_anomalies',

--- a/integration_tests/macros/e2e_tests/tests_validation.sql
+++ b/integration_tests/macros/e2e_tests/tests_validation.sql
@@ -77,6 +77,21 @@
 
 {% endmacro %}
 
+{% macro validate_event_freshness_anomalies() %}
+    {%- set max_bucket_end = elementary.quote(elementary.get_run_started_at().strftime("%Y-%m-%d 00:00:00")) %}
+    {% set alerts_relation = ref('alerts_anomaly_detection') %}
+    {% set freshness_validation_query %}
+        select distinct table_name
+        from {{ alerts_relation }}
+        where sub_type = 'event_freshness' and detected_at >= {{ max_bucket_end }}
+    {% endset %}
+
+    {% set results = elementary.result_column_to_list(freshness_validation_query) %}
+    {{ assert_lists_contain_same_items(results, ['string_column_anomalies',
+                                                 'numeric_column_anomalies',
+                                                 'string_column_anomalies_training']) }}
+{% endmacro %}
+
 {% macro validate_dimension_anomalies() %}
     {% set alerts_relation = ref('alerts_anomaly_detection') %}
     {% set dimension_validation_query %}

--- a/integration_tests/models/any_type_column_anomalies.sql
+++ b/integration_tests/models/any_type_column_anomalies.sql
@@ -21,6 +21,7 @@ with training as (
  final as (
      select
          updated_at,
+         occurred_at,
          null_count_str,
          null_percent_str,
          null_count_float,

--- a/integration_tests/models/no_timestamp_anomalies.sql
+++ b/integration_tests/models/no_timestamp_anomalies.sql
@@ -21,6 +21,7 @@ with training as (
  final as (
      select
          updated_at,
+         occurred_at,
          null_count_str,
          null_percent_str,
          null_count_float,

--- a/integration_tests/models/numeric_column_anomalies.sql
+++ b/integration_tests/models/numeric_column_anomalies.sql
@@ -21,6 +21,7 @@ with training as (
  final as (
      select
          updated_at,
+         occurred_at,
          min,
          max,
          zero_count,

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -267,7 +267,7 @@ models:
 
 sources:
   - name: training
-    schema: test_seeds_freshness_v2
+    schema: test_seeds_v2
     tables:
       - name: any_type_column_anomalies_training
         freshness:
@@ -303,7 +303,7 @@ sources:
               update_timestamp_column: updated_at
       - name: numeric_column_anomalies_training
   - name: validation
-    schema: test_seeds_freshness_v2
+    schema: test_seeds_v2
     tables:
       - name: any_type_column_anomalies_validation
         freshness:

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -267,7 +267,7 @@ models:
 
 sources:
   - name: training
-    schema: test_seeds
+    schema: test_seeds_freshness_v2
     tables:
       - name: any_type_column_anomalies_training
         freshness:

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -98,7 +98,7 @@ models:
       - elementary.freshness_anomalies:
           tags: [ "table_anomalies" ]
       - elementary.event_freshness_anomalies:
-          tags: [ "event_freshness" ]
+          tags: [ "event_freshness_anomalies" ]
           event_timestamp_column: occurred_at
           update_timestamp_column: updated_at
       - elementary.all_columns_anomalies:
@@ -152,7 +152,7 @@ models:
       - elementary.freshness_anomalies:
           tags: [ "table_anomalies" ]
       - elementary.event_freshness_anomalies:
-          tags: [ "event_freshness" ]
+          tags: [ "event_freshness_anomalies" ]
           event_timestamp_column: occurred_at
           update_timestamp_column: updated_at
       - elementary.schema_changes:
@@ -281,7 +281,7 @@ sources:
           - elementary.freshness_anomalies:
               tags: [ "table_anomalies" ]
           - elementary.event_freshness_anomalies:
-              tags: [ "event_freshness" ]
+              tags: [ "event_freshness_anomalies" ]
               event_timestamp_column: occurred_at
       - name: string_column_anomalies_training
         freshness:
@@ -298,9 +298,9 @@ sources:
           - elementary.freshness_anomalies:
               tags: [ "table_anomalies" ]
           - elementary.event_freshness_anomalies:
-              tags: [ "event_freshness" ]
+              tags: [ "event_freshness_anomalies" ]
               event_timestamp_column: occurred_at
-              update_timestamp_column: date
+              update_timestamp_column: updated_at
       - name: numeric_column_anomalies_training
   - name: validation
     schema: test_seeds

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -146,6 +146,8 @@ models:
       - elementary.volume_anomalies:
           tags: [ "table_anomalies" ]
       - elementary.freshness_anomalies:
+          data_timestamp_column: "occurred_at"
+          insertion_timestamp_column: "updated_at"
           tags: [ "table_anomalies" ]
       - elementary.schema_changes:
           tags: [ "schema_changes" ]
@@ -286,6 +288,7 @@ sources:
           - elementary.volume_anomalies:
               tags: [ "table_anomalies" ]
           - elementary.freshness_anomalies:
+              data_timestamp_column: "date"
               tags: [ "table_anomalies" ]
       - name: numeric_column_anomalies_training
   - name: validation

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -146,8 +146,6 @@ models:
       - elementary.volume_anomalies:
           tags: [ "table_anomalies" ]
       - elementary.freshness_anomalies:
-          data_timestamp_column: "occurred_at"
-          insertion_timestamp_column: "updated_at"
           tags: [ "table_anomalies" ]
       - elementary.schema_changes:
           tags: [ "schema_changes" ]
@@ -288,7 +286,6 @@ sources:
           - elementary.volume_anomalies:
               tags: [ "table_anomalies" ]
           - elementary.freshness_anomalies:
-              data_timestamp_column: "date"
               tags: [ "table_anomalies" ]
       - name: numeric_column_anomalies_training
   - name: validation

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -303,7 +303,7 @@ sources:
               update_timestamp_column: updated_at
       - name: numeric_column_anomalies_training
   - name: validation
-    schema: test_seeds
+    schema: test_seeds_freshness_v2
     tables:
       - name: any_type_column_anomalies_validation
         freshness:

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -97,6 +97,10 @@ models:
     tests:
       - elementary.freshness_anomalies:
           tags: [ "table_anomalies" ]
+      - elementary.event_freshness_anomalies:
+          tags: [ "event_freshness" ]
+          event_timestamp_column: occurred_at
+          update_timestamp_column: updated_at
       - elementary.all_columns_anomalies:
           tags: [ "all_string_column_anomalies" ]
       - elementary.schema_changes:
@@ -147,6 +151,10 @@ models:
           tags: [ "table_anomalies" ]
       - elementary.freshness_anomalies:
           tags: [ "table_anomalies" ]
+      - elementary.event_freshness_anomalies:
+          tags: [ "event_freshness" ]
+          event_timestamp_column: occurred_at
+          update_timestamp_column: updated_at
       - elementary.schema_changes:
           tags: [ "schema_changes" ]
       - elementary.all_columns_anomalies:
@@ -272,7 +280,9 @@ sources:
               tags: [ "table_anomalies" ]
           - elementary.freshness_anomalies:
               tags: [ "table_anomalies" ]
-
+          - elementary.event_freshness_anomalies:
+              tags: [ "event_freshness" ]
+              event_timestamp_column: occurred_at
       - name: string_column_anomalies_training
         freshness:
           error_after:
@@ -287,6 +297,10 @@ sources:
               tags: [ "table_anomalies" ]
           - elementary.freshness_anomalies:
               tags: [ "table_anomalies" ]
+          - elementary.event_freshness_anomalies:
+              tags: [ "event_freshness" ]
+              event_timestamp_column: occurred_at
+              update_timestamp_column: date
       - name: numeric_column_anomalies_training
   - name: validation
     schema: test_seeds

--- a/integration_tests/models/string_column_anomalies.sql
+++ b/integration_tests/models/string_column_anomalies.sql
@@ -21,6 +21,7 @@ source as (
 final as (
      select
         updated_at,
+        occurred_at,
         min_length,
         max_length,
         average_length,

--- a/integration_tests/run_e2e_tests.py
+++ b/integration_tests/run_e2e_tests.py
@@ -152,6 +152,16 @@ def e2e_tests(
         ]
         test_results.extend(results)
 
+    if "table" in test_types:
+        dbt_runner.test(select="tag:event_freshness_anomalies")
+        results = [
+            TestResult(type="event_freshness_anomalies", message=msg)
+            for msg in dbt_runner.run_operation(
+                macro_name="validate_event_freshness_anomalies"
+            )
+        ]
+        test_results.extend(results)
+
     if "column" in test_types:
         dbt_runner.test(select="tag:string_column_anomalies")
         results = [

--- a/macros/edr/data_monitoring/data_monitors_configuration/get_table_monitors.sql
+++ b/macros/edr/data_monitoring/data_monitors_configuration/get_table_monitors.sql
@@ -18,5 +18,5 @@
 
 
 {% macro get_allowed_table_monitors() %}
-    {% do return(["row_count", "freshness", "freshness_v2"]) %}
+    {% do return(["row_count", "freshness", "event_freshness"]) %}
 {% endmacro %}

--- a/macros/edr/data_monitoring/data_monitors_configuration/get_table_monitors.sql
+++ b/macros/edr/data_monitoring/data_monitors_configuration/get_table_monitors.sql
@@ -1,19 +1,22 @@
 {% macro get_final_table_monitors(table_anomalies) %}
     {%- set final_table_monitors = [] %}
-    {%- set default_table_monitors = elementary.get_default_table_monitors() %}
 
     {%- if table_anomalies and table_anomalies | length > 0 %}
-        {%- set final_table_monitors = elementary.lists_intersection(table_anomalies, default_table_monitors) %}
+        {%- set allowed_table_monitors = elementary.get_allowed_table_monitors() %}
+        {%- set final_table_monitors = elementary.lists_intersection(table_anomalies, allowed_table_monitors) %}
     {%- else %}
-        {%- set final_table_monitors = default_table_monitors %}
+        {%- set final_table_monitors = elementary.get_default_table_monitors() %}
     {%- endif %}
     {{ return(final_table_monitors) }}
 {% endmacro %}
 
 
 {% macro get_default_table_monitors() %}
-
     {%- set default_table_monitors = elementary.get_config_var('edr_monitors')['table'] | list %}
     {{ return(default_table_monitors) }}
+{% endmacro %}
 
+
+{% macro get_allowed_table_monitors() %}
+    {% do return(["row_count", "freshness", "freshness_v2"]) %}
 {% endmacro %}

--- a/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
+++ b/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
@@ -196,7 +196,7 @@
     bucketed_consecutive_updates_freshness as (
         select
             edr_bucket_start, edr_bucket_end, update_timestamp, freshness
-        from buckets, consecutive_updates_freshness
+        from buckets cross join consecutive_updates_freshness
         where update_timestamp >= edr_bucket_start AND update_timestamp < edr_bucket_end
     ),
 

--- a/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
+++ b/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
@@ -191,3 +191,18 @@
     {% do return(none) %}
 {% endif %}
 {% endmacro %}
+
+{% macro sla_metric_query(metric_args, timestamp_column) %}
+{% set data_time_column = metric_args.data_time_column %}
+{% set insertion_time_column = metric_args.insertion_time_column %}
+
+{% if timestamp_column %}
+{% else %}
+
+    select
+        {{ elementary.const_as_string('sla') }} as metric_name,
+        {{ elementary.timediff('second', elementary.cast_as_timestamp("max('{}')".format(metric_args.data)), elementary.current_timestamp_column()) }} as metric_value
+    from monitored_table
+    group by 1
+{% endif %}
+{% endmacro %}

--- a/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
+++ b/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
@@ -1,10 +1,6 @@
-{% macro table_monitoring_query(monitored_table_relation, timestamp_column, min_bucket_start, table_monitors, freshness_column, where_expression, time_bucket) %}
+{% macro table_monitoring_query(monitored_table_relation, timestamp_column, min_bucket_start, table_monitors, where_expression, time_bucket, metric_args) %}
 
     {% set full_table_name_str = elementary.quote(elementary.relation_to_full_name(monitored_table_relation)) %}
-
-    {% set metric_args = {
-        "freshness_column": freshness_column
-    } %}
 
     with monitored_table as (
         select * from {{ monitored_table_relation }}

--- a/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
+++ b/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
@@ -23,13 +23,15 @@
                 {{ elementary.cast_as_timestamp(timestamp_column) }} >= (select min(edr_bucket_start) from buckets)
                 and {{ elementary.cast_as_timestamp(timestamp_column) }} < (select max(edr_bucket_end) from buckets)
         ),
+    {% endif %}
 
-        metrics as (
-            {{ elementary.get_unified_metrics_query(metrics=table_monitors,
-                                                    metric_args=metric_args,
-                                                    timestamp_column=timestamp_column) }}
-        ),
+    metrics as (
+        {{ elementary.get_unified_metrics_query(metrics=table_monitors,
+                                                metric_args=metric_args,
+                                                timestamp_column=timestamp_column) }}
+    ),
 
+    {% if timestamp_column %}
         metrics_final as (
 
         select
@@ -49,10 +51,6 @@
             metric_value is null
         )
     {% else %}
-        metrics as (
-            {{ elementary.get_unified_metrics_query(metrics=table_monitors, metric_args=metric_args) }}
-        ),
-
         metrics_final as (
 
         select

--- a/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
+++ b/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
@@ -174,7 +174,7 @@
 {% macro freshness_metric_query(metric_args, timestamp_column=none) %}
 {% if timestamp_column %}
     {%- set freshness_column = metric_args.freshness_column %}
-    {%- if freshness_column is undefined or freshness_column is none %}
+    {%- if not freshness_column %}
         {%- set freshness_column = timestamp_column %}
     {%- endif %}
 

--- a/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
+++ b/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
@@ -242,7 +242,7 @@
     where row_number = 1
 {% else %}
     {# Update freshness test not supported when timestamp column is not provided #}
-    {# TODO: Maybe it makes sense to use model_run_results to know update times in this case? #}
+    {# TODO: We can enhance this test for models to use model_run_results in case a timestamp column is not defined #}
     {% do return(none) %}
 {% endif %}
 {% endmacro %}

--- a/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
+++ b/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
@@ -2,6 +2,10 @@
 
     {% set full_table_name_str = elementary.quote(elementary.relation_to_full_name(monitored_table_relation)) %}
 
+    {% set metric_args = {
+        "freshness_column": freshness_column
+    } %}
+
     with monitored_table as (
         select * from {{ monitored_table_relation }}
         {% if where_expression %}
@@ -24,61 +28,10 @@
                 and {{ elementary.cast_as_timestamp(timestamp_column) }} < (select max(edr_bucket_end) from buckets)
         ),
 
-        {%- if 'row_count' in table_monitors %}
-
-        row_count_values as (
-            select edr_bucket_start,
-                   edr_bucket_end,
-                   start_bucket_in_data,
-                   case when start_bucket_in_data is null then
-                       0
-                   else {{ elementary.cast_as_float(elementary.row_count()) }} end as row_count_value
-            from buckets left join time_filtered_monitored_table on (edr_bucket_start = start_bucket_in_data)
-            group by 1,2,3
-        ),
-
-        row_count as (
-            select edr_bucket_start,
-                   edr_bucket_end,
-                   {{ elementary.const_as_string('row_count') }} as metric_name,
-                   {{ elementary.null_string() }} as source_value,
-                   row_count_value as metric_value
-            from row_count_values
-        ),
-
-        {%- else %}
-
-        row_count as (
-            {{ elementary.empty_table([('edr_bucket_start','timestamp'),('edr_bucket_end','timestamp'),('metric_name','string'),('source_value','string'),('metric_value','int')]) }}
-        ),
-
-        {%- endif %}
-
-        table_freshness as (
-        {%- if 'freshness' in table_monitors %}
-            {%- if freshness_column is undefined or freshness_column is none %}
-                {%- set freshness_column = timestamp_column %}
-            {%- endif %}
-            select
-                edr_bucket_start,
-                edr_bucket_end,
-                {{ elementary.const_as_string('freshness') }} as metric_name,
-                {{ elementary.cast_as_string('max('~freshness_column~')') }} as source_value,
-                {{ elementary.timediff('second', elementary.cast_as_timestamp('max('~freshness_column~')'), "edr_bucket_end") }} as metric_value
-            from buckets, monitored_table
-            where {{ elementary.cast_as_timestamp(timestamp_column) }} < edr_bucket_end
-            group by 1,2,3
-        {%- else %}
-            {{ elementary.empty_table([('edr_bucket_start','timestamp'),('edr_bucket_end','timestamp'),('metric_name','string'),('source_value','string'),('metric_value','int')]) }}
-        {%- endif %}
-        ),
-
-        union_metrics as (
-
-        select * from row_count
-        union all
-        select * from table_freshness
-
+        metrics as (
+            {{ elementary.get_unified_metrics_query(metrics=table_monitors,
+                                                    metric_args=metric_args,
+                                                    timestamp_column=timestamp_column) }}
         ),
 
         metrics_final as (
@@ -95,21 +48,13 @@
             {{ elementary.null_string() }} as dimension,
             {{ elementary.null_string() }} as dimension_value
         from
-            union_metrics
+            metrics
         where (metric_value is not null and cast(metric_value as {{ elementary.type_int() }}) < {{ elementary.get_config_var('max_int') }}) or
             metric_value is null
         )
     {% else %}
-        row_count as (
-            {%- if 'row_count' in table_monitors %}
-                select
-                    {{ elementary.const_as_string('row_count') }} as metric_name,
-                    {{ elementary.row_count() }} as metric_value
-                from monitored_table
-                group by 1
-            {%- else %}
-                {{ elementary.empty_table([('metric_name','string'),('metric_value','int')]) }}
-            {%- endif %}
+        metrics as (
+            {{ elementary.get_unified_metrics_query(metrics=table_monitors, metric_args=metric_args) }}
         ),
 
         metrics_final as (
@@ -125,7 +70,7 @@
             {{ elementary.null_int() }} as bucket_duration_hours,
             {{ elementary.null_string() }} as dimension,
             {{ elementary.null_string() }} as dimension_value
-        from row_count
+        from metrics
 
         )
     {% endif %}
@@ -150,4 +95,103 @@
         dimension_value
     from metrics_final
 
+{% endmacro %}
+
+{% macro get_unified_metrics_query(metrics, metric_args, timestamp_column=none) %}
+    {%- set included_monitors = {} %}
+    {%- for metric_name in metrics %}
+        {%- set metric_query = elementary.get_metric_query(metric_name, metric_args, timestamp_column=timestamp_column) %}
+        {%- if metric_query %}
+            {% do included_monitors.update({metric_name: metric_query}) %}
+        {%- endif %}
+    {%- endfor %}
+
+    {% if not included_monitors %}
+        {% if timestamp_column %}
+            {{ do return(elementary.empty_table([('edr_bucket_start','timestamp'),('edr_bucket_end','timestamp'),('metric_name','string'),('source_value','string'),('metric_value','int')])) }}
+        {% else %}
+            {% do return(elementary.empty_table([('metric_name','string'),('metric_value','int')])) %}
+        {% endif %}
+    {% endif %}
+
+    with
+    {%- for metric_name, metric_query in included_monitors.items() %}
+        {{ metric_name }} as (
+            {{ metric_query }}
+        ){% if not loop.last %},{% endif %}
+    {%- endfor %}
+
+    {%- for metric_name in included_monitors %}
+    select * from {{ metric_name }}
+    {% if not loop.last %} union all {% endif %}
+    {%- endfor %}
+{% endmacro %}
+
+{% macro get_metric_query(metric_name, metric_args, timestamp_column) %}
+    {%- set metrics_macro_mapping = {
+        "row_count": elementary.row_count_metric_query,
+        "freshness": elementary.freshness_metric_query
+    } %}
+
+    {%- set metric_macro = metrics_macro_mapping.get(metric_name) %}
+    {%- if not metric_macro %}
+        {%- do return(none) %}
+    {%- endif %}
+
+    {%- set metric_query = metric_macro(metric_args, timestamp_column=timestamp_column) %}
+    {%- if not metric_query %}
+        {%- do return(none) %}
+    {%- endif %}
+
+    {{ metric_query }}
+{% endmacro %}
+
+{% macro row_count_metric_query(metric_args, timestamp_column=none) %}
+{% if timestamp_column %}
+    row_count_values as (
+        select edr_bucket_start,
+               edr_bucket_end,
+               start_bucket_in_data,
+               case when start_bucket_in_data is null then
+                   0
+               else {{ elementary.cast_as_float(elementary.row_count()) }} end as row_count_value
+        from buckets left join filtered_monitored_table on (edr_bucket_start = start_bucket_in_data)
+        group by 1,2,3
+    ),
+
+    select edr_bucket_start,
+           edr_bucket_end,
+           {{ elementary.const_as_string('row_count') }} as metric_name,
+           {{ elementary.null_string() }} as source_value,
+           row_count_value as metric_value
+    from row_count_values
+{% else %}
+    select
+        {{ elementary.const_as_string('row_count') }} as metric_name,
+        {{ elementary.row_count() }} as metric_value
+    from monitored_table
+    group by 1
+{% endif %}
+{% endmacro %}
+
+{% macro freshness_metric_query(metric_args, timestamp_column=none) %}
+{% if timestamp_column %}
+    {%- set freshness_column = metric_args.freshness_column %}
+    {%- if freshness_column is undefined or freshness_column is none %}
+        {%- set freshness_column = timestamp_column %}
+    {%- endif %}
+
+    select
+        edr_bucket_start,
+        edr_bucket_end,
+        {{ elementary.const_as_string('freshness') }} as metric_name,
+        {{ elementary.cast_as_string('max('~freshness_column~')') }} as source_value,
+        {{ elementary.timediff('second', elementary.cast_as_timestamp('max('~freshness_column~')'), "edr_bucket_end") }} as metric_value
+    from buckets, monitored_table
+    where {{ elementary.cast_as_timestamp(timestamp_column) }} < edr_bucket_end
+    group by 1,2,3
+{% else %}
+    {# Freshness test not supported when timestamp column is not provided #}
+    {% do return(none) %}
+{% endif %}
 {% endmacro %}

--- a/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
+++ b/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
@@ -151,7 +151,7 @@
                case when start_bucket_in_data is null then
                    0
                else {{ elementary.cast_as_float(elementary.row_count()) }} end as row_count_value
-        from buckets left join filtered_monitored_table on (edr_bucket_start = start_bucket_in_data)
+        from buckets left join time_filtered_monitored_table on (edr_bucket_start = start_bucket_in_data)
         group by 1,2,3
     ),
 

--- a/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
+++ b/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
@@ -190,7 +190,7 @@
         select
             timestamp_val as update_timestamp,
             lag(timestamp_val) over (order by timestamp_val) as prev_timestamp,
-            {{ elementary.timediff('second', 'prev_timestamp', 'update_timestamp') }} as freshness
+            {{ elementary.timediff('second', 'lag(timestamp_val)', 'timestamp_val') }} as freshness
         from unique_timestamps
         where timestamp_val >= (select min(edr_bucket_start) from buckets)
     ),

--- a/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
+++ b/macros/edr/data_monitoring/monitors_query/table_monitoring_query.sql
@@ -185,14 +185,20 @@
         order by 1
     ),
 
-    -- compute freshness for every update as the time difference from the previous update
-    consecutive_updates_freshness as (
+    consecutive_updates as (
         select
             timestamp_val as update_timestamp,
             lag(timestamp_val) over (order by timestamp_val) as prev_timestamp,
-            {{ elementary.timediff('second', 'lag(timestamp_val)', 'timestamp_val') }} as freshness
         from unique_timestamps
         where timestamp_val >= (select min(edr_bucket_start) from buckets)
+    ),
+
+    -- compute freshness for every update as the time difference from the previous update
+    consecutive_updates_freshness as (
+        select
+            update_timestamp,
+            {{ elementary.timediff('second', 'prev_timestamp', 'update_timestamp') }} as freshness
+        from consecutive_updates
     ),
 
     -- divide the freshness metrics above to buckets

--- a/macros/edr/tests/test_event_freshness_anomalies.sql
+++ b/macros/edr/tests/test_event_freshness_anomalies.sql
@@ -1,0 +1,13 @@
+{% test event_freshness_anomalies(model, event_timestamp_column, update_timestamp_column, sensitivity, backfill_days, where_expression, time_bucket) %}
+  {{ elementary.test_table_anomalies(
+      model=model,
+      table_anomalies=["event_freshness"],
+      event_timestamp_column=event_timestamp_column,
+      timestamp_column=update_timestamp_column,
+      sensitivity=sensitivity,
+      backfill_days=backfill_days,
+      where_expression=where_expression,
+      time_bucket=time_bucket
+    )
+  }}
+{% endtest %}

--- a/macros/edr/tests/test_event_freshness_anomalies.sql
+++ b/macros/edr/tests/test_event_freshness_anomalies.sql
@@ -1,4 +1,15 @@
 {% test event_freshness_anomalies(model, event_timestamp_column, update_timestamp_column, sensitivity, backfill_days, where_expression, time_bucket) %}
+  {% if execute %}
+    {%- if not event_timestamp_column -%}
+      {%- do exceptions.raise_compiler_error('event_timestamp_column must be specified for the event freshness test!') -%}
+    {%- endif -%}
+
+    {%- set event_timestamp_column_data_type = elementary.find_normalized_data_type_for_column(model, event_timestamp_column) -%}
+    {%- if not elementary.get_is_column_timestamp(model_relation, event_timestamp_column, event_timestamp_column_data_type) -%}
+      {% do exceptions.raise_compiler_error("Column `{}` is not a timestamp.".format(event_timestamp_column)) %}
+    {%- endif -%}
+  {% endif %}
+
   {{ elementary.test_table_anomalies(
       model=model,
       table_anomalies=["event_freshness"],

--- a/macros/edr/tests/test_freshness_anomalies.sql
+++ b/macros/edr/tests/test_freshness_anomalies.sql
@@ -1,7 +1,7 @@
-{% test freshness_anomalies(model, timestamp_column, sensitivity, backfill_days, where_expression, time_bucket) %}
+{% test freshness_anomalies(model, data_timestamp_column, insertion_timestamp_column, sensitivity, backfill_days, where_expression, time_bucket) %}
   {{ elementary.test_table_anomalies(
       model=model,
-      table_anomalies=["freshness"],
+      table_anomalies=["freshness_v2"],
       freshness_column=none,
       timestamp_column=timestamp_column,
       sensitivity=sensitivity,

--- a/macros/edr/tests/test_freshness_anomalies.sql
+++ b/macros/edr/tests/test_freshness_anomalies.sql
@@ -2,6 +2,7 @@
   {{ elementary.test_table_anomalies(
       model=model,
       table_anomalies=["freshness"],
+      freshness_column=none,
       timestamp_column=timestamp_column,
       sensitivity=sensitivity,
       backfill_days=backfill_days,

--- a/macros/edr/tests/test_freshness_anomalies.sql
+++ b/macros/edr/tests/test_freshness_anomalies.sql
@@ -1,9 +1,8 @@
-{% test freshness_anomalies(model, data_timestamp_column, insertion_timestamp_column, sensitivity, backfill_days, where_expression, time_bucket) %}
+{% test freshness_anomalies(model, timestamp_column, sensitivity, backfill_days, where_expression, time_bucket) %}
   {{ elementary.test_table_anomalies(
       model=model,
-      table_anomalies=["freshness_v2"],
-      data_timestamp_column=data_timestamp_column,
-      timestamp_column=insertion_timestamp_column,
+      table_anomalies=["freshness"],
+      timestamp_column=timestamp_column,
       sensitivity=sensitivity,
       backfill_days=backfill_days,
       where_expression=where_expression,

--- a/macros/edr/tests/test_freshness_anomalies.sql
+++ b/macros/edr/tests/test_freshness_anomalies.sql
@@ -2,8 +2,8 @@
   {{ elementary.test_table_anomalies(
       model=model,
       table_anomalies=["freshness_v2"],
-      freshness_column=none,
-      timestamp_column=timestamp_column,
+      data_timestamp_column=data_timestamp_column,
+      timestamp_column=insertion_timestamp_column,
       sensitivity=sensitivity,
       backfill_days=backfill_days,
       where_expression=where_expression,

--- a/macros/edr/tests/test_table_anomalies.sql
+++ b/macros/edr/tests/test_table_anomalies.sql
@@ -1,4 +1,4 @@
-{% test table_anomalies(model, table_anomalies, freshness_column, timestamp_column, sensitivity, backfill_days, where_expression, time_bucket) %}
+{% test table_anomalies(model, table_anomalies, timestamp_column, sensitivity, backfill_days, where_expression, time_bucket) %}
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('alerts_anomaly_detection') }}
@@ -41,7 +41,7 @@
         {{ elementary.debug_log('min_bucket_start - ' ~ min_bucket_start) }}
         {#- execute table monitors and write to temp test table -#}
         {{ elementary.test_log('start', full_table_name) }}
-        {%- set table_monitoring_query = elementary.table_monitoring_query(model_relation, timestamp_column, min_bucket_start, table_monitors, freshness_column, where_expression, time_bucket) %}
+        {%- set table_monitoring_query = elementary.table_monitoring_query(model_relation, timestamp_column, min_bucket_start, table_monitors, where_expression, time_bucket, metric_args=kwargs) %}
         {{ elementary.debug_log('table_monitoring_query - \n' ~ table_monitoring_query) }}
         {% set temp_table_relation = elementary.create_elementary_test_table(database_name, tests_schema_name, test_table_name, 'metrics', table_monitoring_query) %}
 


### PR DESCRIPTION
This PR revamps our existing freshness test, and splits it into two tests:
1. `freshness_anomalies` - the goal of this test is to test the **expected time between updates**, and alert if the freshness during the detection period deviates from it.
2. `event_freshness_anomalies` - the goal of this test is to monitor freshness of event data. Since this is continuous / streaming data normally, monitoring time between updates as we do in the first test is not useful. So instead, we monitor the freshness as the time since the event timestamp, where there are two options:

- If an update timestamp is supplied, the freshness is defined as the maximum value of (`update_timestamp` - `event_timestamp`).
- Otherwise, we continuously collect the "current freshness" - e.g. `current_timestamp() - max(event_timestamp)`
