### PR TITLE
Cache artifacts

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -19,9 +19,8 @@ clean-targets: # directories to be removed by `dbt clean`
 
 vars:
   days_back: 30
-  debug_logs: false
+  debug_logs: true
   custom_run_started_at: "{{ modules.datetime.datetime.utcfromtimestamp(0) }}"
-  disable_dbt_artifacts_autoupload: true
 
 seeds:
   +schema: test_seeds

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -19,7 +19,7 @@ clean-targets: # directories to be removed by `dbt clean`
 
 vars:
   days_back: 30
-  debug_logs: true
+  debug_logs: false
   custom_run_started_at: "{{ modules.datetime.datetime.utcfromtimestamp(0) }}"
 
 seeds:

--- a/macros/edr/dbt_artifacts/upload_artifacts_to_table.sql
+++ b/macros/edr/dbt_artifacts/upload_artifacts_to_table.sql
@@ -1,4 +1,4 @@
-{% macro upload_artifacts_to_table(table_relation, artifacts, flatten_artifact_callback, append=False, should_commit=False) %}
+{% macro upload_artifacts_to_table(table_relation, artifacts, flatten_artifact_callback, append=False, should_commit=False, state_hash=None) %}
     {% set flatten_artifact_dicts = [] %}
     {% for artifact in artifacts %}
         {% set flatten_artifact_dict = flatten_artifact_callback(artifact) %}
@@ -6,6 +6,14 @@
             {% do flatten_artifact_dicts.append(flatten_artifact_dict) %}
         {% endif %}
     {% endfor %}
+
+    {% if local_md5 %}
+        {% set artifacts_hash = local_md5(flatten_artifact_dicts | map(attribute="hash") | sort | join(",")) %}
+        {% if artifacts_hash == state_hash %}
+            {% do elementary.debug_log("[{}] Artifacts did not change.".format(table_relation.identifier)) %}
+            {% do return(none) %}
+        {% endif %}
+    {% endif %}
 
     {% if append %}
         {# In append mode, just insert, and no need to be atomic #}

--- a/macros/edr/dbt_artifacts/upload_dbt_exposures.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_exposures.sql
@@ -25,7 +25,9 @@
                                                                      ('package_name', 'string'),
                                                                      ('original_path', 'long_string'),
                                                                      ('path', 'string'),
-                                                                     ('generated_at', 'string')]) %}
+                                                                     ('generated_at', 'string'),
+                                                                     ('hash', 'string'),
+                                                                     ]) %}
     {{ return(dbt_exposures_empty_table_query) }}
 {% endmacro %}
 
@@ -52,5 +54,6 @@
         'path': node_dict.get('path'),
         'generated_at': elementary.datetime_now_utc_as_string()
       }%}
+    {% do flatten_exposure_metadata_dict.update({"hash": local_md5(flatten_exposure_metadata_dict | string) if local_md5 else none}) %}
     {{ return(flatten_exposure_metadata_dict) }}
 {% endmacro %}

--- a/macros/edr/dbt_artifacts/upload_dbt_exposures.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_exposures.sql
@@ -1,8 +1,8 @@
-{%- macro upload_dbt_exposures(should_commit=false) -%}
+{%- macro upload_dbt_exposures(should_commit=false, state_hash=none) -%}
     {% set relation = elementary.get_elementary_relation('dbt_exposures') %}
     {% if execute and relation %}
         {% set exposures = graph.exposures.values() | selectattr('resource_type', '==', 'exposure') %}
-        {% do elementary.upload_artifacts_to_table(relation, exposures, elementary.flatten_exposure, should_commit=should_commit) %}
+        {% do elementary.upload_artifacts_to_table(relation, exposures, elementary.flatten_exposure, should_commit=should_commit, state_hash=state_hash) %}
     {%- endif -%}
     {{- return('') -}}
 {%- endmacro -%}
@@ -54,6 +54,8 @@
         'path': node_dict.get('path'),
         'generated_at': elementary.datetime_now_utc_as_string()
       }%}
-    {% do flatten_exposure_metadata_dict.update({"hash": local_md5(flatten_exposure_metadata_dict | string) if local_md5 else none}) %}
+    {% set time_excluded_dict = flatten_exposure_metadata_dict.copy() %}
+    {% do time_excluded_dict.pop("generated_at") %}
+    {% do flatten_exposure_metadata_dict.update({"hash": local_md5(time_excluded_dict | string) if local_md5 else none}) %}
     {{ return(flatten_exposure_metadata_dict) }}
 {% endmacro %}

--- a/macros/edr/dbt_artifacts/upload_dbt_metrics.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_metrics.sql
@@ -28,7 +28,9 @@
                                                                    ('package_name', 'string'),
                                                                    ('original_path', 'long_string'),
                                                                    ('path', 'string'),
-                                                                   ('generated_at', 'string')]) %}
+                                                                   ('generated_at', 'string'),
+                                                                   ('hash', 'string'),
+                                                                   ]) %}
     {{ return(dbt_metrics_empty_table_query) }}
 {% endmacro %}
 
@@ -36,7 +38,7 @@
     {% set depends_on_dict = elementary.safe_get_with_default(node_dict, 'depends_on', {}) %}
     {% set meta_dict = elementary.safe_get_with_default(node_dict, 'meta', {}) %}
     {% set tags = elementary.safe_get_with_default(node_dict, 'tags', []) %}
-    {% set flatten_metrics_metadata_dict = {
+    {% set flatten_metric_metadata_dict = {
         'unique_id': node_dict.get('unique_id'),
         'name': node_dict.get('name'),
         'label': node_dict.get('label'),
@@ -57,5 +59,6 @@
         'path': node_dict.get('path'),
         'generated_at': elementary.datetime_now_utc_as_string()
     }%}
-    {{ return(flatten_metrics_metadata_dict) }}
+    {% do flatten_metric_metadata_dict.update({"hash": local_md5(flatten_metric_metadata_dict | string) if local_md5 else none}) %}
+    {{ return(flatten_metric_metadata_dict) }}
 {% endmacro %}

--- a/macros/edr/dbt_artifacts/upload_dbt_metrics.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_metrics.sql
@@ -1,8 +1,8 @@
-{%- macro upload_dbt_metrics(should_commit=false) -%}
+{%- macro upload_dbt_metrics(should_commit=false, state_hash=none) -%}
     {% set relation = elementary.get_elementary_relation('dbt_metrics') %}
     {% if execute and relation %}
         {% set metrics = graph.metrics.values() | selectattr('resource_type', '==', 'metric') %}
-        {% do elementary.upload_artifacts_to_table(relation, metrics, elementary.flatten_metric, should_commit=should_commit) %}
+        {% do elementary.upload_artifacts_to_table(relation, metrics, elementary.flatten_metric, should_commit=should_commit, state_hash=state_hash) %}
     {%- endif -%}
     {{- return('') -}}
 {%- endmacro -%}
@@ -59,6 +59,8 @@
         'path': node_dict.get('path'),
         'generated_at': elementary.datetime_now_utc_as_string()
     }%}
-    {% do flatten_metric_metadata_dict.update({"hash": local_md5(flatten_metric_metadata_dict | string) if local_md5 else none}) %}
+    {% set time_excluded_dict = flatten_metric_metadata_dict.copy() %}
+    {% do time_excluded_dict.pop("generated_at") %}
+    {% do flatten_metric_metadata_dict.update({"hash": local_md5(time_excluded_dict | string) if local_md5 else none}) %}
     {{ return(flatten_metric_metadata_dict) }}
 {% endmacro %}

--- a/macros/edr/dbt_artifacts/upload_dbt_models.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_models.sql
@@ -1,8 +1,8 @@
-{%- macro upload_dbt_models(should_commit=false) -%}
+{%- macro upload_dbt_models(should_commit=false, state_hash=none) -%}
     {% set relation = elementary.get_elementary_relation('dbt_models') %}
     {% if execute and relation %}
         {% set models = graph.nodes.values() | selectattr('resource_type', '==', 'model') %}
-        {% do elementary.upload_artifacts_to_table(relation, models, elementary.flatten_model, should_commit=should_commit) %}
+        {% do elementary.upload_artifacts_to_table(relation, models, elementary.flatten_model, should_commit=should_commit, state_hash=state_hash) %}
     {%- endif -%}
     {{- return('') -}}
 {%- endmacro -%}
@@ -73,6 +73,8 @@
         'path': node_dict.get('path'),
         'generated_at': elementary.datetime_now_utc_as_string()
     }%}
-    {% do flatten_model_metadata_dict.update({"hash": local_md5(flatten_model_metadata_dict | string) if local_md5 else none}) %}
+    {% set time_excluded_dict = flatten_model_metadata_dict.copy() %}
+    {% do time_excluded_dict.pop("generated_at") %}
+    {% do flatten_model_metadata_dict.update({"hash": local_md5(time_excluded_dict | string) if local_md5 else none}) %}
     {{ return(flatten_model_metadata_dict) }}
 {% endmacro %}

--- a/macros/edr/dbt_artifacts/upload_dbt_models.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_models.sql
@@ -24,7 +24,9 @@
                                                                   ('package_name', 'string'),
                                                                   ('original_path', 'long_string'),
                                                                   ('path', 'string'),
-                                                                  ('generated_at', 'string')]) %}
+                                                                  ('generated_at', 'string'),
+                                                                  ('hash', 'string'),
+                                                                  ]) %}
     {{ return(dbt_models_empty_table_query) }}
 {% endmacro %}
 
@@ -71,5 +73,6 @@
         'path': node_dict.get('path'),
         'generated_at': elementary.datetime_now_utc_as_string()
     }%}
+    {% do flatten_model_metadata_dict.update({"hash": local_md5(flatten_model_metadata_dict | string) if local_md5 else none}) %}
     {{ return(flatten_model_metadata_dict) }}
 {% endmacro %}

--- a/macros/edr/dbt_artifacts/upload_dbt_seeds.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_seeds.sql
@@ -1,8 +1,8 @@
-{%- macro upload_dbt_seeds(should_commit=false) -%}
+{%- macro upload_dbt_seeds(should_commit=false, state_hash=none) -%}
     {% set relation = elementary.get_elementary_relation('dbt_seeds') %}
     {% if execute and relation %}
         {% set seeds = graph.nodes.values() | selectattr('resource_type', '==', 'seed') %}
-        {% do elementary.upload_artifacts_to_table(relation, seeds, elementary.flatten_seed, should_commit=should_commit) %}
+        {% do elementary.upload_artifacts_to_table(relation, seeds, elementary.flatten_seed, should_commit=should_commit, state_hash=state_hash) %}
     {%- endif -%}
     {{- return('') -}}
 {%- endmacro -%}
@@ -67,6 +67,8 @@
         'path': node_dict.get('path'),
         'generated_at': elementary.datetime_now_utc_as_string()
     }%}
-    {% do flatten_seed_metadata_dict.update({"hash": local_md5(flatten_seed_metadata_dict | string) if local_md5 else none}) %}
+    {% set time_excluded_dict = flatten_seed_metadata_dict.copy() %}
+    {% do time_excluded_dict.pop("generated_at") %}
+    {% do flatten_seed_metadata_dict.update({"hash": local_md5(time_excluded_dict | string) if local_md5 else none}) %}
     {{ return(flatten_seed_metadata_dict) }}
 {% endmacro %}

--- a/macros/edr/dbt_artifacts/upload_dbt_seeds.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_seeds.sql
@@ -21,7 +21,9 @@
                                                                   ('package_name', 'string'),
                                                                   ('original_path', 'long_string'),
                                                                   ('path', 'string'),
-                                                                  ('generated_at', 'string')]) %}
+                                                                  ('generated_at', 'string'),
+                                                                  ('hash', 'string'),
+                                                                  ]) %}
     {{ return(dbt_seeds_empty_table_query) }}
 {% endmacro %}
 
@@ -65,5 +67,6 @@
         'path': node_dict.get('path'),
         'generated_at': elementary.datetime_now_utc_as_string()
     }%}
+    {% do flatten_seed_metadata_dict.update({"hash": local_md5(flatten_seed_metadata_dict | string) if local_md5 else none}) %}
     {{ return(flatten_seed_metadata_dict) }}
 {% endmacro %}

--- a/macros/edr/dbt_artifacts/upload_dbt_snapshots.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_snapshots.sql
@@ -1,8 +1,8 @@
-{%- macro upload_dbt_snapshots(should_commit=false) -%}
+{%- macro upload_dbt_snapshots(should_commit=false, state_hash=none) -%}
     {% set relation = elementary.get_elementary_relation('dbt_snapshots') %}
     {% if execute and relation %}
         {% set snapshots = graph.nodes.values() | selectattr('resource_type', '==', 'snapshot') %}
-        {% do elementary.upload_artifacts_to_table(relation, snapshots, elementary.flatten_model, should_commit=should_commit) %}
+        {% do elementary.upload_artifacts_to_table(relation, snapshots, elementary.flatten_model, should_commit=should_commit, state_hash=state_hash) %}
     {%- endif -%}
     {{- return('') -}}
 {%- endmacro -%}

--- a/macros/edr/dbt_artifacts/upload_dbt_sources.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_sources.sql
@@ -29,7 +29,9 @@
                                                                    ('path', 'string'),
                                                                    ('source_description', 'long_string'),
                                                                    ('description', 'long_string'),
-                                                                   ('generated_at', 'string')]) %}
+                                                                   ('generated_at', 'string'),
+                                                                   ('hash', 'string'),
+                                                                   ]) %}
     {{ return(dbt_sources_empty_table_query) }}
 {% endmacro %}
 
@@ -64,5 +66,6 @@
          'description': node_dict.get('description'),
          'generated_at': elementary.datetime_now_utc_as_string()
      }%}
+    {% do flatten_source_metadata_dict.update({"hash": local_md5(flatten_source_metadata_dict | string) if local_md5 else none}) %}
     {{ return(flatten_source_metadata_dict) }}
 {% endmacro %}

--- a/macros/edr/dbt_artifacts/upload_dbt_sources.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_sources.sql
@@ -1,8 +1,8 @@
-{%- macro upload_dbt_sources(should_commit=false) -%}
+{%- macro upload_dbt_sources(should_commit=false, state_hash=none) -%}
     {% set relation = elementary.get_elementary_relation('dbt_sources') %}
     {% if execute and relation %}
         {% set sources = graph.sources.values() | selectattr('resource_type', '==', 'source') %}
-        {% do elementary.upload_artifacts_to_table(relation, sources, elementary.flatten_source, should_commit=should_commit) %}
+        {% do elementary.upload_artifacts_to_table(relation, sources, elementary.flatten_source, should_commit=should_commit, state_hash=state_hash) %}
     {%- endif -%}
     {{- return('') -}}
 {%- endmacro -%}
@@ -66,6 +66,8 @@
          'description': node_dict.get('description'),
          'generated_at': elementary.datetime_now_utc_as_string()
      }%}
-    {% do flatten_source_metadata_dict.update({"hash": local_md5(flatten_source_metadata_dict | string) if local_md5 else none}) %}
+    {% set time_excluded_dict = flatten_source_metadata_dict.copy() %}
+    {% do time_excluded_dict.pop("generated_at") %}
+    {% do flatten_source_metadata_dict.update({"hash": local_md5(time_excluded_dict | string) if local_md5 else none}) %}
     {{ return(flatten_source_metadata_dict) }}
 {% endmacro %}

--- a/macros/edr/dbt_artifacts/upload_dbt_tests.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_tests.sql
@@ -35,7 +35,9 @@
                                                                  ('type', 'string'),
                                                                  ('original_path', 'long_string'),
                                                                  ('path', 'string'),
-                                                                 ('generated_at', 'string')]) %}
+                                                                 ('generated_at', 'string'),
+                                                                 ('hash', 'string'),
+                                                                 ]) %}
     {{ return(dbt_tests_empty_table_query) }}
 {% endmacro %}
 
@@ -156,6 +158,7 @@
         'path': node_dict.get('path'),
         'generated_at': elementary.datetime_now_utc_as_string()
     }%}
+    {% do flatten_test_metadata_dict.update({"hash": local_md5(flatten_test_metadata_dict | string) if local_md5 else none}) %}
     {{ return(flatten_test_metadata_dict) }}
 {% endmacro %}
 

--- a/macros/edr/dbt_artifacts/upload_dbt_tests.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_tests.sql
@@ -1,8 +1,8 @@
-{%- macro upload_dbt_tests(should_commit=false) -%}
+{%- macro upload_dbt_tests(should_commit=false, state_hash=none) -%}
     {% set relation = elementary.get_elementary_relation('dbt_tests') %}
     {% if execute and relation %}
         {% set tests = graph.nodes.values() | selectattr('resource_type', '==', 'test') %}
-        {% do elementary.upload_artifacts_to_table(relation, tests, elementary.flatten_test, should_commit=should_commit) %}
+        {% do elementary.upload_artifacts_to_table(relation, tests, elementary.flatten_test, should_commit=should_commit, state_hash=state_hash) %}
     {%- endif -%}
     {{- return('') -}}
 {%- endmacro -%}
@@ -158,7 +158,9 @@
         'path': node_dict.get('path'),
         'generated_at': elementary.datetime_now_utc_as_string()
     }%}
-    {% do flatten_test_metadata_dict.update({"hash": local_md5(flatten_test_metadata_dict | string) if local_md5 else none}) %}
+    {% set time_excluded_dict = flatten_test_metadata_dict.copy() %}
+    {% do time_excluded_dict.pop("generated_at") %}
+    {% do flatten_test_metadata_dict.update({"hash": local_md5(time_excluded_dict | string) if local_md5 else none}) %}
     {{ return(flatten_test_metadata_dict) }}
 {% endmacro %}
 

--- a/models/edr/dbt_artifacts/dbt_artifacts_state.sql
+++ b/models/edr/dbt_artifacts/dbt_artifacts_state.sql
@@ -6,9 +6,9 @@
 }}
 
 select
-  (select md5({{ elementary.cast_as_string("array_agg(hash)") }}) from {{ ref("dbt_models") }}) as models_hash,
-  (select md5({{ elementary.cast_as_string("array_agg(hash)") }}) from {{ ref("dbt_tests") }}) as tests_hash,
-  (select md5({{ elementary.cast_as_string("array_agg(hash)") }}) from {{ ref("dbt_sources") }}) as sources_hash,
-  (select md5({{ elementary.cast_as_string("array_agg(hash)") }}) from {{ ref("dbt_snapshots") }}) as snapshots_hash,
-  (select md5({{ elementary.cast_as_string("array_agg(hash)") }}) from {{ ref("dbt_exposures") }}) as exposures_hash,
-  (select md5({{ elementary.cast_as_string("array_agg(hash)") }}) from {{ ref("dbt_metrics") }}) as metrics_hash
+  (select md5({{ dbt.listagg("hash", order_by_clause="order by hash") }}) from {{ ref("dbt_models") }}) as dbt_models,
+  (select md5({{ dbt.listagg("hash", order_by_clause="order by hash") }}) from {{ ref("dbt_tests") }}) as dbt_tests,
+  (select md5({{ dbt.listagg("hash", order_by_clause="order by hash") }}) from {{ ref("dbt_sources") }}) as dbt_sources,
+  (select md5({{ dbt.listagg("hash", order_by_clause="order by hash") }}) from {{ ref("dbt_snapshots") }}) as dbt_snapshots,
+  (select md5({{ dbt.listagg("hash", order_by_clause="order by hash") }}) from {{ ref("dbt_exposures") }}) as dbt_exposures,
+  (select md5({{ dbt.listagg("hash", order_by_clause="order by hash") }}) from {{ ref("dbt_metrics") }}) as dbt_metrics

--- a/models/edr/dbt_artifacts/dbt_artifacts_state.sql
+++ b/models/edr/dbt_artifacts/dbt_artifacts_state.sql
@@ -1,0 +1,14 @@
+{{
+  config(
+    materialized = 'view',
+    bind=False
+  )
+}}
+
+select
+  (select md5({{ elementary.cast_as_string("array_agg(hash)") }}) from {{ ref("dbt_models") }}) as models_hash,
+  (select md5({{ elementary.cast_as_string("array_agg(hash)") }}) from {{ ref("dbt_tests") }}) as tests_hash,
+  (select md5({{ elementary.cast_as_string("array_agg(hash)") }}) from {{ ref("dbt_sources") }}) as sources_hash,
+  (select md5({{ elementary.cast_as_string("array_agg(hash)") }}) from {{ ref("dbt_snapshots") }}) as snapshots_hash,
+  (select md5({{ elementary.cast_as_string("array_agg(hash)") }}) from {{ ref("dbt_exposures") }}) as exposures_hash,
+  (select md5({{ elementary.cast_as_string("array_agg(hash)") }}) from {{ ref("dbt_metrics") }}) as metrics_hash

--- a/models/edr/dbt_artifacts/dbt_exposures.sql
+++ b/models/edr/dbt_artifacts/dbt_exposures.sql
@@ -2,7 +2,10 @@
   config(
     materialized='incremental',
     transient=False,
-    post_hook='{{ elementary.upload_dbt_exposures() }}'
+    post_hook='{{ elementary.upload_dbt_exposures() }}',
+    unique_key='unique_id',
+    on_schema_change='append_new_columns',
+    full_refresh=elementary.get_config_var('elementary_full_refresh')
     )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_metrics.sql
+++ b/models/edr/dbt_artifacts/dbt_metrics.sql
@@ -2,7 +2,10 @@
   config(
     materialized='incremental',
     transient=False,
-    post_hook='{{ elementary.upload_dbt_metrics() }}'
+    post_hook='{{ elementary.upload_dbt_metrics() }}',
+    unique_key='unique_id',
+    on_schema_change='append_new_columns',
+    full_refresh=elementary.get_config_var('elementary_full_refresh')
     )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_models.sql
+++ b/models/edr/dbt_artifacts/dbt_models.sql
@@ -2,7 +2,10 @@
   config(
     materialized='incremental',
     transient=False,
-    post_hook='{{ elementary.upload_dbt_models() }}'
+    post_hook='{{ elementary.upload_dbt_models() }}',
+    unique_key='unique_id',
+    on_schema_change='append_new_columns',
+    full_refresh=elementary.get_config_var('elementary_full_refresh')
   )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_seeds.sql
+++ b/models/edr/dbt_artifacts/dbt_seeds.sql
@@ -2,7 +2,10 @@
   config(
     materialized='incremental',
     transient=False,
-    post_hook='{{ elementary.upload_dbt_seeds() }}'
+    post_hook='{{ elementary.upload_dbt_seeds() }}',
+    unique_key='unique_id',
+    on_schema_change='append_new_columns',
+    full_refresh=elementary.get_config_var('elementary_full_refresh')
   )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_snapshots.sql
+++ b/models/edr/dbt_artifacts/dbt_snapshots.sql
@@ -2,7 +2,10 @@
   config(
     materialized='incremental',
     transient=False,
-    post_hook='{{ elementary.upload_dbt_snapshots() }}'
+    post_hook='{{ elementary.upload_dbt_snapshots() }}',
+    unique_key='unique_id',
+    on_schema_change='append_new_columns',
+    full_refresh=elementary.get_config_var('elementary_full_refresh')
   )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_sources.sql
+++ b/models/edr/dbt_artifacts/dbt_sources.sql
@@ -2,7 +2,10 @@
   config(
     materialized='incremental',
     transient=False,
-    post_hook='{{ elementary.upload_dbt_sources() }}'
+    post_hook='{{ elementary.upload_dbt_sources() }}',
+    unique_key='unique_id',
+    on_schema_change='append_new_columns',
+    full_refresh=elementary.get_config_var('elementary_full_refresh')
     )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_tests.sql
+++ b/models/edr/dbt_artifacts/dbt_tests.sql
@@ -2,7 +2,10 @@
   config(
     materialized='incremental',
     transient=False,
-    post_hook='{{ elementary.upload_dbt_tests() }}'
+    post_hook='{{ elementary.upload_dbt_tests() }}',
+    unique_key='unique_id',
+    on_schema_change='append_new_columns',
+    full_refresh=elementary.get_config_var('elementary_full_refresh')
   )
 }}
 


### PR DESCRIPTION
Changes:

1. Added `hash` column to artifacts.
2. Added `dbt_artifacts_state` view that hash a hash on all the hashes per artifact.
3. Upon `on-run-end`, the state is pulled and compared to the current state using `local_md5`.

This means that the caching will only take place from dbt 1.4.0 onwards.