### PR TITLE
Lowercasing agate's columns by default.

### DIFF
--- a/integration_tests/macros/system/read_table.sql
+++ b/integration_tests/macros/system/read_table.sql
@@ -6,7 +6,7 @@
     {% endif %}
   {% endset %}
 
-  {% set results = dbt.run_query(query) %}
+  {% set results = elementary.run_query(query) %}
   {% set results_json = elementary.agate_to_json(results) %}
   {% do elementary.edr_log(results_json) %}
 {% endmacro %}

--- a/macros/edr/materializations/tests/test.sql
+++ b/macros/edr/materializations/tests/test.sql
@@ -5,7 +5,7 @@
     )
     select * from test_results {% if sample_limit is not none %} limit {{ sample_limit }} {% endif %}
   {% endset %}
-  {% do return(elementary.agate_to_dicts(dbt.run_query(query))) %}
+  {% do return(elementary.agate_to_dicts(elementary.run_query(query))) %}
 {% endmacro %}
 
 {% macro cache_elementary_test_results_rows(elementary_test_results_rows) %}

--- a/macros/utils/run_queries/result_column_to_list.sql
+++ b/macros/utils/run_queries/result_column_to_list.sql
@@ -1,4 +1,4 @@
 {% macro result_column_to_list(single_column_query) %}
-    {% set query_result = dbt.run_query(single_column_query) %}
+    {% set query_result = elementary.run_query(single_column_query) %}
     {% do return(query_result.columns[0]) %}
 {% endmacro %}

--- a/macros/utils/run_queries/result_value.sql
+++ b/macros/utils/run_queries/result_value.sql
@@ -1,5 +1,5 @@
 {% macro result_value(single_column_query) %}
-    {% set result = dbt.run_query(single_column_query) %}
+    {% set result = elementary.run_query(single_column_query) %}
     {% if not result %}
       {% do return(none) %}
     {% endif %}

--- a/macros/utils/table_operations/create_table_like.sql
+++ b/macros/utils/table_operations/create_table_like.sql
@@ -1,4 +1,4 @@
 {% macro create_table_like(relation, like_relation, temporary=False) %}
     {% set empty_table_query = 'SELECT * FROM {} WHERE 1 = 0'.format(like_relation) %}
-    {% do dbt.run_query(dbt.create_table_as(temporary, relation, empty_table_query)) %}
+    {% do elementary.run_query(dbt.create_table_as(temporary, relation, empty_table_query)) %}
 {% endmacro %}

--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -22,7 +22,7 @@
       {% set queries_len = insert_rows_queries | length %}
       {% for insert_query in insert_rows_queries %}
         {% do elementary.debug_log("[{}/{}] Running insert query.".format(loop.index, queries_len)) %}
-        {% do dbt.run_query(insert_query) %}
+        {% do elementary.run_query(insert_query) %}
       {% endfor %}
     {% elif insert_rows_method == 'chunk' %}
       {% set rows_chunks = elementary.split_list_to_chunks(rows, chunk_size) %}

--- a/macros/utils/table_operations/replace_table_data.sql
+++ b/macros/utils/table_operations/replace_table_data.sql
@@ -5,7 +5,7 @@
 {# Default (Bigquery & Snowflake) - upload data to a temp table, and then atomically replace the table with a new one #}
 {% macro default__replace_table_data(relation, rows) %}
     {% set intermediate_relation = elementary.create_intermediate_relation(relation, rows, temporary=True) %}
-    {% do dbt.run_query(dbt.create_table_as(False, relation, 'select * from {}'.format(intermediate_relation))) %}
+    {% do elementary.run_query(dbt.create_table_as(False, relation, 'select * from {}'.format(intermediate_relation))) %}
 {% endmacro %}
 
 {# Spark / Databricks - truncate and insert (non-atomic) #}
@@ -25,7 +25,7 @@
         insert into {{ relation }} select * from {{ intermediate_relation }};
         commit;
     {% endset %}
-    {% do dbt.run_query(query) %}
+    {% do elementary.run_query(query) %}
 {% endmacro %}
 
 {% macro create_intermediate_relation(base_relation, rows, temporary) %}


### PR DESCRIPTION
This is in order to avoid using `.insensitive_get_dict_value()` all the time throughout the code.