### PR TITLE
override test result detected at when custom run started at is provided

### DIFF
--- a/macros/edr/materializations/tests/test.sql
+++ b/macros/edr/materializations/tests/test.sql
@@ -193,7 +193,7 @@
         'test_execution_id': test_execution_id,
         'test_unique_id': elementary.insensitive_get_dict_value(flattened_test, 'unique_id'),
         'model_unique_id': parent_model_unique_id,
-        'detected_at': elementary.insensitive_get_dict_value(flattened_test, 'generated_at'),
+        'detected_at': elementary.get_config_var('custom_run_started_at') or elementary.insensitive_get_dict_value(flattened_test, 'generated_at'),
         'database_name': elementary.insensitive_get_dict_value(flattened_test, 'database_name'),
         'schema_name': elementary.insensitive_get_dict_value(flattened_test, 'schema_name'),
         'table_name': parent_model_name,


### PR DESCRIPTION
We use custom run started at to override some of the data (used mostly at our tests).
The detected at of a test results should also be overridden when we pass custom run started at.