### PR TITLE
Fix the `DBT_ORCHESTRATOR` env var not being used.

### DIFF
--- a/macros/edr/dbt_artifacts/upload_dbt_invocation.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_invocation.sql
@@ -106,7 +106,7 @@
       {% do return(orchestrator) %}
     {% endif %}
   {% endfor %}
-  {% do return(none) %}
+  {% do return(elementary.get_first_env_var(["DBT_ORCHESTRATOR"])) %}
 {% endmacro %}
 
 {% macro get_dbt_invocations_empty_table_query() %}


### PR DESCRIPTION
As the doc says ([link](https://docs.elementary-data.com/guides/modules-overview/dbt-package)), setting the `DBT_ORCHESTRATOR` environment variable should populate the `orchestrator` column in `invocations` table. However, per my experience, this is not happening.

This PR aims to fix this behaviour with a simple change.