### PR TITLE
Feature/python test where expression

### DIFF
--- a/macros/edr/tests/python.sql
+++ b/macros/edr/tests/python.sql
@@ -1,4 +1,4 @@
-{% test python(model, code_macro, macro_args) %}
+{% test python(model, code_macro, macro_args, where_expression) %}
   {{ config(fail_calc = 'fail_count') }}
 
   {% if not execute %}
@@ -39,7 +39,7 @@
   {% endif %}
   {% set user_py_code = user_py_code_macro(macro_args) %}
   {% set compiled_py_code = adapter.dispatch('compile_py_code', 'elementary')(model_relation, user_py_code,
-                                                                              output_table, code_type='test') %}
+                                                                              output_table, where_expression, code_type='test') %}
 
   {% do elementary.run_python(test_node, compiled_py_code) %}
   select fail_count from {{ output_table }}

--- a/macros/edr/tests/test_json_schema.sql
+++ b/macros/edr/tests/test_json_schema.sql
@@ -1,4 +1,4 @@
-{% test json_schema(model, column_name) %}
+{% test json_schema(model, column_name, where_expression) %}
     {{ config(fail_calc = 'fail_count') }}
 
     {% if not execute %}
@@ -11,7 +11,7 @@
         {% do exceptions.raise_compiler_error("A json schema must be supplied as a part of the test!") %}
     {% endif %}
 
-    {{ elementary.test_python(model, elementary.json_schema_python_test, {'column_name': column_name, 'json_schema': kwargs},
+    {{ elementary.test_python(model, elementary.json_schema_python_test, {'column_name': column_name, 'json_schema': kwargs}, where_expression,
                               packages=['jsonschema']) }}
 {% endtest %}
 

--- a/macros/edr/tests/test_utils/compile_py_code.sql
+++ b/macros/edr/tests/test_utils/compile_py_code.sql
@@ -1,4 +1,4 @@
-{% macro snowflake__compile_py_code(model, py_code, output_table, code_type) %}
+{% macro snowflake__compile_py_code(model, py_code, output_table, where_expression, code_type) %}
 import pandas
 import snowflake.snowpark
 
@@ -32,12 +32,17 @@ def get_output_df(model_df, code_type, ref, session):
 def main(session):
     ref = session.table
     model_df = ref('{{ model }}')
+
+    {% if where_expression %}
+    model_df = model_df.filter("""{{ where_expression }}""")
+    {% endif %}
+
     output_df = get_output_df(model_df, '{{ code_type }}', ref, session)
     write_output_table(session, output_df, '{{ output_table }}')
 {% endmacro %}
 
 
-{% macro bigquery__compile_py_code(model, py_code, output_table, code_type) %}
+{% macro bigquery__compile_py_code(model, py_code, output_table, where_expression, code_type) %}
 import pandas
 import pyspark.sql
 
@@ -78,6 +83,11 @@ def main():
     session = get_session()
     ref = session.read.format('bigquery').load
     model_df = ref('{{ model }}')
+
+    {% if where_expression %}
+    model_df = model_df.filter("""{{ where_expression }}""")
+    {% endif %}
+
     output_df = get_output_df(model_df, '{{ code_type }}', ref, session)
     write_output_table(session, output_df, '{{ output_table }}')
 

--- a/macros/edr/tests/test_utils/compile_py_code.sql
+++ b/macros/edr/tests/test_utils/compile_py_code.sql
@@ -94,6 +94,6 @@ def main():
 main()
 {% endmacro %}
 
-{% macro default__compile_py_code(model, py_code, output_table, code_type) %}
+{% macro default__compile_py_code(model, py_code, output_table, where_expression, code_type) %}
   {{ exceptions.raise_compiler_error("Elementary's Python tests are not yet supported on %s." % target.type) }}
 {% endmacro %}


### PR DESCRIPTION
Related to: https://github.com/elementary-data/elementary/issues/697

_Description_
Adding support for where_expression in python tests. Python-tests now accept `where_expression` which should be an sql where-clause. 

Only tested in Snowflake. 
 