### PR TITLE
feature/detailed output python - draft

### DIFF
--- a/macros/edr/tests/python.sql
+++ b/macros/edr/tests/python.sql
@@ -1,4 +1,4 @@
-{% test python(model, code_macro, macro_args, where_expression) %}
+{% test python(model, code_macro, macro_args, where_expression, detailed_test_output) %}
   {{ config(fail_calc = 'fail_count') }}
 
   {% if not execute %}
@@ -18,6 +18,12 @@
   {% set elementary_database_name, elementary_schema_name = elementary.get_package_database_and_schema() %}
   {% set output_table = api.Relation.create(database=elementary_database_name, schema=elementary_schema_name,
     identifier='pytest_tmp__' ~ test_node.alias).quote(false, false, false) %}
+
+{% if detailed_test_output %}
+  {% set detailed_output_table = api.Relation.create(database=elementary_database_name, schema=elementary_schema_name,
+    identifier='elementary_detailed_output_' ~ test_node.alias).quote(false, false, false) %}
+{% endif %}
+
 
   {# This affects where resources needed for python execution (e.g. stored procedures) are created.
      By default, dbt uses the audit schema (adds _dbt__test_audit to the model's schema).
@@ -39,8 +45,13 @@
   {% endif %}
   {% set user_py_code = user_py_code_macro(macro_args) %}
   {% set compiled_py_code = adapter.dispatch('compile_py_code', 'elementary')(model_relation, user_py_code,
-                                                                              output_table, where_expression, code_type='test') %}
+                                                                              output_table, where_expression, detailed_output_table, code_type='test') %}
 
   {% do elementary.run_python(test_node, compiled_py_code) %}
+
+  {% if detailed_test_output %}
+  select fail_count, detailed_output_table from {{ output_table }}
+  {% else %}
   select fail_count from {{ output_table }}
+  {% endif %}
 {% endtest %}

--- a/macros/edr/tests/test_json_schema.sql
+++ b/macros/edr/tests/test_json_schema.sql
@@ -1,4 +1,4 @@
-{% test json_schema(model, column_name, where_expression) %}
+{% test json_schema(model, column_name, where_expression, detailed_test_output) %}
     {{ config(fail_calc = 'fail_count') }}
 
     {% if not execute %}
@@ -11,7 +11,7 @@
         {% do exceptions.raise_compiler_error("A json schema must be supplied as a part of the test!") %}
     {% endif %}
 
-    {{ elementary.test_python(model, elementary.json_schema_python_test, {'column_name': column_name, 'json_schema': kwargs}, where_expression,
+    {{ elementary.test_python(model, elementary.json_schema_python_test, {'column_name': column_name, 'json_schema': kwargs}, where_expression, detailed_test_output,
                               packages=['jsonschema']) }}
 {% endtest %}
 

--- a/macros/edr/tests/test_utils/compile_py_code.sql
+++ b/macros/edr/tests/test_utils/compile_py_code.sql
@@ -120,7 +120,7 @@ def main():
     {% if detailed_output_table %}
     output_df, detailed_output_df = get_output_df(model_df, '{{ code_type }}', ref, session)
     write_output_table(session, output_df, '{{ output_table }}')
-    write_output_table(session, detailed_output_df, '{{ detailed_output_table }}', 'transient')
+    write_output_table(session, detailed_output_df, '{{ detailed_output_table }}')
     {% else %}
     output_df = get_output_df(model_df, '{{ code_type }}', ref, session)
     write_output_table(session, output_df, '{{ output_table }}')


### PR DESCRIPTION
Hope it is okey, but just to give you an idea how I would like this feature.

1. Python test now takes `detailed_test_output: bool` as a parameter. 
2. For this to work, the output from the python-macro needs to be a dataframe(pandas or spark). If this is not the case, it will throw an error.
3. The outputed dataframe will be saved to a separate table.
4. Instead of just "fail_count" in the edr-report, a sql-query will have an sql-query for that table.   

This is just rough draft, but works. Things that could be nice to add is possibility to chose which columns that should be saved, and maybe a limit to avoid saving hundreds of rows.

![image](https://user-images.githubusercontent.com/53213782/222432139-ab892466-34f0-4bb5-bce6-e3175e844bdb.png)

https://github.com/elementary-data/elementary/issues/701