### PR TITLE
Feature/python detailed output

### DIFF
--- a/macros/edr/tests/python.sql
+++ b/macros/edr/tests/python.sql
@@ -44,7 +44,7 @@
   {% endif %}
   {% set user_py_code = user_py_code_macro(macro_args) %}
   {% set compiled_py_code = adapter.dispatch('compile_py_code', 'elementary')(model_relation, user_py_code,
-                                                                              output_table, where_expression, code_type='test') %}
+                                                                              output_table, where_expression, detailed_output, code_type='test') %}
 
   {% do elementary.run_python(test_node, compiled_py_code) %}
 

--- a/macros/edr/tests/test_json_schema.sql
+++ b/macros/edr/tests/test_json_schema.sql
@@ -27,9 +27,9 @@ import jsonschema
 def is_valid_json(val, json_schema):
     try:
         jsonschema.validate(json.loads(val), json_schema)
-        return None
+        return ""
     except (json.JSONDecodeError, jsonschema.ValidationError) as e:
-        return e
+        return str(e)
 
 def get_column_name_in_df(df, column_name):
     matching = [col for col in df.columns if col.lower() == column_name.lower()]
@@ -49,5 +49,5 @@ def test(model_df, ref, session):
     column_name = get_column_name_in_df(model_df, "{{ args.column_name }}")
     model_df["is_valid_json"] = model_df[column_name].apply(lambda val: is_valid_json(val, json_schema))
 
-    return model_df[model_df.is_valid_json != None]
+    return model_df[model_df.is_valid_json != ""]
 {% endmacro %}

--- a/macros/edr/tests/test_json_schema.sql
+++ b/macros/edr/tests/test_json_schema.sql
@@ -1,5 +1,10 @@
-{% test json_schema(model, column_name, where_expression) %}
+{% test json_schema(model, column_name, where_expression, detailed_output) %}
+    
+    {% if detailed_output %}
+    {{ config(fail_calc = 'count(*)') }}
+    {% else %}
     {{ config(fail_calc = 'fail_count') }}
+    {% endif %}
 
     {% if not execute %}
         {% do return(none) %}
@@ -11,7 +16,7 @@
         {% do exceptions.raise_compiler_error("A json schema must be supplied as a part of the test!") %}
     {% endif %}
 
-    {{ elementary.test_python(model, elementary.json_schema_python_test, {'column_name': column_name, 'json_schema': kwargs}, where_expression,
+    {{ elementary.test_python(model, elementary.json_schema_python_test, {'column_name': column_name, 'json_schema': kwargs}, where_expression, detailed_output,
                               packages=['jsonschema']) }}
 {% endtest %}
 
@@ -22,9 +27,9 @@ import jsonschema
 def is_valid_json(val, json_schema):
     try:
         jsonschema.validate(json.loads(val), json_schema)
-        return True
-    except (json.JSONDecodeError, jsonschema.ValidationError):
-        return False
+        return None
+    except (json.JSONDecodeError, jsonschema.ValidationError) as e:
+        return e
 
 def get_column_name_in_df(df, column_name):
     matching = [col for col in df.columns if col.lower() == column_name.lower()]
@@ -44,5 +49,5 @@ def test(model_df, ref, session):
     column_name = get_column_name_in_df(model_df, "{{ args.column_name }}")
     model_df["is_valid_json"] = model_df[column_name].apply(lambda val: is_valid_json(val, json_schema))
 
-    return model_df[model_df.is_valid_json == False]
+    return model_df[model_df.is_valid_json != None]
 {% endmacro %}

--- a/macros/edr/tests/test_utils/compile_py_code.sql
+++ b/macros/edr/tests/test_utils/compile_py_code.sql
@@ -1,11 +1,11 @@
-{% macro snowflake__compile_py_code(model, py_code, output_table, where_expression, code_type) %}
+{% macro snowflake__compile_py_code(model, py_code, output_table, where_expression, detailed_output, code_type) %}
 import pandas
 import snowflake.snowpark
 
 {{ py_code }}
 
 def write_output_table(session, output_df, target_relation):
-    output_df.write.mode('overwrite').save_as_table(target_relation, table_type='temporary')
+    output_df.write.mode('overwrite').save_as_table(target_relation)
 
 def get_fail_count(test_output):
     if isinstance(test_output, int):

--- a/macros/edr/tests/test_utils/compile_py_code.sql
+++ b/macros/edr/tests/test_utils/compile_py_code.sql
@@ -21,8 +21,23 @@ def get_fail_count(test_output):
 def get_output_df(model_df, code_type, ref, session):
     if code_type == "test":
         test_output = test(model_df, ref, session)
+        
+        {% if detailed_output %}
+        
+        if isinstance(test_output, pandas.DataFrame):
+            return session.createDataFrame(test_output)
+        elif isinstance(test_output, snowflake.snowpark.DataFrame):
+            return test_output
+        else:
+            raise ValueError('Detailed output requires python test macro to return a pandas.DataFrame or snowflake.snowpark.DataFrame.')
+        
+        {% else %}
+
         fail_count = get_fail_count(test_output)
         return session.createDataFrame([[fail_count]], ['fail_count'])
+
+        {% endif %}
+
     elif code_type == "function":
         res = func(model_df, ref, session)
         return session.createDataFrame([[res]], ['result'])
@@ -71,8 +86,23 @@ def get_session():
 def get_output_df(model_df, code_type, ref, session):
     if code_type == "test":
         test_output = test(model_df, ref, session)
+        
+        {% if detailed_output %}
+        
+        if isinstance(test_output, pandas.DataFrame):
+            return session.createDataFrame(test_output)
+        elif isinstance(test_output, pyspark.sql.DataFrame):
+            return test_output
+        else:
+            raise ValueError('Detailed output requires python test macro to return a pandas.Dataframe or pyspark.sql.DataFrame.')
+        
+        {% else %}
+
         fail_count = get_fail_count(test_output)
         return session.createDataFrame([[fail_count]], ['fail_count'])
+
+        {% endif %}
+        
     elif code_type == "function":
         res = func(model_df, ref, session)
         return session.createDataFrame([[res]], ['result'])
@@ -94,6 +124,6 @@ def main():
 main()
 {% endmacro %}
 
-{% macro default__compile_py_code(model, py_code, output_table, where_expression, code_type) %}
+{% macro default__compile_py_code(model, py_code, output_table, where_expression, detailed_output, code_type) %}
   {{ exceptions.raise_compiler_error("Elementary's Python tests are not yet supported on %s." % target.type) }}
 {% endmacro %}


### PR DESCRIPTION
Here is my suggestion on how to get more detailed output from the python-tests, like the output from a normal sql test. 

The overall idea is that python test now saves the "faulty"-records and can provide them as "sample" in the edr-report and edr-monitor. 

_I may done to many changes in once here, so happy to break out changes etc. Also, I just whipped this up in less than an hour so happy for feedback._

**Detailed python output.**
The python test now accept an extra parameter `detailed_output`(I hade this epiphany and realised maybe it should be called `store_failures` to align with dbt etc.).

This parameter changes the following things:

1. `fail_calc` is changed from `fail_count` to `count(*)`. Basic dbt to make the error output correct.
2. The main magic is happening in the `compile_py_code.sql`. Instead of calling the `get_fail_count` the code will check if the python test returns either a pandas or pyspark/snowpark dataframe, if not, it throws an error. If the return type is a pandas dataframe, it will be converted to a pyspark/snowpark dataframe. 

```
        {% if detailed_output %}

        if isinstance(test_output, pandas.DataFrame):
            return session.createDataFrame(test_output)
        elif isinstance(test_output, snowflake.snowpark.DataFrame):
            return test_output
        else:
            raise ValueError('Detailed output requires python test macro to return a pandas.DataFrame or snowflake.snowpark.DataFrame.')

        {% else %}

        fail_count = get_fail_count(test_output)
        return session.createDataFrame([[fail_count]], ['fail_count'])

        {% endif %}
```

These changes are enough to produce a more detailed output from the python tests. Report now show samples, and if one is interested you can use the result-query to check the full failures.

![image](https://user-images.githubusercontent.com/53213782/222653541-00f7db0f-dfd2-40e4-9b6d-2dbb7081c4a1.png)


Extra changes - That maybe should have been its own PR.

* Fixing edr mointor failing due `<table> does not exist or not authorized.` 

While troubleshooting I found out that the `<table>` is created a temporary table, this explain why it does not exsist, since temporary tables only exist in the same session. This solves it, but could also be a bug in the `edr monitor tool`.

```
   - output_df.write.mode('overwrite').save_as_table(target_relation, table_type='temporary')
   + output_df.write.mode('overwrite').save_as_table(target_relation)
```
Since the table is no long temporary I did this too, naming wise there could be a better name so it aligns with rest of elementary naming convention. 
```
   - identifier='pytest_tmp__' ~ test_node.alias).quote(false, false, false) %}
   + identifier='pytest_output_' ~ test_node.alias).quote(false, false, false) %}
```

If this is the solution, the big query part needs to be revised. 

* Better output from the JSON-test. 
This only make sense if the detailed-output change in merged, but instead of just returning True (valid json) or False (not valid json) the test now returns `""` for valid json and `str(e)` for not valid json.

This way every record will have what went wrong, instead of just bool. Ex, `'12' does not match '^-?[0-9]+\\.x[0-9]{2}$' Failed validating 'pattern' in schema['x']['x']['x']['x']['x']['x']: {'description': '', 'pattern': '^-?[0-9]+\\.x[0-9]{2}$', 'type': 'string'} On instance['x']['x']['x']: '12` 

```
def is_valid_json(val, json_schema):
    try:
        jsonschema.validate(json.loads(val), json_schema)
-        return True
-    except (json.JSONDecodeError, jsonschema.ValidationError):
-        return False
+        return ""
+    except (json.JSONDecodeError, jsonschema.ValidationError) as e:
+        return str(e)
```
Filter also needs to change
```
-    return model_df[model_df.is_valid_json == False]
+    return model_df[model_df.is_valid_json != ""]
```