### PR TITLE
Changed default query max for BQ

### DIFF
--- a/macros/edr/system/system_utils/get_config_var.sql
+++ b/macros/edr/system/system_utils/get_config_var.sql
@@ -56,6 +56,6 @@
 
 {%- macro bigquery__get_default_config() -%}
     {% set default_config = elementary.default__get_default_config() %}
-    {% do default_config.update({'query_max_size': 500000}) %}
+    {% do default_config.update({'query_max_size': 250000}) %}
     {{- return(default_config) -}}
 {%- endmacro -%}


### PR DESCRIPTION
Following the support threads:
https://elementary-community.slack.com/archives/C02CTC89LAX/p1677869503258149
https://elementary-community.slack.com/archives/C02CTC89LAX/p1678265959321259