### PR TITLE
add lower to avoid string matching error

### DIFF
--- a/macros/edr/data_monitoring/schema_changes/get_columns_changes_query.sql
+++ b/macros/edr/data_monitoring/schema_changes/get_columns_changes_query.sql
@@ -77,7 +77,7 @@
             pre.data_type as pre_data_type,
             pre.detected_at
         from cur inner join pre
-            on (cur.full_table_name = pre.full_table_name and lower(cur.column_name) = lower(pre.column_name))
+            on (lower(cur.full_table_name) = lower(pre.full_table_name) and lower(cur.column_name) = lower(pre.column_name))
         where pre.data_type IS NOT NULL AND lower(cur.data_type) != lower(pre.data_type)
 
     ),
@@ -110,7 +110,7 @@
             pre.data_type as pre_data_type,
             pre.detected_at as detected_at
         from pre left join cur
-            on (cur.full_table_name = pre.full_table_name and lower(cur.column_name) = lower(pre.column_name))
+            on (lower(cur.full_table_name) = lower(pre.full_table_name) and lower(cur.column_name) = lower(pre.column_name))
         where cur.full_table_name is null and cur.column_name is null
 
     ),
@@ -126,7 +126,7 @@
             removed.pre_data_type,
             removed.detected_at
         from columns_removed as removed join cur
-            on (removed.full_table_name = cur.full_table_name)
+            on (lower(removed.full_table_name) = lower(cur.full_table_name))
 
     ),
 

--- a/macros/edr/data_monitoring/schema_changes/get_columns_changes_query.sql
+++ b/macros/edr/data_monitoring/schema_changes/get_columns_changes_query.sql
@@ -77,7 +77,7 @@
             pre.data_type as pre_data_type,
             pre.detected_at
         from cur inner join pre
-            on (cur.full_table_name = pre.full_table_name and cur.column_name = pre.column_name)
+            on (cur.full_table_name = pre.full_table_name and lower(cur.column_name) = lower(pre.column_name))
         where pre.data_type IS NOT NULL AND lower(cur.data_type) != lower(pre.data_type)
 
     ),


### PR DESCRIPTION
To fix column_name matching error

when using `elementary.schema_changes_from_baseline` with `enforce_types: true`

before fix -> success
after fix -> error
```
cur:
  column_name: partition_hourly
  data_type: VARCHAR
pre:
  column_name: PARTITION_HOURLY
  data_type: TIMESTAMP_NTZ
```

