### PR TITLE
Raise an exception if user configures a timestamp column that doesn't exist

### DIFF
--- a/macros/edr/tests/test_utils/find_normalized_data_type_for_column.sql
+++ b/macros/edr/tests/test_utils/find_normalized_data_type_for_column.sql
@@ -7,6 +7,7 @@
             {{ return(elementary.normalize_data_type(column_obj.dtype)) }}
         {% endif %}
     {% endfor %}
+    {% do exceptions.raise_compiler_error("Column `{}` was not found in `{}`.".format(column_name, model_relation.name)) %}
 {% endif %}
 {{ return(none) }}
 


### PR DESCRIPTION
Today we just ignore and the test works without a timestamp.