### PR TITLE
Add "direction" param to anomalies tests

### DIFF
--- a/integration_tests/macros/e2e_tests/tests_validation.sql
+++ b/integration_tests/macros/e2e_tests/tests_validation.sql
@@ -119,8 +119,7 @@
             {% do dimensions_with_problems.append[dimensions] %}
         {% endif %}
     {% endfor %}
-
-    {% if results | length != 2 %}
+    {% if results | length != 3 %}
         {% do elementary.edr_log('FAILED: dimension anomalies tests failed because it has too many fail/error tests') %}
         {{ return(1) }}
     {% elif dimensions_with_problems %}
@@ -259,6 +258,42 @@
     {% endset %}
     {% set results = elementary.result_column_to_list(error_test_validation_query) %}
     {{ assert_lists_contain_same_items(results, ['error']) }}
+{% endmacro %}
+
+{% macro validate_spike_directional_anomalies() %}
+    {% set alerts_relation = ref('alerts_anomaly_detection') %}
+    {# Validating alert for correct direction anomalies #}
+
+    {% set row_count_validation_query %}
+        select distinct table_name
+        from {{ alerts_relation }}
+        where status in ('fail', 'warn') and tags like '%spike_directional_anomalies%';
+    {% endset %}
+    {% set results = elementary.result_column_to_list(row_count_validation_query) %}
+    -- The result list's purpose is a more readable error messages
+    {% set results_list = [] %}
+    {% for result in results %}
+        {% do results_list.append(result) %}
+    {% endfor %}
+    {{ assert_lists_contain_same_items(results_list,  ['any_type_column_anomalies']) }}
+{% endmacro %}
+
+{% macro validate_drop_directional_anomalies() %}
+    {% set alerts_relation = ref('alerts_anomaly_detection') %}
+    {# Validating alert for correct direction anomalies #}
+
+    {% set row_count_validation_query %}
+        select distinct table_name
+        from {{ alerts_relation }}
+        where status in ('fail', 'warn') and tags like '%drop_directional_anomalies%';
+    {% endset %}
+    {% set results = elementary.result_column_to_list(row_count_validation_query) %}
+    -- The result list's purpose is a more readable error messages
+    {% set results_list = [] %}
+    {% for result in results %}
+        {% do results_list.append(result) %}
+    {% endfor %}
+    {{ assert_lists_contain_same_items(results_list,  ['any_type_column_anomalies', 'dimension_anomalies', 'numeric_column_anomalies']) }}
 {% endmacro %}
 
 {% macro validate_error_model() %}

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -53,7 +53,12 @@ models:
           exclude_regexp: ".*column1|column2|column3|column4|column5|column6|column7|column8|column9|column10|column11|column12|column13|column14|column15|column16|column17.*"
       - generic_test_on_model:
           tags: ["regular_tests"]
-
+      - elementary.all_columns_anomalies:
+          anomaly_direction: "drop"
+          tags: [ "all_any_type_columns_anomalies", "drop_directional_anomalies" ]
+      - elementary.all_columns_anomalies:
+          anomaly_direction: "spike"
+          tags: [ "all_any_type_columns_anomalies", "spike_directional_anomalies" ]
   - name: no_timestamp_anomalies
     meta:
       owner: "elon@elementary-data.com, or@elementary-data.com"
@@ -82,6 +87,16 @@ models:
     tests:
       - elementary.dimension_anomalies:
           tags: ["dimension_anomalies"]
+          dimensions:
+            - platform
+      - elementary.dimension_anomalies:
+          anomaly_direction: "spike"
+          tags: [ "dimension_anomalies", "spike_directional_anomalies" ]
+          dimensions:
+            - platform
+      - elementary.dimension_anomalies:
+          anomaly_direction: "drop"
+          tags: [ "dimension_anomalies", "drop_directional_anomalies" ]
           dimensions:
             - platform
       - elementary.dimension_anomalies:
@@ -169,6 +184,12 @@ models:
     tests:
       - elementary.volume_anomalies:
           tags: ["table_anomalies"]
+      - elementary.volume_anomalies:
+          anomaly_direction: "drop"
+          tags: [ "table_anomalies", "drop_directional_anomalies" ]
+      - elementary.volume_anomalies:
+          anomaly_direction: "spike"
+          tags: [ "table_anomalies", "spike_directional_anomalies" ]
       - elementary.freshness_anomalies:
           tags: ["table_anomalies"]
       - elementary.event_freshness_anomalies:
@@ -211,6 +232,16 @@ models:
               tags: ["numeric_column_anomalies"]
               column_anomalies:
                 - average
+          - elementary.column_anomalies:
+              column_anomalies:
+                - average
+              anomaly_direction: "spike"
+              tags: [ "numeric_column_anomalies", "spike_directional_anomalies" ]
+          - elementary.column_anomalies:
+              column_anomalies:
+                - average
+              anomaly_direction: "drop"
+              tags: [ "numeric_column_anomalies", "drop_directional_anomalies" ]
       - name: average
         tests:
           - elementary.column_anomalies:

--- a/integration_tests/run_e2e_tests.py
+++ b/integration_tests/run_e2e_tests.py
@@ -136,6 +136,26 @@ def e2e_tests(
         ]
         test_results.extend(results)
 
+    if "directional_anomalies" in test_types:
+        dbt_runner.test(select="tag:drop_directional_anomalies")
+        results = [
+            TestResult(type="drop_directional_anomalies", message=msg)
+            for msg in dbt_runner.run_operation(
+                macro_name="validate_drop_directional_anomalies", should_log=False
+            )
+        ]
+        test_results.extend(results)
+
+    if "directional_anomalies" in test_types:
+        dbt_runner.test(select="tag:spike_directional_anomalies")
+        results = [
+            TestResult(type="spike_directional_anomalies", message=msg)
+            for msg in dbt_runner.run_operation(
+                macro_name="validate_spike_directional_anomalies", should_log=False
+            )
+        ]
+        test_results.extend(results)
+
     if "create_table" in test_types:
         # If there is a problem with create_or_replace macro, it will crash the test.
         dbt_runner.test(select="tag:table_anomalies")
@@ -309,7 +329,7 @@ def e2e_tests(
 def print_failed_test_results(e2e_target: str, failed_test_results: List[TestResult]):
     print(f"Failed {e2e_target} tests:")
     for failed_test_result in failed_test_results:
-        print(f"{failed_test_result.type}: {failed_test_result.message}")
+        print(f"\033[1m\033[91m{failed_test_result.type}: {failed_test_result.message}\033[0m")
 
 
 @click.command()
@@ -350,6 +370,7 @@ def main(target, e2e_type, generate_data, clear_tests):
         e2e_types = [
             "table",
             "column",
+            "directional_anomalies"
             "schema",
             "regular",
             "artifacts",

--- a/macros/edr/system/system_utils/get_config_var.sql
+++ b/macros/edr/system/system_utils/get_config_var.sql
@@ -49,6 +49,7 @@
     'elementary_full_refresh': false,
     'min_training_set_size': 14,
     'cache_artifacts': true,
+    'anomaly_direction': none,
     'store_result_rows_in_own_table': true
   } %}
   {{- return(default_config) -}}

--- a/macros/edr/tests/test_all_columns_anomalies.sql
+++ b/macros/edr/tests/test_all_columns_anomalies.sql
@@ -1,4 +1,4 @@
-{% test all_columns_anomalies(model, column_anomalies, exclude_prefix, exclude_regexp, timestamp_column, sensitivity, backfill_days, where_expression, time_bucket) %}
+{% test all_columns_anomalies(model, column_anomalies, exclude_prefix, exclude_regexp, timestamp_column, sensitivity, backfill_days, where_expression, time_bucket, anomaly_direction) %}
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('alerts_anomaly_detection') }}
@@ -80,7 +80,8 @@
                                                                            backfill_days,
                                                                            all_columns_monitors,
                                                                            columns_only=true,
-                                                                           metric_properties=metric_properties) %}
+                                                                           metric_properties=metric_properties,
+                                                                           anomaly_direction=anomaly_direction) %}
         {% set anomaly_scores_test_table_relation = elementary.create_elementary_test_table(database_name, tests_schema_name, test_table_name, 'anomaly_scores', anomaly_scores_query) %}
 
         {{- elementary.test_log('end', full_table_name, 'all columns') }}

--- a/macros/edr/tests/test_column_anomalies.sql
+++ b/macros/edr/tests/test_column_anomalies.sql
@@ -1,4 +1,4 @@
-{% test column_anomalies(model, column_name, column_anomalies, timestamp_column, sensitivity, backfill_days, where_expression, time_bucket) %}
+{% test column_anomalies(model, column_name, column_anomalies, timestamp_column, sensitivity, backfill_days, where_expression, time_bucket, anomaly_direction) %}
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('alerts_anomaly_detection') }}
@@ -73,7 +73,8 @@
                                                                           backfill_days,
                                                                           column_monitors,
                                                                           column_name,
-                                                                          metric_properties=metric_properties) %}
+                                                                          metric_properties=metric_properties,
+                                                                          anomaly_direction=anomaly_direction) %}
         {{ elementary.debug_log('anomaly_score_query - \n' ~ anomaly_scores_query) }}
         {% set anomaly_scores_test_table_relation = elementary.create_elementary_test_table(database_name, tests_schema_name, test_table_name, 'anomaly_scores', anomaly_scores_query) %}
         {{ elementary.test_log('end', full_table_name, column_name) }}

--- a/macros/edr/tests/test_dimension_anomalies.sql
+++ b/macros/edr/tests/test_dimension_anomalies.sql
@@ -1,4 +1,4 @@
-{% test dimension_anomalies(model, dimensions, where_expression, timestamp_column, sensitivity, backfill_days, time_bucket) %}
+{% test dimension_anomalies(model, dimensions, where_expression, timestamp_column, sensitivity, backfill_days, time_bucket, anomaly_direction) %}
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('alerts_anomaly_detection') }}
@@ -69,7 +69,8 @@
                                                                           backfill_days,
                                                                           ['dimension'],
                                                                           dimensions=dimensions,
-                                                                          metric_properties=metric_properties) %}
+                                                                          metric_properties=metric_properties,
+                                                                          anomaly_direction=anomaly_direction) %}
         {{ elementary.debug_log('dimension monitors anomaly scores query - \n' ~ anomaly_scores_query) }}
         {% set anomaly_scores_test_table_relation = elementary.create_elementary_test_table(database_name, tests_schema_name, test_table_name, 'anomaly_scores', anomaly_scores_query) %}
         {{ elementary.test_log('end', full_table_name) }}

--- a/macros/edr/tests/test_table_anomalies.sql
+++ b/macros/edr/tests/test_table_anomalies.sql
@@ -1,4 +1,4 @@
-{% test table_anomalies(model, table_anomalies, timestamp_column, sensitivity, backfill_days, where_expression, time_bucket, event_timestamp_column=none,freshness_column=none) %}
+{% test table_anomalies(model, table_anomalies, timestamp_column, sensitivity, backfill_days, where_expression, time_bucket, event_timestamp_column=none,freshness_column=none, anomaly_direction=none) %}
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('alerts_anomaly_detection') }}
@@ -67,7 +67,8 @@
                                                                           sensitivity,
                                                                           backfill_days,
                                                                           table_monitors,
-                                                                          metric_properties=metric_properties) %}
+                                                                          metric_properties=metric_properties,
+                                                                          anomaly_direction=anomaly_direction) %}
         {{ elementary.debug_log('table monitors anomaly scores query - \n' ~ anomaly_scores_query) }}
         
         {% set anomaly_scores_test_table_relation = elementary.create_elementary_test_table(database_name, tests_schema_name, test_table_name, 'anomaly_scores', anomaly_scores_query) %}

--- a/macros/edr/tests/test_utils/get_anomaly_query.sql
+++ b/macros/edr/tests/test_utils/get_anomaly_query.sql
@@ -12,6 +12,7 @@
     {% endif %}
 
     {% set sensitivity = elementary.get_test_argument(argument_name='anomaly_sensitivity', value=flattened_test.test_params.sensitivity) %}
+    {% set anomaly_direction = elementary.get_test_argument(argument_name='anomaly_direction', value=flattened_test.test_params.anomaly_direction) %}
     {% set backfill_days = elementary.get_test_argument(argument_name='backfill_days', value=flattened_test.test_params.backfill_days) %}
     {%- set backfill_period = "'-" ~ backfill_days ~ "'" %}
     {%- set anomaly_query -%}
@@ -26,7 +27,7 @@
           *,
           case when
             anomaly_score is not null and
-            {{ elementary.is_score_anomalous_condition(sensitivity) }} and
+            {{ elementary.is_score_anomalous_condition(sensitivity, anomaly_direction) }} and
             bucket_end >= {{ elementary.edr_timeadd('day', backfill_period, elementary.edr_quote(elementary.get_max_bucket_end())) }} and
             training_set_size >= {{ elementary.get_config_var('min_training_set_size') }}
           then TRUE else FALSE end as is_anomalous
@@ -36,10 +37,12 @@
       select
         metric_value as value,
         training_avg as average,
-        case when is_anomalous = TRUE then
+        -- when there's an anomaly we would want to use the last value of the metric (lag), otherwise visually the expactations would look out of bounds
+        case
+        when is_anomalous = TRUE and '{{ anomaly_direction }}' != 'spike' then
          lag(min_metric_value) over (partition by full_table_name, column_name, metric_name, dimension, dimension_value order by bucket_end)
         else min_metric_value end as min_value,
-        case when is_anomalous = TRUE then
+        case when is_anomalous = TRUE and '{{ anomaly_direction }}' != 'drop' then
          lag(max_metric_value) over (partition by full_table_name, column_name, metric_name, dimension, dimension_value order by bucket_end)
         else max_metric_value end as max_value,
         bucket_start as start_time,
@@ -51,12 +54,25 @@
     {{- return(anomaly_query) -}}
 {% endmacro %}
 
-{%- macro is_score_anomalous_condition(sensitivity) -%}
-    {%- set spikes_only_metrics = ['freshness', 'event_freshness'] -%}
+{%- macro set_directional_anomaly(anomaly_direction, anomaly_score, sensitivity) -%}
+    {%- if anomaly_direction is not none -%}
+        {% if anomaly_direction == 'spike' %}
+            anomaly_score > {{ sensitivity }}
+        {% elif anomaly_direction == 'drop' %}
+            anomaly_score < {{ sensitivity * -1 }}
+        {% else %}
+            abs(anomaly_score) > {{ sensitivity }}
+        {% endif %}
+    {% else %}
+        abs(anomaly_score) > {{ sensitivity }}
+    {% endif %}
+{% endmacro %}
 
+{%- macro is_score_anomalous_condition(sensitivity, anomaly_direction) -%}
+    {%- set spikes_only_metrics = ['freshness', 'event_freshness'] -%}
     case when metric_name IN {{ elementary.strings_list_to_tuple(spikes_only_metrics) }} then
             anomaly_score > {{ sensitivity }}
-         else
-            abs(anomaly_score) > {{ sensitivity }}
-         end
+    else
+        {{ elementary.set_directional_anomaly(anomaly_direction, anomaly_score, sensitivity) }}
+     end
 {%- endmacro -%}

--- a/macros/edr/tests/test_volume_anomalies.sql
+++ b/macros/edr/tests/test_volume_anomalies.sql
@@ -1,4 +1,4 @@
-{% test volume_anomalies(model, timestamp_column, sensitivity, backfill_days, where_expression, time_bucket) %}
+{% test volume_anomalies(model, timestamp_column, sensitivity, backfill_days, where_expression, time_bucket, anomaly_direction) %}
   {{ elementary.test_table_anomalies(
       model=model,
       table_anomalies=["row_count"],
@@ -7,7 +7,8 @@
       sensitivity=sensitivity,
       backfill_days=backfill_days,
       where_expression=where_expression,
-      time_bucket=time_bucket
+      time_bucket=time_bucket,
+      anomaly_direction=anomaly_direction
     )
   }}
 {% endtest %}


### PR DESCRIPTION
Added a flag called "anomaly_direction" implying if we want the anomaly test to only test upwards or downwards change,
Added the test to our e2e tests (all the relevant ones - volume, dimension, and column anomalies)
