### PR TITLE
delete_and_insert macro deletes NULLs.

### DIFF
--- a/macros/utils/table_operations/delete_and_insert.sql
+++ b/macros/utils/table_operations/delete_and_insert.sql
@@ -32,7 +32,10 @@
     {% set query %}
         begin transaction;
         {% if delete_relation %}
-            delete from {{ relation }} where {{ delete_column_key }} in (select {{ delete_column_key }} from {{ delete_relation }});
+            delete from {{ relation }}
+            where
+            {{ delete_column_key }} is null
+            or {{ delete_column_key }} in (select {{ delete_column_key }} from {{ delete_relation }});
         {% endif %}
         {% if insert_relation %}
             insert into {{ relation }} select * from {{ insert_relation }};
@@ -47,7 +50,10 @@
 
     {% if delete_relation %}
         {% set delete_query %}
-            delete from {{ relation }} where {{ delete_column_key }} in (select {{ delete_column_key }} from {{ delete_relation }});
+            delete from {{ relation }}
+            where
+            {{ delete_column_key }} is null
+            or {{ delete_column_key }} in (select {{ delete_column_key }} from {{ delete_relation }});
         {% endset %}
         {% do queries.append(delete_query) %}
     {% endif %}


### PR DESCRIPTION
Doing:
```sql
delete from <TABLE> where <COLUMN> in (null);
```
doesn't delete rows where the column's value is `NULL`.
Instead, you have to explicitly match the case for `NULL` like so:
```sql
delete from <TABLE> where <COLUMN> is null;
```

The problem that happened is that if a user was running dbt<1.4.0 in which the caching is not supported,
the `metadata_hash` field was `null` because there was no way to calculate the hash (`local_md5` introduced in dbt v1.4.0).

If the user later upgraded to dbt >=1.4.0, the previous artifacts that had `NULL`s in them were kept and weren't deleted.
This resulted in duplicated rows in the table and therefore the report.
This PR solves this issue.

As a workaround, doing `dbt run -s elementary` should resolve the issue as it ignores the caching and rebuilds the tables.