### PR TITLE
Fixes to dbt_columns slowing down dbt docs

### DIFF
--- a/macros/edr/system/configuration/get_configured_schemas_from_graph.sql
+++ b/macros/edr/system/configuration/get_configured_schemas_from_graph.sql
@@ -1,5 +1,6 @@
 {% macro get_configured_schemas_from_graph() %}
     {% set configured_schemas = [] %}
+    {% set existing_schemas = [] %}
     {% if execute %}
         {% set root_project = context["project_name"] %}
         {% set nodes = elementary.get_nodes_from_graph() %}
@@ -7,11 +8,17 @@
             {% if node.resource_type in ['model', 'source', 'snapshot', 'seed'] and node.package_name == root_project %}
                 {% set database_name = node.database %}
                 {% set schema_name = node.schema %}
-                {% if adapter.check_schema_exists(database_name, schema_name) %}
-                    {% do configured_schemas.append((database_name, schema_name)) %}
-                {% endif %}
+                {% do configured_schemas.append((database_name, schema_name)) %}
             {% endif %}
         {% endfor %}
+        {%- set configured_schemas = configured_schemas | unique | list %}
+        {%- for schema_tupple in configured_schemas %}
+            {% set database_name = schema_tupple[0] %}
+            {% set schema_name = schema_tupple[1] %}
+            {% if adapter.check_schema_exists(database_name, schema_name) %}
+                {% do existing_schemas.append((database_name, schema_name)) %}
+            {% endif %}
+        {%- endfor %}
     {% endif %}
-    {{ return(configured_schemas | unique | list ) }}
+    {{ return(existing_schemas | unique | list ) }}
 {% endmacro %}

--- a/macros/edr/system/hooks/on_run_end.sql
+++ b/macros/edr/system/hooks/on_run_end.sql
@@ -1,22 +1,24 @@
 {% macro on_run_end() %}
-  {% set edr_cli_run = elementary.get_config_var('edr_cli_run') %}
-  {% if not execute or edr_cli_run %}
-    {{ return('') }}
-  {% endif %}
+  {%- if execute and flags.WHICH not in ['generate', 'serve'] %}
+      {% set edr_cli_run = elementary.get_config_var('edr_cli_run') %}
+      {% if not execute or edr_cli_run %}
+        {{ return('') }}
+      {% endif %}
 
-  {% if not elementary.get_config_var('disable_dbt_artifacts_autoupload') %}
-    {{ elementary.upload_dbt_artifacts() }}
-  {% endif %}
+      {% if not elementary.get_config_var('disable_dbt_artifacts_autoupload') %}
+        {{ elementary.upload_dbt_artifacts() }}
+      {% endif %}
 
-  {% if not elementary.get_config_var('disable_run_results') %}
-    {{ elementary.upload_run_results() }}
-  {% endif %}
+      {% if not elementary.get_config_var('disable_run_results') %}
+        {{ elementary.upload_run_results() }}
+      {% endif %}
 
-  {% if flags.WHICH in ['test', 'build'] and not elementary.get_config_var('disable_tests_results') %}
-    {{ elementary.handle_tests_results() }}
-  {% endif %}
+      {% if flags.WHICH in ['test', 'build'] and not elementary.get_config_var('disable_tests_results') %}
+        {{ elementary.handle_tests_results() }}
+      {% endif %}
 
-  {% if not elementary.get_config_var('disable_dbt_invocation_autoupload') %}
-    {{ elementary.upload_dbt_invocation() }}
+      {% if not elementary.get_config_var('disable_dbt_invocation_autoupload') %}
+        {{ elementary.upload_dbt_invocation() }}
+      {% endif %}
   {% endif %}
 {% endmacro %}

--- a/macros/edr/system/system_utils/get_config_var.sql
+++ b/macros/edr/system/system_utils/get_config_var.sql
@@ -32,6 +32,7 @@
     'disable_tests_results': false,
     'disable_dbt_artifacts_autoupload': false,
     'disable_dbt_invocation_autoupload': false,
+    'enable_dbt_columns': true,
     'disable_skipped_model_alerts': true,
     'disable_skipped_test_alerts': true,
     'dbt_artifacts_chunk_size': 5000,

--- a/models/edr/dbt_artifacts/dbt_columns.sql
+++ b/models/edr/dbt_artifacts/dbt_columns.sql
@@ -1,7 +1,7 @@
 {{
   config(
     materialized = 'view',
-    enabled = target.type != 'databricks' and target.type != 'spark' | as_bool()
+    enabled = elementary.get_config_var('enable_dbt_columns') and target.type != 'databricks' and target.type != 'spark' | as_bool()
   )
 }}
 


### PR DESCRIPTION
1. Made the on-run-end hook not run in docs generate.
2. Improved the logic `get_configured_schemas_from_graph` to save tons of queries on the db.
3. Added a var to disable the new model in case we need to.
