### PR TITLE
add materialization to run results table

### DIFF
--- a/macros/edr/dbt_artifacts/upload_run_results.sql
+++ b/macros/edr/dbt_artifacts/upload_run_results.sql
@@ -28,7 +28,8 @@
                                                                        ('compiled_code', 'long_string'),
                                                                        ('failures', 'bigint'),
                                                                        ('query_id', 'string'),
-                                                                       ('thread_id', 'string')
+                                                                       ('thread_id', 'string'),
+                                                                       ('materialization', 'string')
                                                                        ]) %}
     {{ return(dbt_run_results_empty_table_query) }}
 {% endmacro %}
@@ -36,6 +37,7 @@
 {% macro flatten_run_result(run_result) %}
     {% set run_result_dict = run_result.to_dict() %}
     {% set node = elementary.safe_get_with_default(run_result_dict, 'node', {}) %}
+    {% set config_dict = elementary.safe_get_with_default(node, 'config', {}) %}
     {% set flatten_run_result_dict = {
         'model_execution_id': elementary.get_node_execution_id(node),
         'invocation_id': invocation_id,
@@ -55,7 +57,8 @@
         'compiled_code': elementary.get_compiled_model_code_text(node),
         'failures': run_result_dict.get('failures'),
         'query_id': run_result_dict.get('adapter_response', {}).get('query_id'),
-        'thread_id': run_result_dict.get('thread_id')
+        'thread_id': run_result_dict.get('thread_id'),
+        'materialization': config_dict.get('materialized')
     }%}
 
     {% set timings = elementary.safe_get_with_default(run_result_dict, 'timing', []) %}

--- a/models/edr/run_results/model_run_results.sql
+++ b/models/edr/run_results/model_run_results.sql
@@ -32,7 +32,7 @@ SELECT
     run_results.thread_id,
     models.database_name,
     models.schema_name,
-    models.materialization,
+    coalesce(run_results.materialization, models.materialization) as materialization,
     models.tags,
     models.package_name,
     models.path,

--- a/models/edr/run_results/snapshot_run_results.sql
+++ b/models/edr/run_results/snapshot_run_results.sql
@@ -32,7 +32,7 @@ SELECT
     run_results.thread_id,
     snapshots.database_name,
     snapshots.schema_name,
-    snapshots.materialization,
+    coalesce(run_results.materialization, snapshots.materialization) as materialization,
     snapshots.tags,
     snapshots.package_name,
     snapshots.path,


### PR DESCRIPTION
Adds the materialization field to the dbt_run_results table, addressing ELE-847.

<img width="1120" alt="Screenshot 2023-05-16 at 4 04 38 PM" src="https://github.com/elementary-data/dbt-data-reliability/assets/60354578/38776adc-e59d-4b22-ac91-bab338dff792">
