### PR TITLE
ELE-917 delete the temp tables on atomic upload

### DIFF
--- a/macros/utils/table_operations/delete_and_insert.sql
+++ b/macros/utils/table_operations/delete_and_insert.sql
@@ -21,6 +21,15 @@
     {% for query in queries %}
         {% do elementary.run_query(query) %}
     {% endfor %}
+
+    {# Make sure we delete the temp tables we created #}
+    {% if delete_relation %}
+        {% do adapter.drop_relation(delete_relation) %}
+    {% endif %}
+    {% if insert_relation %}
+        {% do adapter.drop_relation(insert_relation) %}
+    {% endif %}
+
     {% do elementary.file_log("Finished deleting from and inserting to: {}".format(relation)) %}
 {% endmacro %}
 

--- a/macros/utils/table_operations/replace_table_data.sql
+++ b/macros/utils/table_operations/replace_table_data.sql
@@ -6,6 +6,7 @@
 {% macro default__replace_table_data(relation, rows) %}
     {% set intermediate_relation = elementary.create_intermediate_relation(relation, rows, temporary=True) %}
     {% do elementary.run_query(dbt.create_table_as(False, relation, 'select * from {}'.format(intermediate_relation))) %}
+    {% do adapter.drop_relation(intermediate_relation) %}
 {% endmacro %}
 
 {# Spark / Databricks - truncate and insert (non-atomic) #}
@@ -26,4 +27,6 @@
         commit;
     {% endset %}
     {% do elementary.run_query(query) %}
+
+    {% do adapter.drop_relation(intermediate_relation) %}
 {% endmacro %}


### PR DESCRIPTION
When uploading the artifacts on our dbt package we create temp tables.
On BigQuery those tables are not being dropped automatically at the end of the session (they have an expiration time of 12 hours instead).

We delete those temp tables on the end of the atomic upload.