### PR TITLE
Ele 983 generate job url and job run url

### DIFF
--- a/macros/edr/dbt_artifacts/upload_dbt_invocation.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_invocation.sql
@@ -6,6 +6,9 @@
 
   {% do elementary.file_log("Uploading dbt invocation.") %}
   {% set now_str = elementary.datetime_now_utc_as_string() %}
+  {% set orchestrator = elementary.get_orchestrator() %}
+  {% set job_id = elementary.get_var("job_id", ["JOB_ID", "DBT_JOB_ID", "DBT_CLOUD_JOB_ID"]) %}
+  {% set job_run_id = elementary.get_var("job_run_id", ["DBT_JOB_RUN_ID", "DBT_CLOUD_RUN_ID", "GITHUB_RUN_ID"]) %}
   {% set dbt_invocation = {
       'invocation_id': invocation_id,
       'run_started_at': elementary.run_started_at_as_string(),
@@ -25,8 +28,8 @@
       'selected': elementary.get_invocation_select_filter(),
       'yaml_selector': elementary.get_invocation_yaml_selector(),
       'project_name': elementary.get_project_name(),
-      'job_id': elementary.get_var("job_id", ["JOB_ID", "DBT_JOB_ID", "DBT_CLOUD_JOB_ID"]),
-      'job_run_id': elementary.get_var("job_run_id", ["DBT_JOB_RUN_ID", "DBT_CLOUD_RUN_ID", "GITHUB_RUN_ID"]),
+      'job_id': job_id,
+      'job_run_id': job_run_id,
       'job_name': elementary.get_var("job_name", ["JOB_NAME", "DBT_JOB_NAME"]),
       'env': elementary.get_first_env_var(["DBT_ENV"]),
       'env_id': elementary.get_first_env_var(["DBT_ENV_ID"]),
@@ -35,7 +38,7 @@
       'cause': elementary.get_first_env_var(["DBT_CAUSE", "DBT_CLOUD_RUN_REASON"]),
       'pull_request_id': elementary.get_first_env_var(["DBT_PULL_REQUEST_ID", "DBT_CLOUD_PR_ID", "GITHUB_HEAD_REF"]),
       'git_sha': elementary.get_first_env_var(["DBT_GIT_SHA", "DBT_CLOUD_GIT_SHA", "GITHUB_SHA"]),
-      'orchestrator': elementary.get_orchestrator(),
+      'orchestrator': orchestrator,
       'dbt_user': elementary.get_first_env_var(["DBT_USER"]),
       'job_url': elementary.get_job_url(),
       'job_run_url': elementary.null_string(),

--- a/macros/edr/dbt_artifacts/upload_dbt_invocation.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_invocation.sql
@@ -151,7 +151,7 @@
 {% endmacro %}
 
 {% macro get_job_run_url(orchestrator, job_id, job_run_id) %}
-  {% set var_value = elementary.get_var("job_url", ["JOB_RUN_URL", "DBT_JOB_RUN_URL"]) %}
+  {% set var_value = elementary.get_var("job_run_url", ["JOB_RUN_URL", "DBT_JOB_RUN_URL"]) %}
   {% if var_value %}
     {% do return(var_value) %}
   {% endif %}

--- a/macros/edr/dbt_artifacts/upload_dbt_invocation.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_invocation.sql
@@ -129,7 +129,7 @@
     {% do return(var_value) %}
   {% endif %}
   {% if orchestrator == 'airflow' %}
-    {% set server_url = elementary.get_var('orchestrator_domain', ["ORCHESTRATOR_DOMAIN"]) %}
+    {% set server_url = elementary.get_var('airflow_url', ["AIRFLOW_URL"]) %}
     {% set airflow_job_url = server_url ~ "/dags/" ~ job_id ~ "/grid" %}
     {% do return(airflow_job_url) %}
   {% elif orchestrator == 'dbt_cloud' %}
@@ -156,7 +156,7 @@
     {% do return(var_value) %}
   {% endif %}
   {% if orchestrator == 'airflow' %}
-    {% set server_url = elementary.get_var('orchestrator_domain', ["ORCHESTRATOR_DOMAIN"]) %}
+    {% set server_url = elementary.get_var('airflow_url', ["AIRFLOW_URL"]) %}
     {% set airflow_job_url = server_url ~ "/dags/" ~ job_id ~ "/grid?dag_run_id=" ~ job_run_id %}
     {% do return(airflow_job_url) %}
   {% elif orchestrator == 'dbt_cloud' %}

--- a/macros/edr/dbt_artifacts/upload_dbt_invocation.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_invocation.sql
@@ -40,8 +40,8 @@
       'git_sha': elementary.get_first_env_var(["DBT_GIT_SHA", "DBT_CLOUD_GIT_SHA", "GITHUB_SHA"]),
       'orchestrator': orchestrator,
       'dbt_user': elementary.get_first_env_var(["DBT_USER"]),
-      'job_run_url': elementary.null_string(),
       'job_url': elementary.get_job_url(orchestrator, job_id),
+      'job_run_url': elementary.get_job_run_url(orchestrator, job_id, job_run_id),
       'account_id': elementary.get_var("account_id", ["ACCOUNT_ID"]),
   } %}
   {% do elementary.insert_rows(relation, [dbt_invocation], should_commit=true) %}
@@ -150,6 +150,23 @@
   {% do return(none) %}
 {% endmacro %}
 
+{% macro get_job_run_url(orchestrator, job_id, job_run_id) %}
+  {% set var_value = elementary.get_var("job_url", ["JOB_RUN_URL", "DBT_JOB_RUN_URL"]) %}
+  {% if var_value %}
+    {% do return(var_value) %}
+  {% endif %}
+  {% if orchestrator == 'airflow' %}
+    {% set server_url = elementary.get_var('orchestrator_domain', ["ORCHESTRATOR_DOMAIN"]) %}
+    {% set airflow_job_url = server_url ~ "/dags/" ~ job_id ~ "/grid?dag_run_id=" ~ job_run_id %}
+    {% do return(airflow_job_url) %}
+  {% elif orchestrator == 'dbt_cloud' %}
+    {% set account_id = elementary.get_var('account_id', ['ACCOUNT_ID']) %}
+    {% set dbt_cloud_project_id = elementary.get_first_env_var(['DBT_CLOUD_PROJECT_ID']) %}
+    {% set dbt_cloud_run_id = elementary.get_first_env_var(['DBT_CLOUD_RUN_ID']) %}
+
+    {% set dbt_cloud_job_url = "https://cloud.getdbt.com/deploy/" ~ account_id ~ "/projects/" ~ dbt_cloud_project_id ~ "/runs/" ~ dbt_cloud_run_id %}
+    {% do return(dbt_cloud_job_url) %}
+  {% elif orchestrator == 'github_actions' %}
     {% set server_url = elementary.get_first_env_var(["GITHUB_SERVER_URL"]) %}
     {% set repository = elementary.get_first_env_var(["GITHUB_REPOSITORY"]) %}
     {% set run_id = elementary.get_first_env_var(["GITHUB_RUN_ID"]) %}

--- a/macros/utils/cross_db_utils/current_timestamp.sql
+++ b/macros/utils/cross_db_utils/current_timestamp.sql
@@ -15,7 +15,7 @@
     {% if not macro %}
         {{ exceptions.raise_compiler_error("Did not find a `current_timestamp` macro.") }}
     {% endif %}
-    {{ return(macro()) }}§
+    {{ return(macro()) }}
 {%- endmacro %}
 
 {% macro spark__edr_current_timestamp() %}


### PR DESCRIPTION
Support job_url and job_run_url fields.
Generate values for:
- Airflow
  - job_url - [domain]/dags/[job_id]/grid
  - job_run_url - [domain]/dags/[job_id]/grid?dag_run_id=[job_run_id]
- dbt Cloud
  - job_url - https://cloud.getdbt.com/deploy/[account_id]/projects/[DBT_CLOUD_PROJECT_ID]/jobs/[DBT_CLOUD_JOB_ID]
  - job_run_url - https://cloud.getdbt.com/deploy/[account_id]/projects/[DBT_CLOUD_PROJECT_ID]/runs/[DBT_CLOUD_RUN_ID]
- Github Actions
  - same value for job_url and job_run_url
  - [GITHUB_SERVER_URL]/[GITHUB_REPOSITORY]/actions/runs/[GITHUB_RUN_ID]
  
  
### I run:
<img width="552" alt="Screen Shot 2023-06-13 at 9 17 15" src="https://github.com/elementary-data/dbt-data-reliability/assets/31591071/fd7cd604-2f10-4b62-b90c-57bfaffe5369">

### The results in dbt_invocations table:
<img width="1786" alt="Screen Shot 2023-06-13 at 9 20 07" src="https://github.com/elementary-data/dbt-data-reliability/assets/31591071/4b2d626b-d3a1-4591-acbe-c898e56712e3">

