### PR TITLE
add pg_catalog to redshift macros so they work with late binding views

### DIFF
--- a/macros/edr/metadata_collection/get_columns_from_information_schema.sql
+++ b/macros/edr/metadata_collection/get_columns_from_information_schema.sql
@@ -27,7 +27,7 @@
         upper(table_name) as table_name,
         upper(column_name) as column_name,
         data_type
-    from svv_columns
+    from pg_catalog.svv_columns
     where upper(table_schema) = upper('{{ schema_name }}')
 
 {% endmacro %}

--- a/macros/edr/metadata_collection/get_tables_from_information_schema.sql
+++ b/macros/edr/metadata_collection/get_tables_from_information_schema.sql
@@ -50,7 +50,7 @@
             upper(table_catalog) as database_name,
             upper(table_schema) as schema_name,
             upper(table_name) as table_name
-        from svv_tables
+        from pg_catalog.svv_tables
             where upper(table_schema) = upper('{{ schema_name }}') and upper(table_catalog) = upper('{{ database_name }}')
 
     )


### PR DESCRIPTION
We have our Redshift DBT project configured for all views to be 'late binding' - this requires all references to tables to be fully qualified. 

Alternatively, the documentation could be updated to say: `+bind: true` for the elementary models. However, this change should work with both configurations.

References:
https://docs.getdbt.com/reference/resource-configs/redshift-configs#late-binding-views
https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_VIEW.html#r_CREATE_VIEW_late-binding-views

Without these changes, running `dbt run --select elementary` with `+bind: false` set for models in `dbt_project.yml` results in the following error:
```
20:39:08  Database Error in model filtered_information_schema_columns (models/edr/metadata_store/filtered_information_schema_columns.sql)
20:39:08    All the relation names inside should be qualified when creating VIEW WITH NO SCHEMA BINDING.
20:39:08    compiled Code at target/run/elementary/models/edr/metadata_store/filtered_information_schema_columns.sql
20:39:08
20:39:08  Database Error in model filtered_information_schema_tables (models/edr/metadata_store/filtered_information_schema_tables.sql)
20:39:08    All the relation names inside should be qualified when creating VIEW WITH NO SCHEMA BINDING.
20:39:08    compiled Code at target/run/elementary/models/edr/metadata_store/filtered_information_schema_tables.sql
20:39:08
20:39:08  Database Error in model dbt_columns (models/edr/dbt_artifacts/dbt_columns.sql)
20:39:08    All the relation names inside should be qualified when creating VIEW WITH NO SCHEMA BINDING.
20:39:08    compiled Code at target/run/elementary/models/edr/dbt_artifacts/dbt_columns.sql
```