### PR TITLE
Added databricks specific information schema macros

### DIFF
--- a/macros/edr/metadata_collection/get_columns_from_information_schema.sql
+++ b/macros/edr/metadata_collection/get_columns_from_information_schema.sql
@@ -45,6 +45,25 @@
 
 {% endmacro %}
 
+{% macro databricks__get_columns_from_information_schema(database_name, schema_name) %}
+{% set schema_relation = api.Relation.create(database=database_name, schema=schema_name).without_identifier() %}
+
+{% if schema_relation.database %}
+    select
+        upper(table_catalog || '.' || table_schema || '.' || table_name) as full_table_name,
+        upper(table_catalog) as database_name,
+        upper(table_schema) as schema_name,
+        upper(table_name) as table_name,
+        upper(column_name) as column_name,
+        data_type
+    from {{ database_name }}.information_schema.columns
+    where upper(table_schema) = upper('{{ schema_name }}')
+{% else %}
+    {{ elementary.get_empty_columns_from_information_schema_table() }}
+{% endif %}
+
+{% endmacro %}
+
 {% macro spark__get_columns_from_information_schema(database_name, schema_name) %}
     {{ elementary.get_empty_columns_from_information_schema_table() }}
 {% endmacro %}

--- a/macros/edr/metadata_collection/get_tables_from_information_schema.sql
+++ b/macros/edr/metadata_collection/get_tables_from_information_schema.sql
@@ -86,3 +86,44 @@
         table_name
     from information_schema_tables
 {% endmacro %}
+
+{% macro databricks__get_tables_from_information_schema(schema_tuple) %}
+    {%- set database_name, schema_name = schema_tuple %}
+    {% set schema_relation = api.Relation.create(database=database_name, schema=schema_name).without_identifier() %}
+
+    {% if schema_relation.database %}
+        with information_schema_tables as (
+
+            select
+                upper(table_catalog) as database_name,
+                upper(table_schema) as schema_name,
+                upper(table_name) as table_name
+            from {{ database_name }}.information_schema.tables
+            where upper(table_schema) = upper('{{ schema_name }}')
+
+        ),
+
+        information_schema_schemata as (
+
+            select
+                upper(catalog_name) as database_name,
+                upper(schema_name) as schema_name
+            from {{ database_name }}.information_schema.schemata
+            where upper(schema_name) = upper('{{ schema_name }}')
+
+        )
+
+        select
+            case when tables.table_name is not null
+                then {{ elementary.full_table_name('TABLES') }}
+            else null end as full_table_name,
+            upper(schemas.database_name || '.' || schemas.schema_name) as full_schema_name,
+            schemas.database_name as database_name,
+            schemas.schema_name as schema_name,
+            tables.table_name
+        from information_schema_tables as tables
+        full outer join information_schema_schemata as schemas
+        on (tables.database_name = schemas.database_name and tables.schema_name = schemas.schema_name)
+    {% endif %}
+
+{% endmacro %}


### PR DESCRIPTION
Changes made to:

- macros/edr/metadata_collection/get_columns_from_information_schema.sql
- macros/edr/metadata_collection/get_tables_from_information_schema.sql

For fixing - [ELE-1062](https://linear.app/elementary/issue/ELE-1062/make-information-schema-macros-work-for-databricks-unity-catalog)

Tested with Unity Catalog enabled as well as disabled 