### PR TITLE
Fixes to dimension anomalies and added incremental to e2e tests

### DIFF
--- a/integration_tests/macros/e2e_tests/validate_dimensions_anomalies.sql
+++ b/integration_tests/macros/e2e_tests/validate_dimensions_anomalies.sql
@@ -23,5 +23,5 @@
         {%- endif %}
     {% endfor %}
 
-    {{ assert_lists_contain_same_items(should_fail_names, ['elementary_dimension_anomalies_dimension_anomalies_platform', 'elementary_dimension_anomalies_dimension_anomalies_platform__updated_at', 'elementary_dimension_anomalies_dimension_anomalies_platform__version__updated_at']) }}
+    {{ assert_lists_contain_same_items(should_fail_names, ['elementary_dimension_anomalies_dimension_anomalies_platform__updated_at', 'elementary_dimension_anomalies_dimension_anomalies_platform__version__updated_at']) }}
 {% endmacro %}

--- a/integration_tests/models/any_type_column_anomalies.sql
+++ b/integration_tests/models/any_type_column_anomalies.sql
@@ -3,7 +3,10 @@
 ) }}
 
 with training as (
-select * from {{ ref('any_type_column_anomalies_training') }}
+    select * from {{ ref('any_type_column_anomalies_training') }}
+    {% if is_incremental() %}
+    where updated_at > (select max(updated_at) from {{ this }})
+    {% endif %}
 ),
 
 {% if var("stage") == "validation" %}
@@ -38,6 +41,3 @@ select * from {{ ref('any_type_column_anomalies_training') }}
  )
 
 select * from final
-{% if is_incremental() %}
-    where updated_at > (select max(updated_at) from {{ this }})
-{% endif %}

--- a/integration_tests/models/any_type_column_anomalies.sql
+++ b/integration_tests/models/any_type_column_anomalies.sql
@@ -5,7 +5,7 @@
 with training as (
     select * from {{ ref('any_type_column_anomalies_training') }}
     {% if is_incremental() %}
-    where updated_at > (select max(updated_at) from {{ this }})
+        where updated_at > (select max(updated_at) from {{ this }})
     {% endif %}
 ),
 

--- a/integration_tests/models/any_type_column_anomalies.sql
+++ b/integration_tests/models/any_type_column_anomalies.sql
@@ -1,5 +1,9 @@
+{{ config(
+    materialized="incremental"
+) }}
+
 with training as (
-    select * from {{ ref('any_type_column_anomalies_training') }}
+select * from {{ ref('any_type_column_anomalies_training') }}
 ),
 
 {% if var("stage") == "validation" %}
@@ -34,3 +38,6 @@ with training as (
  )
 
 select * from final
+{% if is_incremental() %}
+    where updated_at > (select max(updated_at) from {{ this }})
+{% endif %}

--- a/integration_tests/models/copy_numeric_column_anomalies.sql
+++ b/integration_tests/models/copy_numeric_column_anomalies.sql
@@ -1,1 +1,13 @@
-select * from {{ ref("numeric_column_anomalies") }}
+select
+        {{ elementary.edr_cast_as_timestanp('updated_at') }},
+        occurred_at,
+        min,
+        max,
+        zero_count,
+        zero_percent,
+        average,
+        standard_deviation,
+        variance,
+        sum
+
+from {{ ref("numeric_column_anomalies") }}

--- a/integration_tests/models/copy_numeric_column_anomalies.sql
+++ b/integration_tests/models/copy_numeric_column_anomalies.sql
@@ -1,13 +1,1 @@
-select
-        {{ elementary.edr_cast_as_timestamp('updated_at') }},
-        occurred_at,
-        min,
-        max,
-        zero_count,
-        zero_percent,
-        average,
-        standard_deviation,
-        variance,
-        sum
-
-from {{ ref("numeric_column_anomalies") }}
+select * from {{ ref("numeric_column_anomalies") }}

--- a/integration_tests/models/copy_numeric_column_anomalies.sql
+++ b/integration_tests/models/copy_numeric_column_anomalies.sql
@@ -1,5 +1,5 @@
 select
-        {{ elementary.edr_cast_as_timestanp('updated_at') }},
+        {{ elementary.edr_cast_as_timestamp('updated_at') }},
         occurred_at,
         min,
         max,

--- a/integration_tests/models/dimension_anomalies.sql
+++ b/integration_tests/models/dimension_anomalies.sql
@@ -1,3 +1,7 @@
+{{ config(
+    materialized="incremental"
+) }}
+
 with training as (
     select * from {{ ref('dimension_anomalies_training') }}
 ),
@@ -28,3 +32,6 @@ with training as (
  )
 
 select * from final
+{% if is_incremental() %}
+    where updated_at > (select max(updated_at) from {{ this }})
+{% endif %}

--- a/integration_tests/models/dimension_anomalies.sql
+++ b/integration_tests/models/dimension_anomalies.sql
@@ -4,6 +4,9 @@
 
 with training as (
     select * from {{ ref('dimension_anomalies_training') }}
+    {% if is_incremental() %}
+        where updated_at > (select max(updated_at) from {{ this }})
+    {% endif %}
 ),
 
 {% if var("stage") == "validation" %}
@@ -32,6 +35,3 @@ with training as (
  )
 
 select * from final
-{% if is_incremental() %}
-    where updated_at > (select max(updated_at) from {{ this }})
-{% endif %}

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -24,8 +24,6 @@ models:
       and comma,
       and even a string like this 'wow'. You know, these $##$34#@#!^ can also be helpful
       WDYT?
-    config:
-      tags: ["validation_stage"]
       elementary:
         timestamp_column: updated_at
     tests:
@@ -64,8 +62,6 @@ models:
           tags: ["spike_directional_anomalies"]
 
   - name: no_timestamp_anomalies
-    config:
-      tags: ["validation_stage"]
     meta:
       owner: "elon@elementary-data.com, or@elementary-data.com"
       subscribers: ["elon@elementary-data.com"]
@@ -88,8 +84,6 @@ models:
       owner: "egk"
       subscribers: "elon, egk"
     description: We use this model to test dimension anomalies
-    config:
-      tags: ["validation_stage"]
     tests:
       - elementary.dimension_anomalies:
           tags: ["dimension_anomalies", "should_fail"]
@@ -145,7 +139,6 @@ models:
     config:
       elementary:
         timestamp_column: updated_at
-      tags: ["validation_stage"]
     columns:
       - name: "min_length"
         tests:
@@ -166,7 +159,6 @@ models:
       owner: "@or"
       tags: ["marketing"]
     config:
-      tags: ["validation_stage"]
       elementary:
         timestamp_column: updated_at
     tests:
@@ -221,7 +213,6 @@ models:
     config:
       elementary:
         timestamp_column: updated_at
-      tags: ["validation_stage"]
     tests:
       - elementary.volume_anomalies:
           tags: ["table_anomalies"]
@@ -335,8 +326,6 @@ models:
           tags: ["numeric_column_anomalies"]
 
   - name: groups
-    config:
-      tags: ["validation_stage"]
     columns:
       - name: group_a
         data_type: "{{ 'strIng' if target.type == 'bigquery' else 'CHArACTER varying' if target.type == 'redshift' else 'teXt' }}"
@@ -354,8 +343,7 @@ models:
           enforce_types: true
 
   - name: stats_players
-    config:
-      tags: ["validation_stage"]
+
     columns:
       - name: player
         data_type: "{{ 'STRING' if target.type == 'bigquery' else 'character varying' if target.type == 'redshift' else 'TEXT' }}"
@@ -373,15 +361,11 @@ models:
           enforce_types: true
 
   - name: stats_team
-    config:
-      tags: ["validation_stage"]
     tests:
       - elementary.schema_changes:
           tags: ["schema_changes"]
 
   - name: users_per_day_weekly_seasonal
-    config:
-      tags: ["validation_stage"]
     description: >
       Volume anomalies on the training should fail when seasonality is Off and pass when seasonality is On. 
       When Validation data is added, should fail when seasonality is On and pass when seasonality is Off.

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -18,6 +18,8 @@ models:
     meta:
       owner: ["@edr"]
       subscribers: "@egk"
+    config:
+      tags: ["validation_stage"]
     description: >
       This is a very weird description
       with breaklines
@@ -63,6 +65,8 @@ models:
           tags: ["spike_directional_anomalies"]
 
   - name: no_timestamp_anomalies
+    config:
+      tags: ["validation_stage"]
     meta:
       owner: "elon@elementary-data.com, or@elementary-data.com"
       subscribers: ["elon@elementary-data.com"]
@@ -85,6 +89,8 @@ models:
       owner: "egk"
       subscribers: "elon, egk"
     description: We use this model to test dimension anomalies
+    config:
+      tags: ["validation_stage"]
     tests:
       - elementary.dimension_anomalies:
           tags: ["dimension_anomalies", "should_fail"]
@@ -121,7 +127,7 @@ models:
       - elementary.dimension_anomalies:
           dimensions:
             - platform
-          tags: ["dimension_anomalies", "should_fail"]
+          tags: ["dimension_anomalies"]
           alias: "dimension_anomalies_no_timestamp"
 
   - name: error_model
@@ -140,6 +146,7 @@ models:
     config:
       elementary:
         timestamp_column: updated_at
+      tags: ["validation_stage"]
     columns:
       - name: "min_length"
         tests:
@@ -160,6 +167,7 @@ models:
       owner: "@or"
       tags: ["marketing"]
     config:
+      tags: ["validation_stage"]
       elementary:
         timestamp_column: updated_at
     tests:
@@ -214,6 +222,7 @@ models:
     config:
       elementary:
         timestamp_column: updated_at
+      tags: ["validation_stage"]
     tests:
       - elementary.volume_anomalies:
           tags: ["table_anomalies"]
@@ -327,6 +336,8 @@ models:
           tags: ["numeric_column_anomalies"]
 
   - name: groups
+    config:
+      tags: ["validation_stage"]
     columns:
       - name: group_a
         data_type: "{{ 'strIng' if target.type == 'bigquery' else 'CHArACTER varying' if target.type == 'redshift' else 'teXt' }}"
@@ -344,6 +355,8 @@ models:
           enforce_types: true
 
   - name: stats_players
+    config:
+      tags: ["validation_stage"]
     columns:
       - name: player
         data_type: "{{ 'STRING' if target.type == 'bigquery' else 'character varying' if target.type == 'redshift' else 'TEXT' }}"
@@ -361,11 +374,15 @@ models:
           enforce_types: true
 
   - name: stats_team
+    config:
+      tags: ["validation_stage"]
     tests:
       - elementary.schema_changes:
           tags: ["schema_changes"]
 
   - name: users_per_day_weekly_seasonal
+    config:
+      tags: ["validation_stage"]
     description: >
       Volume anomalies on the training should fail when seasonality is Off and pass when seasonality is On. 
       When Validation data is added, should fail when seasonality is On and pass when seasonality is Off.

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -41,7 +41,7 @@ models:
               WDYT?
           config:
             severity: warn
-          tags: ["table_anomalies"]
+          tags: ["table_anomalies","incremental_table_anomalies"]
       - elementary.volume_anomalies:
           time_bucket:
             period: week

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -18,8 +18,6 @@ models:
     meta:
       owner: ["@edr"]
       subscribers: "@egk"
-    config:
-      tags: ["validation_stage"]
     description: >
       This is a very weird description
       with breaklines
@@ -27,6 +25,7 @@ models:
       and even a string like this 'wow'. You know, these $##$34#@#!^ can also be helpful
       WDYT?
     config:
+      tags: ["validation_stage"]
       elementary:
         timestamp_column: updated_at
     tests:

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -24,6 +24,7 @@ models:
       and comma,
       and even a string like this 'wow'. You know, these $##$34#@#!^ can also be helpful
       WDYT?
+    config:
       elementary:
         timestamp_column: updated_at
     tests:
@@ -40,7 +41,7 @@ models:
               WDYT?
           config:
             severity: warn
-          tags: ["table_anomalies","incremental_table_anomalies"]
+          tags: ["table_anomalies", "incremental_table_anomalies"]
       - elementary.volume_anomalies:
           time_bucket:
             period: week
@@ -120,7 +121,7 @@ models:
       - elementary.dimension_anomalies:
           dimensions:
             - platform
-          tags: ["dimension_anomalies"]
+          tags: ["dimension_anomalies", "should_fail"]
           alias: "dimension_anomalies_no_timestamp"
 
   - name: error_model
@@ -343,7 +344,6 @@ models:
           enforce_types: true
 
   - name: stats_players
-
     columns:
       - name: player
         data_type: "{{ 'STRING' if target.type == 'bigquery' else 'character varying' if target.type == 'redshift' else 'TEXT' }}"

--- a/integration_tests/run_e2e_tests.py
+++ b/integration_tests/run_e2e_tests.py
@@ -143,6 +143,20 @@ def e2e_tests(
         ]
         test_results.extend(results)
 
+# Calculating metrics in training stage to test incremental models monitoring
+    if "column" in test_types:
+        dbt_runner.test(select="tag:all_any_type_columns_anomalies")
+    if "table" in test_types:
+        dbt_runner.test(
+            select="tag:incremental_table_anomalies",
+            vars={"custom_run_started_at": "1969-12-30 00:01:00"},
+        )
+    if "dimension" in test_types:
+        dbt_runner.test(
+            select="tag:dimension_anomalies",
+            vars={"custom_run_started_at": "1969-12-29 00:01:00"},
+        )
+
     if "table" in test_types:
         dbt_runner.test(select="tag:table_anomalies")
         results = [

--- a/integration_tests/run_e2e_tests.py
+++ b/integration_tests/run_e2e_tests.py
@@ -217,7 +217,10 @@ def e2e_tests(
         dbt_runner.test(select="tag:schema_changes")
         dbt_runner.test(select="tag:schema_changes_from_baseline")
 
-    dbt_runner.run(vars={"stage": "validation"})
+    dbt_runner.run(
+        select="tag:validation_stage",
+        vars={"stage": "validation"}
+    )
 
     if "directional_anomalies" in test_types:
         dbt_runner.test(select="tag:drop_directional_anomalies")

--- a/integration_tests/run_e2e_tests.py
+++ b/integration_tests/run_e2e_tests.py
@@ -217,10 +217,7 @@ def e2e_tests(
         dbt_runner.test(select="tag:schema_changes")
         dbt_runner.test(select="tag:schema_changes_from_baseline")
 
-    dbt_runner.run(
-        select="tag:validation_stage",
-        vars={"stage": "validation"}
-    )
+    dbt_runner.run(vars={"stage": "validation"})
 
     if "directional_anomalies" in test_types:
         dbt_runner.test(select="tag:drop_directional_anomalies")

--- a/integration_tests/run_e2e_tests.py
+++ b/integration_tests/run_e2e_tests.py
@@ -143,7 +143,8 @@ def e2e_tests(
         ]
         test_results.extend(results)
 
-# Calculating metrics in training stage to test incremental models monitoring
+
+    # Calculating metrics in training stage to test incremental models monitoring
     if "column" in test_types:
         dbt_runner.test(select="tag:all_any_type_columns_anomalies")
     if "table" in test_types:

--- a/macros/edr/data_monitoring/monitors_query/dimension_monitoring_query.sql
+++ b/macros/edr/data_monitoring/monitors_query/dimension_monitoring_query.sql
@@ -140,8 +140,7 @@
             dimension,
             dimension_value,
             metric_properties
-        from
-            row_count
+        from row_count
         where (metric_value is not null and cast(metric_value as {{ elementary.edr_type_int() }}) < {{ elementary.get_config_var('max_int') }}) or
             metric_value is null
         )
@@ -188,7 +187,7 @@
                    dimension_value,
                    0 as row_count_value
             from training_set_dimensions
-            where dimension_value not in (select distinct dimension_value from row_count_values)
+            where dimension_value not in (select distinct dimension_value from row_count_values) results
         ),
 
         {# Union between current row count for each dimension, and the "hydrated" metrics of the test until this run #}

--- a/macros/edr/data_monitoring/monitors_query/dimension_monitoring_query.sql
+++ b/macros/edr/data_monitoring/monitors_query/dimension_monitoring_query.sql
@@ -111,7 +111,7 @@
             select * from row_count_values
               union all
             select * from fill_empty_buckets_row_count_values
-            )
+            ) as results
         ),
 
         row_count as (
@@ -187,7 +187,7 @@
                    dimension_value,
                    0 as row_count_value
             from training_set_dimensions
-            where dimension_value not in (select distinct dimension_value from row_count_values) results
+            where dimension_value not in (select distinct dimension_value from row_count_values)
         ),
 
         {# Union between current row count for each dimension, and the "hydrated" metrics of the test until this run #}

--- a/macros/edr/data_monitoring/monitors_query/dimension_monitoring_query.sql
+++ b/macros/edr/data_monitoring/monitors_query/dimension_monitoring_query.sql
@@ -1,13 +1,21 @@
-{% macro dimension_monitoring_query(monitored_table_relation, dimensions, min_bucket_start, max_bucket_end, days_back, metric_properties) %}
+{% macro dimension_monitoring_query(monitored_table_relation, dimensions, min_bucket_start, max_bucket_end, test_configuration, metric_properties) %}
     {% set metric_name = 'dimension' %}
     {% set full_table_name_str = elementary.edr_quote(elementary.relation_to_full_name(monitored_table_relation)) %}
     {% set dimensions_string = elementary.join_list(dimensions, '; ') %}
     {% set concat_dimensions_sql_expression = elementary.list_concat_with_separator(dimensions, '; ') %}
-
     {% set timestamp_column = metric_properties.timestamp_column %}
 
+    with filtered_monitored_table as (
+        select *,
+        {{ concat_dimensions_sql_expression }} as dimension_value
+        from {{ monitored_table_relation }}
+        {% if metric_properties.where_expression %}
+            where {{ metric_properties.where_expression }}
+        {% endif %}
+    ),
+
     {% if timestamp_column %}
-        with buckets as (
+        buckets as (
           select
             edr_bucket_start,
             edr_bucket_end,
@@ -17,21 +25,17 @@
             and edr_bucket_end <= {{ elementary.edr_cast_as_timestamp(max_bucket_end) }}
         ),
 
-        filtered_monitored_table as (
+        time_filtered_monitored_table as (
             select *,
-                   {{ concat_dimensions_sql_expression }} as dimension_value,
                    {{ elementary.get_start_bucket_in_data(timestamp_column, min_bucket_start, metric_properties.time_bucket) }} as start_bucket_in_data
-            from {{ monitored_table_relation }}
+            from filtered_monitored_table
             where
                 {{ elementary.edr_cast_as_timestamp(timestamp_column) }} >= (select min(edr_bucket_start) from buckets)
                 and {{ elementary.edr_cast_as_timestamp(timestamp_column) }} < (select max(edr_bucket_end) from buckets)
-            {% if metric_properties.where_expression %}
-                and {{ metric_properties.where_expression }}
-            {% endif %}
         ),
 
         {# Outdated dimension values are dimensions with all metrics of 0 in the range of the test time #}
-        dimension_values_without_outdated as (
+        previous_dimension_values_without_outdated as (
             select distinct 
                 dimension_value,
                 sum(metric_value)
@@ -44,48 +48,56 @@
             having sum(metric_value) > 0
         ),
 
-        dimension_values_union as (
-            select distinct *
-            from (
-                select distinct 
-                    dimension_value,
-                    1 as joiner
-                from dimension_values_without_outdated
-                union all
-                select distinct
-                    dimension_value,
-                    1 as joiner
-                from filtered_monitored_table
-            ) results
+        unique_previous_dimension_values as (
+            select distinct
+                dimension_value,
+                1 as joiner
+            from previous_dimension_values_without_outdated
         ),
 
-        {# Created buckets for each dimension value #}
+        {# Create buckets for each previous dimension value #}
         dimensions_buckets as (
             select edr_bucket_start, edr_bucket_end, dimension_value
-            from buckets left join dimension_values_union on buckets.joiner = dimension_values_union.joiner
+            from buckets left join unique_previous_dimension_values on buckets.joiner = unique_previous_dimension_values.joiner
+            where dimension_value is not null
         ),
 
         {# Calculating the row count for the value of each dimension #}
-        filtered_row_count_values as (
-            select 
+        row_count_values as (
+            select
+                edr_bucket_start,
+                edr_bucket_end,
                 start_bucket_in_data,
-                {{ concat_dimensions_sql_expression }} as dimension_value, 
-                {{ elementary.edr_cast_as_float(elementary.row_count()) }} as row_count_value
-            from filtered_monitored_table
-            {{ dbt_utils.group_by(2) }}
+                dimension_value,
+                case when start_bucket_in_data is null then
+                    0
+                else {{ elementary.edr_cast_as_float(elementary.row_count()) }} end as row_count_value
+            from buckets left join time_filtered_monitored_table on (edr_bucket_start = start_bucket_in_data)
+            group by 1,2,3,4
         ),
 
         {# Merging between the row count and the dimensions buckets #}
-        {# This way we make sure that if a dimension has no rows in a day, it will get a metric with value 0 #}
-        row_count_values as (
-            select edr_bucket_start,
-                   edr_bucket_end,
+        {# This way we make sure that if a dimension has no rows, it will get a metric with value 0 #}
+        fill_empty_buckets_row_count_values as (
+            select dimensions_buckets.edr_bucket_start,
+                   dimensions_buckets.edr_bucket_end,
                    start_bucket_in_data,
                    dimensions_buckets.dimension_value,
                    case when start_bucket_in_data is null then
                        0
                    else row_count_value end as row_count_value
-            from dimensions_buckets left join filtered_row_count_values on (edr_bucket_start = start_bucket_in_data and dimensions_buckets.dimension_value = filtered_row_count_values.dimension_value)
+            from dimensions_buckets left join row_count_values
+                on (dimensions_buckets.edr_bucket_start = start_bucket_in_data and dimensions_buckets.dimension_value = row_count_values.dimension_value)
+        ),
+
+        union_row_count_values as (
+            select distinct *
+            from
+            (
+            select * from row_count_values
+              union all
+            select * from fill_empty_buckets_row_count_values
+            )
         ),
 
         row_count as (
@@ -97,7 +109,7 @@
                    {{ elementary.const_as_string(dimensions_string) }} as dimension,
                    dimension_value,
                    {{elementary.dict_to_quoted_json(metric_properties) }} as metric_properties
-            from row_count_values
+            from union_row_count_values
         ),
 
         metrics_final as (
@@ -121,105 +133,55 @@
         )
 
     {% else %}
-        with filtered_monitored_table as (
-            select *,
-                   {{ concat_dimensions_sql_expression }} as dimension_value
-            from {{ monitored_table_relation }}
-        {% if metric_properties.where_expression %}
-            where {{ metric_properties.where_expression }}
-        {% endif %}
-        ),
-        
+
         {# Get all of the dimension anomally metrics that were created for the test until this run #}
-        last_dimension_metrics as (
-            select 
+        all_dimension_metrics as (
+            select
                 bucket_end,
                 dimension_value,
-                metric_value
+                metric_value,
+                row_number () over (partition by dimension_value order by bucket_end desc) as row_number
             from {{ ref('data_monitoring_metrics') }}
             where full_table_name = {{ full_table_name_str }}
                 and metric_name = {{ elementary.edr_quote(metric_name) }}
                 and dimension = {{ elementary.edr_quote(dimensions_string) }}
-                and {{ elementary.edr_cast_as_timestamp('bucket_end') }} >= {{ elementary.edr_timeadd(metric_properties.time_bucket.period,
-                                                                                              metric_properties.time_bucket.count,
-                                                                                              elementary.edr_cast_as_timestamp(min_bucket_start)) }}
         ),
 
-        {# Outdated dimension values are dimensions with all metrics of 0 in the range of the test time #}
-        dimension_values_without_outdated as (
-            select
-                bucket_end,
+        training_set_dimensions as (
+            select distinct
                 dimension_value,
-                metric_value
-            from last_dimension_metrics
-            where dimension_value in (
-                select dimension_value
-                from (
-                    select distinct 
-                        dimension_value,
-                        sum(metric_value)
-                    from last_dimension_metrics
-                    group by 1
-                    having sum(metric_value) > 0
-                ) results
-            )
-        ),
-        
-
-        dimension_values_union as (
-            select distinct *
-            from (
-                select distinct 
-                    dimension_value,
-                    1 as joiner
-                from dimension_values_without_outdated
-                union all
-                select distinct 
-                    dimension_value,
-                    1 as joiner
-                from filtered_monitored_table
-            ) results
+                sum(metric_value)
+            from all_dimension_metrics
+            where row_number <= {{ test_configuration.min_training_set_size }}
+            group by 1
+            {# Remove outdated dimension values (dimensions with all metrics of 0 in the range of the test time) #}
+            having sum(metric_value) > 0
         ),
 
-        {# Create buckets for each day from max(first metric time, min bucket end) until max bucket end #}
-        buckets as (
-          select
-            edr_bucket_start,
-            edr_bucket_end,
-            1 as joiner
-          from ({{ elementary.complete_buckets_cte(metric_properties, min_bucket_start, max_bucket_end) }}) results
-          where edr_bucket_start >= {{ elementary.edr_cast_as_timestamp(min_bucket_start) }}
-            and edr_bucket_end <= {{ elementary.edr_cast_as_timestamp(max_bucket_end) }}
+        {# Calculating the row count for the value of each dimension #}
+        row_count_values as (
+            select
+                {{ elementary.edr_cast_as_timestamp(elementary.edr_quote(elementary.run_started_at_as_string())) }} as bucket_end,
+                dimension_value,
+                {{ elementary.edr_cast_as_float(elementary.row_count()) }} as row_count_value
+            from filtered_monitored_table
+            group by 1,2
         ),
 
-        {# Get all of the metrics for all of the dimensions that were create for the test until this run, #}
-        {# "hydrated" with metrics with value 0 for dimensions with no row count in the given time range. #}
-        hydrated_last_dimension_metrics as (
-            select 
-                edr_bucket_end as bucket_end,
-                dimension_values_union.dimension_value as dimension_value,
-                case when metric_value is not null then metric_value else 0 end as metric_value
-            from buckets left join dimension_values_union on buckets.joiner = dimension_values_union.joiner
-                left outer join dimension_values_without_outdated on (buckets.edr_bucket_end = dimension_values_without_outdated.bucket_end and dimension_values_union.dimension_value = dimension_values_without_outdated.dimension_value)
+        {# This way we make sure that if a dimension has no rows, it will get a metric with value 0 #}
+        fill_empty_dimensions_row_count_values as (
+            select {{ elementary.edr_cast_as_timestamp(elementary.edr_quote(elementary.run_started_at_as_string())) }} as bucket_end,
+                   dimension_value,
+                   0 as row_count_value
+            from training_set_dimensions
+            where dimension_value not in (select distinct dimension_value from row_count_values)
         ),
 
         {# Union between current row count for each dimension, and the "hydrated" metrics of the test until this run #}
         row_count as (
-            select 
-                bucket_end,
-                dimension_value,
-                metric_value
-            from hydrated_last_dimension_metrics
+            select * from row_count_values
             union all
-            select
-                {{ elementary.edr_cast_as_timestamp(elementary.edr_quote(elementary.run_started_at_as_string())) }} as bucket_end,
-                {{ concat_dimensions_sql_expression }} as dimension_value,
-                {{ elementary.row_count() }} as metric_value
-            from {{ monitored_table_relation }}
-            {% if metric_properties.where_expression %}
-                where {{ metric_properties.where_expression }}
-            {% endif %}
-            {{ dbt_utils.group_by(2) }}
+            select * from fill_empty_dimensions_row_count_values
         ),
 
         metrics_final as (
@@ -227,7 +189,7 @@
                 {{ elementary.edr_cast_as_string(full_table_name_str) }} as full_table_name,
                 {{ elementary.null_string() }} as column_name,
                 {{ elementary.const_as_string(metric_name) }} as metric_name,
-                {{ elementary.edr_cast_as_float('metric_value') }} as metric_value,
+                {{ elementary.edr_cast_as_float('row_count_value') }} as metric_value,
                 {{ elementary.null_string() }} as source_value,
                 {{ elementary.null_timestamp() }} as bucket_start,
                 bucket_end,

--- a/macros/edr/tests/test_dimension_anomalies.sql
+++ b/macros/edr/tests/test_dimension_anomalies.sql
@@ -46,7 +46,7 @@
         {#- execute table monitors and write to temp test table -#}
         {{ elementary.test_log('start', full_table_name) }}
 
-        {%- set dimension_monitoring_query = elementary.dimension_monitoring_query(model, metric_properties.dimensions, min_bucket_start, max_bucket_end, test_configuration.days_back, metric_properties) %}
+        {%- set dimension_monitoring_query = elementary.dimension_monitoring_query(model, metric_properties.dimensions, min_bucket_start, max_bucket_end, test_configuration, metric_properties) %}
         {{ elementary.debug_log('dimension_monitoring_query - \n' ~ dimension_monitoring_query) }}
 
         {% set temp_table_relation = elementary.create_elementary_test_table(database_name, tests_schema_name, test_table_name, 'metrics', dimension_monitoring_query) %}


### PR DESCRIPTION
The changes to `dimension anomalies` are to handle new dimensions.
We used to create empty buckets for these new dimensions, so their appearance created an anomaly. 
On this PR: 
- New dimensions are excluded from empty buckets fill. 
- We don't fill buckets that are older than the dimension first appearance. 