### PR TITLE
Ele 1192 handling new dimension values

### DIFF
--- a/integration_tests/macros/e2e_tests/validate_dimensions_anomalies.sql
+++ b/integration_tests/macros/e2e_tests/validate_dimensions_anomalies.sql
@@ -25,3 +25,17 @@
 
     {{ assert_lists_contain_same_items(should_fail_names, ['elementary_dimension_anomalies_dimension_anomalies_platform__updated_at', 'elementary_dimension_anomalies_dimension_anomalies_platform__version__updated_at']) }}
 {% endmacro %}
+
+{% macro create_new_dimension() %}
+    {% set dimension_validation_data = ref('dimension_anomalies_validation') %}
+    {%- set insert_dimension_query %}
+        INSERT INTO {{ dimension_validation_data }} values ('1969-12-28 00:00:00.000', 'windows', 1, 318);
+    {% endset %}
+{% endmacro %}
+
+{% macro delete_new_dimension() %}
+    {% set dimension_validation_data = ref('dimension_anomalies_validation') %}
+    {%- set delete_dimension_query %}
+        DELETE FROM{{ dimension_validation_data }} WHERE platform = 'windows';
+    {% endset %}
+{% endmacro %}

--- a/integration_tests/macros/e2e_tests/validate_dimensions_anomalies.sql
+++ b/integration_tests/macros/e2e_tests/validate_dimensions_anomalies.sql
@@ -23,5 +23,5 @@
         {%- endif %}
     {% endfor %}
 
-    {{ assert_lists_contain_same_items(should_fail_names, ['elementary_dimension_anomalies_dimension_anomalies_platform', 'elementary_dimension_anomalies_dimension_anomalies_platform__updated_at', 'elementary_dimension_anomalies_dimension_anomalies_platform__version__updated_at']) }}
+    {{ assert_lists_contain_same_items(should_fail_names, ['elementary_dimension_anomalies_dimension_anomalies_platform__updated_at', 'elementary_dimension_anomalies_dimension_anomalies_platform__version__updated_at']) }}
 {% endmacro %}

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -121,7 +121,7 @@ models:
       - elementary.dimension_anomalies:
           dimensions:
             - platform
-          tags: ["dimension_anomalies", "should_fail"]
+          tags: ["dimension_anomalies"]
           alias: "dimension_anomalies_no_timestamp"
 
   - name: error_model

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -100,6 +100,19 @@ models:
             - platform
           where_expression: "platform = 'android'"
       - elementary.dimension_anomalies:
+          alias: "dimension_anomalies_platform_new_dimension"
+          tags: ["dimension_anomalies"]
+          timestamp_column: updated_at
+          dimensions:
+            - platform
+          where_expression: "platform = 'windows'"
+      - elementary.dimension_anomalies:
+          alias: "dimension_anomalies_platform_new_dimension_no_timestamp"
+          tags: ["dimension_anomalies"]
+          dimensions:
+            - platform
+          where_expression: "platform = 'windows'"
+      - elementary.dimension_anomalies:
           tags: ["dimension_anomalies", "should_fail"]
           alias: "dimension_anomalies_platform_version"
           timestamp_column: updated_at

--- a/integration_tests/run_e2e_tests.py
+++ b/integration_tests/run_e2e_tests.py
@@ -128,6 +128,12 @@ def e2e_tests(
 
     dbt_runner.run(vars={"stage": "training"})
 
+    if "dimension" in test_types:
+        dbt_runner.run_operation(
+            macro_name="create_new_dimension",
+            should_log=True,
+        )
+
     if "error_model" in test_types:
         results = [
             TestResult(type="error_model", message=msg)
@@ -308,6 +314,11 @@ def e2e_tests(
             )
         ]
         test_results.extend(results)
+
+        dbt_runner.run_operation(
+            macro_name="delete_new_dimension",
+            should_log=True,
+        )
 
     if "schema" in test_types and target not in ["databricks", "spark"]:
         dbt_runner.test(

--- a/macros/edr/data_monitoring/monitors_query/dimension_monitoring_query.sql
+++ b/macros/edr/data_monitoring/monitors_query/dimension_monitoring_query.sql
@@ -1,13 +1,21 @@
-{% macro dimension_monitoring_query(monitored_table_relation, dimensions, min_bucket_start, max_bucket_end, days_back, metric_properties) %}
+{% macro dimension_monitoring_query(monitored_table_relation, dimensions, min_bucket_start, max_bucket_end, test_configuration, metric_properties) %}
     {% set metric_name = 'dimension' %}
     {% set full_table_name_str = elementary.edr_quote(elementary.relation_to_full_name(monitored_table_relation)) %}
     {% set dimensions_string = elementary.join_list(dimensions, '; ') %}
     {% set concat_dimensions_sql_expression = elementary.list_concat_with_separator(dimensions, '; ') %}
-
     {% set timestamp_column = metric_properties.timestamp_column %}
 
+    with filtered_monitored_table as (
+        select *,
+        {{ concat_dimensions_sql_expression }} as dimension_value
+        from {{ monitored_table_relation }}
+        {% if metric_properties.where_expression %}
+            where {{ metric_properties.where_expression }}
+        {% endif %}
+    ),
+
     {% if timestamp_column %}
-        with buckets as (
+        buckets as (
           select
             edr_bucket_start,
             edr_bucket_end,
@@ -17,75 +25,93 @@
             and edr_bucket_end <= {{ elementary.edr_cast_as_timestamp(max_bucket_end) }}
         ),
 
-        filtered_monitored_table as (
+        time_filtered_monitored_table as (
             select *,
-                   {{ concat_dimensions_sql_expression }} as dimension_value,
                    {{ elementary.get_start_bucket_in_data(timestamp_column, min_bucket_start, metric_properties.time_bucket) }} as start_bucket_in_data
-            from {{ monitored_table_relation }}
+            from filtered_monitored_table
             where
                 {{ elementary.edr_cast_as_timestamp(timestamp_column) }} >= (select min(edr_bucket_start) from buckets)
                 and {{ elementary.edr_cast_as_timestamp(timestamp_column) }} < (select max(edr_bucket_end) from buckets)
-            {% if metric_properties.where_expression %}
-                and {{ metric_properties.where_expression }}
-            {% endif %}
         ),
 
-        {# Outdated dimension values are dimensions with all metrics of 0 in the range of the test time #}
-        dimension_values_without_outdated as (
-            select distinct 
+        all_dimension_metrics as (
+            select
+                bucket_end,
                 dimension_value,
-                sum(metric_value)
+                metric_value,
+                row_number () over (partition by dimension_value order by bucket_end desc) as row_number
             from {{ ref('data_monitoring_metrics') }}
             where full_table_name = {{ full_table_name_str }}
                 and metric_name = {{ elementary.edr_quote(metric_name) }}
-                and dimension = {{ elementary.edr_quote(dimensions_string) }}
-                and {{ elementary.edr_cast_as_timestamp('bucket_end') }} >= {{ elementary.edr_cast_as_timestamp(min_bucket_start) }}
+                and metric_properties = {{ elementary.dict_to_quoted_json(metric_properties) }}
+        ),
+
+        training_set_dimensions as (
+            select distinct
+                dimension_value,
+                min(bucket_end) as dimension_min_bucket_end,
+                sum(metric_value)
+            from all_dimension_metrics
+            where row_number <= {{ test_configuration.min_training_set_size }}
             group by 1
+            {# Remove outdated dimension values (dimensions with all metrics of 0 in the range of the test time) #}
             having sum(metric_value) > 0
         ),
 
-        dimension_values_union as (
-            select distinct *
-            from (
-                select distinct 
-                    dimension_value,
-                    1 as joiner
-                from dimension_values_without_outdated
-                union all
-                select distinct
-                    dimension_value,
-                    1 as joiner
-                from filtered_monitored_table
-            ) results
+        unique_previous_dimension_values as (
+            select distinct
+                dimension_value,
+                dimension_min_bucket_end,
+                1 as joiner
+            from training_set_dimensions
         ),
 
-        {# Created buckets for each dimension value #}
+        {# Create buckets for each previous dimension value #}
         dimensions_buckets as (
             select edr_bucket_start, edr_bucket_end, dimension_value
-            from buckets left join dimension_values_union on buckets.joiner = dimension_values_union.joiner
+            from unique_previous_dimension_values left join buckets
+                on (buckets.joiner = unique_previous_dimension_values.joiner
+                {# This makes sure we don't create empty buckets for dimensions before their first apperance #}
+                and edr_bucket_end >= dimension_min_bucket_end)
+            where dimension_value is not null
         ),
 
         {# Calculating the row count for the value of each dimension #}
-        filtered_row_count_values as (
-            select 
+        row_count_values as (
+            select
+                edr_bucket_start,
+                edr_bucket_end,
                 start_bucket_in_data,
-                {{ concat_dimensions_sql_expression }} as dimension_value, 
-                {{ elementary.edr_cast_as_float(elementary.row_count()) }} as row_count_value
-            from filtered_monitored_table
-            {{ dbt_utils.group_by(2) }}
+                dimension_value,
+                case when start_bucket_in_data is null then
+                    0
+                else {{ elementary.edr_cast_as_float(elementary.row_count()) }} end as row_count_value
+            from buckets left join time_filtered_monitored_table on (edr_bucket_start = start_bucket_in_data)
+            group by 1,2,3,4
         ),
 
         {# Merging between the row count and the dimensions buckets #}
-        {# This way we make sure that if a dimension has no rows in a day, it will get a metric with value 0 #}
-        row_count_values as (
-            select edr_bucket_start,
-                   edr_bucket_end,
+        {# This way we make sure that if a dimension has no rows, it will get a metric with value 0 #}
+        fill_empty_buckets_row_count_values as (
+            select dimensions_buckets.edr_bucket_start,
+                   dimensions_buckets.edr_bucket_end,
                    start_bucket_in_data,
                    dimensions_buckets.dimension_value,
                    case when start_bucket_in_data is null then
                        0
                    else row_count_value end as row_count_value
-            from dimensions_buckets left join filtered_row_count_values on (edr_bucket_start = start_bucket_in_data and dimensions_buckets.dimension_value = filtered_row_count_values.dimension_value)
+            from dimensions_buckets left join row_count_values
+                on (dimensions_buckets.edr_bucket_start = start_bucket_in_data and dimensions_buckets.dimension_value = row_count_values.dimension_value)
+        ),
+
+        union_row_count_values as (
+            select distinct *
+            from
+            (
+            select * from row_count_values
+              union all
+            select * from fill_empty_buckets_row_count_values
+            ) as results
         ),
 
         row_count as (
@@ -97,7 +123,7 @@
                    {{ elementary.const_as_string(dimensions_string) }} as dimension,
                    dimension_value,
                    {{elementary.dict_to_quoted_json(metric_properties) }} as metric_properties
-            from row_count_values
+            from union_row_count_values
         ),
 
         metrics_final as (
@@ -114,112 +140,61 @@
             dimension,
             dimension_value,
             metric_properties
-        from
-            row_count
+        from row_count
         where (metric_value is not null and cast(metric_value as {{ elementary.edr_type_int() }}) < {{ elementary.get_config_var('max_int') }}) or
             metric_value is null
         )
 
     {% else %}
-        with filtered_monitored_table as (
-            select *,
-                   {{ concat_dimensions_sql_expression }} as dimension_value
-            from {{ monitored_table_relation }}
-        {% if metric_properties.where_expression %}
-            where {{ metric_properties.where_expression }}
-        {% endif %}
-        ),
-        
-        {# Get all of the dimension anomally metrics that were created for the test until this run #}
-        last_dimension_metrics as (
-            select 
-                bucket_end,
-                dimension_value,
-                metric_value
-            from {{ ref('data_monitoring_metrics') }}
-            where full_table_name = {{ full_table_name_str }}
-                and metric_name = {{ elementary.edr_quote(metric_name) }}
-                and dimension = {{ elementary.edr_quote(dimensions_string) }}
-                and {{ elementary.edr_cast_as_timestamp('bucket_end') }} >= {{ elementary.edr_timeadd(metric_properties.time_bucket.period,
-                                                                                              metric_properties.time_bucket.count,
-                                                                                              elementary.edr_cast_as_timestamp(min_bucket_start)) }}
-        ),
 
-        {# Outdated dimension values are dimensions with all metrics of 0 in the range of the test time #}
-        dimension_values_without_outdated as (
+        {# Get all of the dimension anomally metrics that were created for the test until this run #}
+        all_dimension_metrics as (
             select
                 bucket_end,
                 dimension_value,
-                metric_value
-            from last_dimension_metrics
-            where dimension_value in (
-                select dimension_value
-                from (
-                    select distinct 
-                        dimension_value,
-                        sum(metric_value)
-                    from last_dimension_metrics
-                    group by 1
-                    having sum(metric_value) > 0
-                ) results
-            )
-        ),
-        
-
-        dimension_values_union as (
-            select distinct *
-            from (
-                select distinct 
-                    dimension_value,
-                    1 as joiner
-                from dimension_values_without_outdated
-                union all
-                select distinct 
-                    dimension_value,
-                    1 as joiner
-                from filtered_monitored_table
-            ) results
+                metric_value,
+                row_number () over (partition by dimension_value order by bucket_end desc) as row_number
+            from {{ ref('data_monitoring_metrics') }}
+            where full_table_name = {{ full_table_name_str }}
+                and metric_name = {{ elementary.edr_quote(metric_name) }}
+                and metric_properties = {{ elementary.dict_to_quoted_json(metric_properties) }}
         ),
 
-        {# Create buckets for each day from max(first metric time, min bucket end) until max bucket end #}
-        buckets as (
-          select
-            edr_bucket_start,
-            edr_bucket_end,
-            1 as joiner
-          from ({{ elementary.complete_buckets_cte(metric_properties, min_bucket_start, max_bucket_end) }}) results
-          where edr_bucket_start >= {{ elementary.edr_cast_as_timestamp(min_bucket_start) }}
-            and edr_bucket_end <= {{ elementary.edr_cast_as_timestamp(max_bucket_end) }}
+        training_set_dimensions as (
+            select distinct
+                dimension_value,
+                sum(metric_value)
+            from all_dimension_metrics
+            where row_number <= {{ test_configuration.min_training_set_size }}
+            group by 1
+            {# Remove outdated dimension values (dimensions with all metrics of 0 in the range of the test time) #}
+            having sum(metric_value) > 0
         ),
 
-        {# Get all of the metrics for all of the dimensions that were create for the test until this run, #}
-        {# "hydrated" with metrics with value 0 for dimensions with no row count in the given time range. #}
-        hydrated_last_dimension_metrics as (
-            select 
-                edr_bucket_end as bucket_end,
-                dimension_values_union.dimension_value as dimension_value,
-                case when metric_value is not null then metric_value else 0 end as metric_value
-            from buckets left join dimension_values_union on buckets.joiner = dimension_values_union.joiner
-                left outer join dimension_values_without_outdated on (buckets.edr_bucket_end = dimension_values_without_outdated.bucket_end and dimension_values_union.dimension_value = dimension_values_without_outdated.dimension_value)
+        {# Calculating the row count for the value of each dimension #}
+        row_count_values as (
+            select
+                {{ elementary.edr_cast_as_timestamp(elementary.edr_quote(elementary.run_started_at_as_string())) }} as bucket_end,
+                dimension_value,
+                {{ elementary.edr_cast_as_float(elementary.row_count()) }} as row_count_value
+            from filtered_monitored_table
+            group by 1,2
+        ),
+
+        {# This way we make sure that if a dimension has no rows, it will get a metric with value 0 #}
+        fill_empty_dimensions_row_count_values as (
+            select {{ elementary.edr_cast_as_timestamp(elementary.edr_quote(elementary.run_started_at_as_string())) }} as bucket_end,
+                   dimension_value,
+                   0 as row_count_value
+            from training_set_dimensions
+            where dimension_value not in (select distinct dimension_value from row_count_values)
         ),
 
         {# Union between current row count for each dimension, and the "hydrated" metrics of the test until this run #}
         row_count as (
-            select 
-                bucket_end,
-                dimension_value,
-                metric_value
-            from hydrated_last_dimension_metrics
+            select * from row_count_values
             union all
-            select
-                {{ elementary.edr_cast_as_timestamp(elementary.edr_quote(elementary.run_started_at_as_string())) }} as bucket_end,
-                {{ concat_dimensions_sql_expression }} as dimension_value,
-                {{ elementary.row_count() }} as metric_value
-            from {{ monitored_table_relation }}
-            {% if metric_properties.where_expression %}
-                where {{ metric_properties.where_expression }}
-            {% endif %}
-            {{ dbt_utils.group_by(2) }}
+            select * from fill_empty_dimensions_row_count_values
         ),
 
         metrics_final as (
@@ -227,7 +202,7 @@
                 {{ elementary.edr_cast_as_string(full_table_name_str) }} as full_table_name,
                 {{ elementary.null_string() }} as column_name,
                 {{ elementary.const_as_string(metric_name) }} as metric_name,
-                {{ elementary.edr_cast_as_float('metric_value') }} as metric_value,
+                {{ elementary.edr_cast_as_float('row_count_value') }} as metric_value,
                 {{ elementary.null_string() }} as source_value,
                 {{ elementary.null_timestamp() }} as bucket_start,
                 bucket_end,

--- a/macros/edr/tests/test_dimension_anomalies.sql
+++ b/macros/edr/tests/test_dimension_anomalies.sql
@@ -46,7 +46,7 @@
         {#- execute table monitors and write to temp test table -#}
         {{ elementary.test_log('start', full_table_name) }}
 
-        {%- set dimension_monitoring_query = elementary.dimension_monitoring_query(model, metric_properties.dimensions, min_bucket_start, max_bucket_end, test_configuration.days_back, metric_properties) %}
+        {%- set dimension_monitoring_query = elementary.dimension_monitoring_query(model, metric_properties.dimensions, min_bucket_start, max_bucket_end, test_configuration, metric_properties) %}
         {{ elementary.debug_log('dimension_monitoring_query - \n' ~ dimension_monitoring_query) }}
 
         {% set temp_table_relation = elementary.create_elementary_test_table(database_name, tests_schema_name, test_table_name, 'metrics', dimension_monitoring_query) %}


### PR DESCRIPTION
The changes to dimension anomalies query are to handle new dimensions.
We used to create empty buckets for these new dimensions, so their appearance created an anomaly.

On this PR:
- New dimensions are excluded from empty buckets fill.
- We don't fill buckets that are older than the dimension first appearance.

There is a product decision we should make - 
Is a new dimension an anomaly? Should this be a flag maybe?