### PR TITLE
Fix formatting and add convert_to_lower flag to elementary.generate_schema_baseline_test

### DIFF
--- a/macros/commands/generate_schema_baseline_test.sql
+++ b/macros/commands/generate_schema_baseline_test.sql
@@ -1,26 +1,26 @@
-{% macro generate_schema_baseline_test(name=none, include_sources=True, include_models=False, fail_on_added=False, enforce_types=False) %}
+{% macro generate_schema_baseline_test(name=none, include_sources=True, include_models=False, fail_on_added=False, enforce_types=False, convert_to_lower=False) %}
   {% if name %}
-    {{ generate_schema_baseline_test_for_node(name, fail_on_added=fail_on_added, enforce_types=enforce_types) }}
+    {{ generate_schema_baseline_test_for_node(name, fail_on_added=fail_on_added, enforce_types=enforce_types, convert_to_lower=convert_to_lower) }}
   {% else %}
     {{ generate_schema_baseline_test_for_all_nodes(include_sources=include_sources, include_models=include_models,
-                                                   fail_on_added=fail_on_added, enforce_types=enforce_types) }}
+                                                   fail_on_added=fail_on_added, enforce_types=enforce_types, convert_to_lower=convert_to_lower) }}
   {% endif %}
 {% endmacro %}
 
-{% macro generate_schema_baseline_test_for_all_nodes(include_sources=True, include_models=False, fail_on_added=False, enforce_types=False) %}
+{% macro generate_schema_baseline_test_for_all_nodes(include_sources=True, include_models=False, fail_on_added=False, enforce_types=False, convert_to_lower=False) %}
   {% set nodes = elementary.get_nodes_from_graph() %}
   {% for node in nodes %}
     {% if node.package_name != 'elementary' and
           ((include_sources and node.resource_type == 'source') or
            (include_models and node.resource_type == 'model')) %}
       {% do print("Generating schema changes from baseline test for {} '{}':".format(node.resource_type, node.name)) %}
-      {{ generate_schema_baseline_test_for_node(node, fail_on_added=fail_on_added, enforce_types=enforce_types) }}
+      {{ generate_schema_baseline_test_for_node(node, fail_on_added=fail_on_added, enforce_types=enforce_types, convert_to_lower=convert_to_lower) }}
       {% do print('----------------------------------') %}
     {% endif %}
   {% endfor %}
 {% endmacro %}
 
-{% macro generate_schema_baseline_test_for_node(node, fail_on_added=False, enforce_types=False) %}
+{% macro generate_schema_baseline_test_for_node(node, fail_on_added=False, enforce_types=False, convert_to_lower=False) %}
   {% if node is string %}
     {% set node_name = node %}
     {% set node = elementary.get_node_by_name(node_name) %}
@@ -52,13 +52,52 @@
     {% do test_params.update({"enforce_types": "true"}) %}
   {% endif %}
 
-  {# Common yaml for sources and models #}
-  {% set common_yaml %}
+  {# Full yaml for sources and models #}
+  {% set full_yaml %}
+  {%- if node.resource_type == 'source' %}
+    {{generate_schema_baseline_test_for_source(node, columns, test_params, convert_to_lower)}}
+  {% else %}
+    {{generate_schema_baseline_test_for_model(node, columns, test_params, convert_to_lower)}}
+  {% endif -%}
+  {% endset %}
+
+  {% do print(full_yaml) %}
+{% endmacro %}
+
+{% macro generate_schema_baseline_test_for_source(node, columns, test_params, convert_to_lower) %}
+sources:
+  - name: {{ node.source_name }}
+    tables:
+      - name: {{ node.name }}
+        columns:
+        {%- for column in columns %}
+          - name: {{ column.name }}
+            {%- if convert_to_lower %}
+            data_type: {{ column.dtype|lower }}
+            {% else %}
+            data_type: {{ column.dtype }}
+            {% endif -%}
+        {% endfor %}
+        tests:
+          - elementary.schema_changes_from_baseline
+          {%- if test_params %}:
+            {%- for param, param_val in test_params.items() %}
+              {{param}}: {{param_val}}
+            {%- endfor -%}
+          {% endif -%}  
+{% endmacro %}
+
+{% macro generate_schema_baseline_test_for_model(node, columns, test_params, convert_to_lower) %}
+models:
   - name: {{ node.name }}
     columns:
     {%- for column in columns %}
       - name: {{ column.name }}
+        {%- if convert_to_lower %}
+        data_type: {{ column.dtype|lower }}
+        {% else %}
         data_type: {{ column.dtype }}
+        {% endif -%}
     {% endfor %}
     tests:
       - elementary.schema_changes_from_baseline
@@ -67,19 +106,4 @@
           {{param}}: {{param_val}}
         {%- endfor -%}
       {% endif -%}
-  {% endset %}
-
-  {% set full_yaml %}
-  {%- if node.resource_type == 'source' %}
-sources:
-  - name: {{ node.source_name }}
-    tables:
-      {{- common_yaml }}
-  {% else %}
-models:
-  {{- common_yaml }}
-  {% endif -%}
-  {% endset %}
-
-  {% do print(full_yaml) %}
 {% endmacro %}


### PR DESCRIPTION
### Description:

This pull request addresses the [issue #810](https://github.com/elementary-data/elementary/issues/810) where the output of `elementary.generate_schema_baseline_test` has incorrect indentation. It also introduces the `convert_to_lower` flag to control the case of data types in the output.

### Changes:

- Refactor the `generate_schema_baseline_test` macro to separate the YAML generation for models and sources into two separate macros.

- Introduce the `convert_to_lower` flag as a parameter to the `elementary.generate_schema_baseline_test` operation. When set to `True`, the output will default to lowercase for data types.

With these modifications, the output will be correctly formatted, and users can now control the case of the output using the `convert_to_lower` flag.