### PR TITLE
Add `adapter_response` in dbt_run_results

### DIFF
--- a/.github/workflows/test-all-warehouses.yml
+++ b/.github/workflows/test-all-warehouses.yml
@@ -25,6 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        dbt-version: ${{ inputs.dbt-version && fromJSON(format('["{0}"]', inputs.dbt-version)) || fromJSON('["1.3.0", null]') }}
         warehouse-type:
           [
             postgres,
@@ -38,7 +39,7 @@ jobs:
     uses: ./.github/workflows/test-warehouse.yml
     with:
       warehouse-type: ${{ matrix.warehouse-type }}
-      dbt-version: ${{ github.event_name != 'workflow_dispatch' && '1.3.0' || inputs.dbt-version }}
+      dbt-version: ${{ matrix.dbt-version }}
       elementary-ref: ${{ inputs.elementary-ref }}
       dbt-data-reliability-ref: ${{ inputs.dbt-data-reliability-ref }}
     secrets: inherit

--- a/.github/workflows/test-all-warehouses.yml
+++ b/.github/workflows/test-all-warehouses.yml
@@ -43,3 +43,19 @@ jobs:
       elementary-ref: ${{ inputs.elementary-ref }}
       dbt-data-reliability-ref: ${{ inputs.dbt-data-reliability-ref }}
     secrets: inherit
+
+  notify_failures:
+    name: Notify Slack
+    secrets: inherit
+    needs: [test]
+    if: |
+      always() &&
+      ! cancelled() &&
+      !contains(needs.test.result, 'success') &&
+      !contains(needs.test.result, 'cancelled') &&
+      ${{ github.event_name == 'schedule' }}
+    uses: elementary-data/elementary/.github/workflows/notify_slack.yml@master
+    with:
+      result: "failure"
+      run_id: ${{ github.run_id }}
+      workflow_name: "Test all warehouse platforms"

--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -50,7 +50,8 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     concurrency:
-      group: tests-${{ inputs.warehouse-type }}-${{ github.head_ref || github.ref_name }}
+      # This is what eventually defines the schema name in the data platform.
+      group: tests_${{ inputs.warehouse-type }}_dbt_${{ inputs.dbt-version }}_${{ github.head_ref || github.ref_name }}
       cancel-in-progress: true
     steps:
       - name: Checkout Elementary
@@ -70,14 +71,6 @@ jobs:
         if: inputs.warehouse-type == 'postgres'
         working-directory: ${{ env.TESTS_DIR }}
         run: docker-compose up -d postgres
-
-      - name: Write dbt profiles
-        env:
-          CI_PROFILES_YML: ${{ secrets.CI_PROFILES_YML }}
-        run: |
-          mkdir -p ~/.dbt
-          UNDERSCORED_REF_NAME=$(echo "${{ env.BRANCH_NAME }}" | head -c 32 | sed "s/-/_/g")
-          echo "$CI_PROFILES_YML" | base64 -d | sed "s/<SCHEMA_NAME>/dbt_$UNDERSCORED_REF_NAME/g" > ~/.dbt/profiles.yml
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -101,6 +94,15 @@ jobs:
         run: |
           dbt deps --project-dir dbt_project
           pip install -r requirements.txt
+
+      - name: Write dbt profiles
+        env:
+          PROFILES_YML: ${{ secrets.CI_PROFILES_YML }}
+        run: |
+          mkdir -p ~/.dbt
+          DBT_VERSION=$(pip show dbt-core | grep -i version | awk '{print $2}' | sed 's/\.//g')
+          UNDERSCORED_REF_NAME=$(echo "dbt_${DBT_VERSION}_${BRANCH_NAME}" | head -c 32 | sed "s/-/_/g")
+          echo "$PROFILES_YML" | base64 -d | sed "s/<SCHEMA_NAME>/py_$UNDERSCORED_REF_NAME/g" > ~/.dbt/profiles.yml
 
       - name: Check DWH connection
         working-directory: ${{ env.TESTS_DIR }}

--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -102,7 +102,7 @@ jobs:
           mkdir -p ~/.dbt
           DBT_VERSION=$(pip show dbt-core | grep -i version | awk '{print $2}' | sed 's/\.//g')
           UNDERSCORED_REF_NAME=$(echo "dbt_${DBT_VERSION}_${BRANCH_NAME}" | head -c 32 | sed "s/-/_/g")
-          echo "$PROFILES_YML" | base64 -d | sed "s/<SCHEMA_NAME>/py_$UNDERSCORED_REF_NAME/g" > ~/.dbt/profiles.yml
+          echo "$PROFILES_YML" | base64 -d | sed "s/<SCHEMA_NAME>/dbt_$UNDERSCORED_REF_NAME/g" > ~/.dbt/profiles.yml
 
       - name: Check DWH connection
         working-directory: ${{ env.TESTS_DIR }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,7 @@
-# Contributing guidelines
+# Contribution guidelines
 
-_Note_: This document is for the dbt package.
-For the Python package (`edr`), refer to
-the [Python package contributing guidelines](https://github.com/elementary-data/elementary/blob/master/CONTRIBUTING.md).
+**Note**: This document contains contribution guidelines for the Elementary dbt package. If you wish to contribute
+to the Elementary CLI (`edr`), please refer to the [CLI contribution guidelines](https://github.com/elementary-data/elementary/blob/master/CONTRIBUTING.md).
 
 ## Getting started with development
 
@@ -71,3 +70,33 @@ The best pull requests are focused, clearly describe what they're for
 and why they're correct, and contain tests for whatever changes they
 make to the code's behavior. As a bonus these are easiest for someone
 to review, which helps your pull request get merged quickly!
+
+## Running integration tests
+
+For every PR we merge, we require integration tests to pass successfully
+on all supported database platforms (Snowflake, Bigquery, Redshift, Databricks and Postgres).
+
+Clearly you might not have a setup for all of these, so the expectation is that you'll run
+the tests on the platform you're using and make sure everything passes. We also encourage you to add new tests for any new non-trivial functionality.
+
+Our tests are located under the `integration_tests` directory, and written using the
+[py-test](https://docs.pytest.org/en/stable/) framework.
+In order to run them, please follow these steps:
+
+1. Install dependencies:
+
+```bash
+cd integration_tests
+pip install -r requirements.txt
+dbt deps --project-dir dbt_project
+```
+
+2. Create a dbt profile named `elementary_tests`, with a target corresponding to the database you are using.
+   For more details on how to set a dbt profile please click [here](https://docs.getdbt.com/docs/core/connect-data-platform/connection-profiles).
+
+3. Run the tests:
+
+```bash
+cd tests
+py.test -vvv --target <your_target>
+```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Monitor your data quality, operation and performance directly from your dbt proj
 ```yml packages.yml
 packages:
   - package: elementary-data/elementary
-    version: 0.10.1
+    version: 0.10.2
     ## Docs: https://docs.elementary-data.com
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Monitor your data quality, operation and performance directly from your dbt proj
 ```yml packages.yml
 packages:
   - package: elementary-data/elementary
-    version: 0.9.4
+    version: 0.10.0
     ## Docs: https://docs.elementary-data.com
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,24 @@
 <p align="center">
-<img alt="Logo" src="https://raw.githubusercontent.com/elementary-data/elementary/master/static/header_git.png"/ width="1000">
+<img alt="Logo" src="https://raw.githubusercontent.com/elementary-data/elementary/master/static/github_banner.png"/ width="1000">
 </p>
 
 <h2 align="center">
- Data observability for analytics & data engineers
+ dbt native data observability for analytics & data engineers
 </h2>
 <h4 align="center">
 Monitor your data quality, operation and performance directly from your dbt project.
 </h4>
 
-<div align="center">
+<p align="center">
+<a href="https://join.slack.com/t/elementary-community/shared_invite/zt-uehfrq2f-zXeVTtXrjYRbdE_V6xq4Rg"><img src="https://img.shields.io/badge/join-Slack-ff69b4"/></a>
+<a href="https://docs.elementary-data.com/quickstart"><img src="https://img.shields.io/badge/docs-quickstart-orange"/></a>
+<img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-ff69b4"/>
+<img alt="Downloads" src="https://static.pepy.tech/personalized-badge/elementary-lineage?period=total&units=international_system&left_color=grey&right_color=orange"&left_text=Downloads"/>
 
-To learn more, refer to our [main repo »](https://github.com/elementary-data/elementary) | [Demo »](https://bit.ly/3IXKShW)
-
-</div>
 
 ## Quick start
 
-Add to your `packages.yml` according to your dbt version:
-
-**For dbt >1.3.0:**
+1. Add to your `packages.yml`:
 
 ```yml packages.yml
 packages:
@@ -28,35 +27,9 @@ packages:
     ## Docs: https://docs.elementary-data.com
 ```
 
-**For dbt >=1.2.0, <1.3.0:**
+2. Run `dbt deps`
 
-```yml packages.yml
-packages:
-  - package: elementary-data/elementary
-    version: 0.9.4
-    ## Docs: https://docs.elementary-data.com
-
-    ## !! Important !! For dbt >=1.2.0 \<1.3.0 ##
-    ## (Prevents dbt_utils versions exceptions) ##
-  - package: dbt-labs/dbt_utils
-    version: [">=0.8.0", "<1.0.0"]
-```
-
-**For dbt >=1.0.0, <1.2.0:**
-
-```yml packages.yml
-packages:
-  - package: elementary-data/elementary
-    version: 0.9.4
-    ## Docs: https://docs.elementary-data.com
-
-    ## !! Important !! For dbt <1.2.0 ##
-    ## (Prevents dbt_utils versions exceptions) ##
-  - package: dbt-labs/dbt_utils
-    version: [">=0.8.0", "<0.9.0"]
-```
-
-After adding to `packages.yml` and running `dbt deps`, add to your `dbt_project.yml`:
+3. Add to your `dbt_project.yml`:
 
 ```yml
 models:
@@ -66,7 +39,7 @@ models:
     +schema: "elementary"
 ```
 
-And run `dbt run --select elementary`.
+4. Run `dbt run --select elementary`
 
 Check out the [full documentation](https://docs.elementary-data.com/) for generating the UI, alerts and adding anomaly detection tests.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Monitor your data quality, operation and performance directly from your dbt proj
 ```yml packages.yml
 packages:
   - package: elementary-data/elementary
-    version: 0.10.0
+    version: 0.10.1
     ## Docs: https://docs.elementary-data.com
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Monitor your data quality, operation and performance directly from your dbt proj
 <img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-ff69b4"/>
 <img alt="Downloads" src="https://static.pepy.tech/personalized-badge/elementary-lineage?period=total&units=international_system&left_color=grey&right_color=orange"&left_text=Downloads"/>
 
-
 ## Quick start
 
 1. Add to your `packages.yml`:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "elementary"
-version: "0.10.1"
+version: "0.10.2"
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "elementary"
-version: "0.10.0"
+version: "0.10.1"
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "elementary"
-version: "0.9.4"
+version: "0.10.0"
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 

--- a/integration_tests/tests/test_metrics.py
+++ b/integration_tests/tests/test_metrics.py
@@ -1,6 +1,6 @@
 import random
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List
 
 import pytest
@@ -56,14 +56,14 @@ def validate_metrics(
     dbt_project: DbtProject,
     remaining_models_to_row_count: dict,
 ):
-    now = datetime.utcnow()
+    yesterday = datetime.utcnow() - timedelta(days=1)
     for metric in dbt_project.read_table("data_monitoring_metrics"):
         for model_name, row_count in remaining_models_to_row_count.items():
             if model_name.upper() in metric["full_table_name"]:
                 if metric["metric_name"] == "row_count":
                     assert metric["metric_value"] == row_count
                 elif metric["metric_name"] == "build_timestamp":
-                    assert metric["metric_value"] < now.timestamp()
+                    assert metric["metric_value"] > yesterday.timestamp()
                 remaining_models_to_row_count.pop(model_name)
                 break
 

--- a/macros/edr/data_monitoring/anomaly_detection/get_anomaly_scores_query.sql
+++ b/macros/edr/data_monitoring/anomaly_detection/get_anomaly_scores_query.sql
@@ -173,7 +173,7 @@
                 {% endset %}
                 case
                     when training_stddev is null then null
-                    when {{ min_metric_value_expr }} < 0 and metric_name in {{ elementary.to_sql_list(elementary.get_negative_value_supported_metrics()) }} then {{ min_metric_value_expr }}
+                    when {{ min_metric_value_expr }} > 0 or metric_name in {{ elementary.to_sql_list(elementary.get_negative_value_supported_metrics()) }} then {{ min_metric_value_expr }}
                     else 0
                 end as min_metric_value,
                 case 

--- a/macros/edr/dbt_artifacts/upload_run_results.sql
+++ b/macros/edr/dbt_artifacts/upload_run_results.sql
@@ -30,7 +30,8 @@
                                                                        ('failures', 'bigint'),
                                                                        ('query_id', 'string'),
                                                                        ('thread_id', 'string'),
-                                                                       ('materialization', 'string')
+                                                                       ('materialization', 'string'),
+                                                                       ('adapter_response', 'string')
                                                                        ]) %}
     {{ return(dbt_run_results_empty_table_query) }}
 {% endmacro %}
@@ -59,7 +60,8 @@
         'failures': run_result_dict.get('failures'),
         'query_id': run_result_dict.get('adapter_response', {}).get('query_id'),
         'thread_id': run_result_dict.get('thread_id'),
-        'materialization': config_dict.get('materialized')
+        'materialization': config_dict.get('materialized'),
+        'adapter_response': run_result_dict.get('adapter_response', {})
     }%}
 
     {% set timings = elementary.safe_get_with_default(run_result_dict, 'timing', []) %}

--- a/macros/edr/system/hooks/on_run_start.sql
+++ b/macros/edr/system/hooks/on_run_start.sql
@@ -5,7 +5,6 @@
   {% endif %}
 
   {% do recommend_dbt_core_artifacts_upgrade() %}
-
   {% do elementary.init_elementary_graph() %}
 
   {% if flags.WHICH in ['test', 'build'] %}

--- a/macros/edr/system/system_utils/get_config_var.sql
+++ b/macros/edr/system/system_utils/get_config_var.sql
@@ -56,7 +56,8 @@
     'calculate_failed_count': true,
     'tests_use_temp_tables': false,
     'collect_metrics': true,
-    'upload_dbt_columns': false
+    'upload_dbt_columns': false,
+    'clean_elementary_temp_tables': true,
   } %}
   {{- return(default_config) -}}
 {%- endmacro -%}

--- a/macros/edr/tests/on_run_end/handle_tests_results.sql
+++ b/macros/edr/tests/on_run_end/handle_tests_results.sql
@@ -11,8 +11,11 @@
     {% set test_metrics_tables = tables_cache.get("metrics").get("relations") %}
     {% set test_columns_snapshot_tables = tables_cache.get("schema_snapshots") %}
     {% set database_name, schema_name = elementary.get_package_database_and_schema('elementary') %}
-    {{ elementary.insert_data_monitoring_metrics(database_name, schema_name, test_metrics_tables) }}
-    {{ elementary.insert_schema_columns_snapshot(database_name, schema_name, test_columns_snapshot_tables) }}
+    {% do elementary.insert_data_monitoring_metrics(database_name, schema_name, test_metrics_tables) %}
+    {% do elementary.insert_schema_columns_snapshot(database_name, schema_name, test_columns_snapshot_tables) %}
+    {% if elementary.get_config_var("clean_elementary_temp_tables") %}
+      {% do elementary.clean_elementary_test_tables() %}
+    {% endif %}
     {% if test_result_rows %}
       {% set test_result_rows_relation = adapter.get_relation(database=database_name, schema=schema_name, identifier='test_result_rows') %}
       {% do elementary.insert_rows(test_result_rows_relation, test_result_rows, should_commit=True) %}
@@ -21,8 +24,8 @@
       {% set elementary_test_results_relation = adapter.get_relation(database=database_name, schema=schema_name, identifier='elementary_test_results') %}
       {% do elementary.insert_rows(elementary_test_results_relation, elementary_test_results, should_commit=True) %}
     {% endif %}
-    {{ elementary.file_log("Handled test results successfully.") }}
-    {{ return('') }}
+    {% do elementary.file_log("Handled test results successfully.") %}
+    {% do return('') %}
 {% endmacro %}
 
 {% macro get_result_enriched_elementary_test_results(cached_elementary_test_results, cached_elementary_test_failed_row_counts, render_result_rows=false) %}

--- a/macros/edr/tests/on_run_start/init_elementary_graph.sql
+++ b/macros/edr/tests/on_run_start/init_elementary_graph.sql
@@ -9,6 +9,7 @@
         "rows": []
       },
       "schema_snapshots": []
-    }
+    },
+    "temp_test_table_relations_map": {},
   }) %}
 {% endmacro %}

--- a/macros/edr/tests/test_utils/clean_elementary_test_tables.sql
+++ b/macros/edr/tests/test_utils/clean_elementary_test_tables.sql
@@ -1,0 +1,50 @@
+{% macro clean_elementary_test_tables() %}
+    {% set test_table_relations = [] %}
+    {% set temp_test_table_relations_map = elementary.get_cache("temp_test_table_relations_map") %}
+    {% for test_entry in temp_test_table_relations_map.values() %}
+        {% for test_relation in test_entry.values() %}
+            {% do test_table_relations.append(test_relation) %}
+        {% endfor %}
+    {% endfor %}
+
+    {% do elementary.file_log("Deleting temporary Elementary test tables: {}".format(test_table_relations)) %}
+    {% set queries = elementary.get_clean_elementary_test_tables_queries(test_table_relations) %}
+    {% for query in queries %}
+        {% do elementary.run_query(query) %}
+    {% endfor %}
+{% endmacro %}
+
+{% macro get_clean_elementary_test_tables_queries(test_table_relations) %}
+    {% do return(adapter.dispatch("get_clean_elementary_test_tables_queries", "elementary")(test_table_relations)) %}
+{% endmacro %}
+
+{% macro default__get_clean_elementary_test_tables_queries(test_table_relations) %}
+    {% do return(elementary.get_transaction_clean_elementary_test_tables_queries(test_table_relations)) %}
+{% endmacro %}
+
+{% macro bigquery__get_clean_elementary_test_tables_queries(test_table_relations) %}
+    {% do return(elementary.get_transactionless_clean_elementary_test_tables_queries(test_table_relations)) %}
+{% endmacro %}
+
+{% macro spark__get_clean_elementary_test_tables_queries(test_table_relations) %}
+    {% do return(elementary.get_transactionless_clean_elementary_test_tables_queries(test_table_relations)) %}
+{% endmacro %}
+
+{% macro get_transaction_clean_elementary_test_tables_queries(test_table_relations) %}
+    {% set query %}
+        BEGIN TRANSACTION;
+        {% for test_relation in test_table_relations %}
+            DROP TABLE IF EXISTS {{ test_relation }};
+        {% endfor %}
+        COMMIT;
+    {% endset %}
+    {% do return([query]) %}
+{% endmacro %}
+
+{% macro get_transactionless_clean_elementary_test_tables_queries(test_table_relations) %}
+    {% set queries = [] %}
+    {% for test_relation in test_table_relations %}
+        {% do queries.append("DROP TABLE IF EXISTS {}".format(test_relation)) %}
+    {% endfor %}
+    {% do return(queries) %}
+{% endmacro %}

--- a/macros/edr/tests/test_utils/create_elementary_test_table.sql
+++ b/macros/edr/tests/test_utils/create_elementary_test_table.sql
@@ -1,23 +1,19 @@
-{% macro create_elementary_test_table(database_name, schema_name, test_name, table_type, sql_query, is_temp_table=False) %}
+{% macro create_elementary_test_table(database_name, schema_name, test_name, table_type, sql_query) %}
     {% if execute %}
-        {% set temp_table_name = elementary.table_name_with_suffix(test_name, "__" ~ table_type) %}
+        {% set temp_table_name = elementary.table_name_with_suffix(test_name, "__" ~ table_type ~ elementary.get_timestamped_table_suffix()) %}
         {{ elementary.debug_log(table_type ~ ' table: ' ~ database_name ~ '.' ~ schema_name ~ '.' ~ temp_table_name) }}
 
         {% set _, temp_table_relation = dbt.get_or_create_relation(database=database_name,
                                                                    schema=schema_name,
                                                                    identifier=temp_table_name,
                                                                    type='table') -%}
-        {% if is_temp_table %}
-            {% set temp_table_relation = elementary.make_temp_view_relation(temp_table_relation) %}
-        {% endif %}
-
-        {# Cache the test table for easy access later #}
-        {% set cache_key = "elementary_test_table|" ~ test_name ~ "|" ~ table_type %}
-        {% do elementary.set_cache(cache_key, temp_table_relation) %}
 
         {# Create the table if it doesn't exist #}
-        {%- do elementary.create_or_replace(is_temp_table, temp_table_relation, sql_query) %}
+        {%- do elementary.create_or_replace(false, temp_table_relation, sql_query) %}
 
+        {# Cache the test table for easy access later #}
+        {% set test_entry = elementary.get_cache("temp_test_table_relations_map").setdefault(test_name, {}) %}
+        {% do test_entry.update({table_type: temp_table_relation}) %}
         {{ return(temp_table_relation) }}
     {% endif %}
     {{ return(none) }}

--- a/macros/edr/tests/test_utils/create_model_baseline_table.sql
+++ b/macros/edr/tests/test_utils/create_model_baseline_table.sql
@@ -2,7 +2,7 @@
     {% set empty_table_query = elementary.empty_table([('column_name','string'),('data_type','string')]) %}
     {% set baseline_table_relation = elementary.create_elementary_test_table(database_name, schema_name,
                                                                              test_name | lower, 'schema_baseline',
-                                                                             empty_table_query, is_temp_table=False) %}
+                                                                             empty_table_query) %}
     {% do elementary.insert_rows(baseline_table_relation, baseline_columns, should_commit=True) %}
     {% do return(baseline_table_relation) %}
 {% endmacro %}

--- a/macros/edr/tests/test_utils/get_elementary_test_table.sql
+++ b/macros/edr/tests/test_utils/get_elementary_test_table.sql
@@ -1,7 +1,7 @@
 {% macro get_elementary_test_table(test_name, table_type) %}
     {% if execute %}
-        {% set cache_key = "elementary_test_table|" ~ test_name ~ "|" ~ table_type %}
-        {{ return(elementary.get_cache(cache_key)) }}
+        {% set test_entry = elementary.get_cache("temp_test_table_relations_map").setdefault(test_name, {}) %}
+        {% do return(test_entry.get(table_type)) %}
     {% endif %}
-    {{ return(none) }}
+    {% do return(none) %}
 {% endmacro %}

--- a/macros/utils/common_test_configs.sql
+++ b/macros/utils/common_test_configs.sql
@@ -312,9 +312,34 @@
         }
       },
       "elementary": {
+        "schema_changes": {
+          "description": "Monitors schema changes on the table of deleted, added, type changed columns over time. The test will fail if the table's schema changed from the previous execution of the test."
+        },
+        "schema_changes_from_baseline": {
+          "description": "Compares the table's schema against a baseline contract of columns defined in the table's configuration."
+        },
         "json_schema": {
           "quality_dimension": "validity",
-          "failed_row_count_calc": "count(*)"
+          "failed_row_count_calc": "count(*)",
+          "description": "This test validates that the data in a column is valid according to a JSON schema."
+        },
+        "volume_anomalies": {
+          "description": "Monitors the row count of your table over time."
+        },
+        "freshness_anomalies": {
+          "description": "Monitors the freshness of your table over time, as the expected time between data updates."
+        },
+        "event_freshness_anomalies": {
+          "description": "Monitors the freshness of event data over time, as the expected time it takes each event to load, that is, the time between when the event actually occurs (the event timestamp), and when it is loaded to the database (the update timestamp)."
+        },
+        "dimension_anomalies": {
+          "description": "Monitors the frequency of values in the configured dimensions over time."
+        },
+        "all_columns_anomalies": {
+          "description": "Column-level anomaly monitors (null_count, null_percent, zero_count, string_length, variance, etc.) on all the columns of the table. The test checks the data type of each column and only executes monitors that are relevant to it."
+        },
+        "column_anomalies": {
+          "description": "Column-level anomaly monitors (null_count, null_percent, zero_count, string_length, variance, etc.) on the column according to its data type."
         }
       }
     } %}

--- a/macros/utils/data_types/data_type.sql
+++ b/macros/utils/data_types/data_type.sql
@@ -25,8 +25,16 @@
 {%- endmacro -%}
 
 {% macro default__edr_type_string() %}
-    {# Redshift and Postgres #}
+    {# Redshift #}
     {% do return("varchar(4096)") %}
+{% endmacro %}
+
+{% macro postgres__edr_type_string() %}
+    {% if var("sync", false) %}
+        {% do return("text") %}
+    {% else %}
+        {% do return("varchar(4096)") %}
+    {% endif %}
 {% endmacro %}
 
 {% macro snowflake__edr_type_string() %}

--- a/macros/utils/sql_utils/to_sql_list.sql
+++ b/macros/utils/sql_utils/to_sql_list.sql
@@ -1,0 +1,8 @@
+{% macro to_sql_list(ls) %}
+    {% set rendered_items = [] %}
+    {% for item in ls %}
+        {% do rendered_items.append(elementary.render_value(item)) %}
+    {% endfor %}
+
+({{ rendered_items | join(', ') }})
+{% endmacro %}

--- a/macros/utils/table_operations/delete_and_insert.sql
+++ b/macros/utils/table_operations/delete_and_insert.sql
@@ -57,7 +57,8 @@
 {% macro spark__get_delete_and_insert_queries(relation, insert_relation, delete_relation, delete_column_key) %}
     {% set queries = [] %}
 
-    {% if delete_relation and relation.is_delta %}
+    {# Calling `is_delta` raises an error if `metadata` is None - https://github.com/databricks/dbt-databricks/blob/33dca4b66b05f268741030b33659d34ff69591c1/dbt/adapters/databricks/relation.py#L71 #}
+    {% if delete_relation and relation.metadata and relation.is_delta %}
         {% set delete_query %}
             merge into {{ relation }} as source
             using {{ delete_relation }} as target

--- a/macros/utils/table_operations/get_timestamped_table_suffix.sql
+++ b/macros/utils/table_operations/get_timestamped_table_suffix.sql
@@ -1,0 +1,3 @@
+{% macro get_timestamped_table_suffix() %}
+    {% do return(modules.datetime.datetime.utcnow().strftime('__tmp_%Y%m%d%H%M%S%f')) %}
+{% endmacro %}

--- a/macros/utils/table_operations/make_temp_relation.sql
+++ b/macros/utils/table_operations/make_temp_relation.sql
@@ -7,7 +7,7 @@
 {% endmacro %}
 
 {% macro spark__edr_make_temp_relation(base_relation, suffix) %}
-    {% set tmp_identifier = base_relation.identifier ~ suffix %}
+    {% set tmp_identifier = elementary.table_name_with_suffix(base_relation.identifier, suffix) %}
     {% set tmp_relation = base_relation.incorporate(path = {
         "schema": none,
         "identifier": tmp_identifier
@@ -23,7 +23,7 @@
 --- VIEWS
 {% macro make_temp_view_relation(base_relation, suffix=none) %}
     {% if not suffix %}
-        {% set suffix = modules.datetime.datetime.utcnow().strftime('__tmp_%Y%m%d%H%M%S%f') %}
+        {% set suffix = elementary.get_timestamped_table_suffix() %}
     {% endif %}
 
     {% do return(elementary.edr_make_temp_relation(base_relation, suffix)) %}
@@ -33,7 +33,7 @@
 --- TABLES
 {% macro make_temp_table_relation(base_relation, suffix=none) %}
     {% if not suffix %}
-        {% set suffix = modules.datetime.datetime.utcnow().strftime('__tmp_%Y%m%d%H%M%S%f') %}
+        {% set suffix = elementary.get_timestamped_table_suffix() %}
     {% endif %}
 
     {% do return(adapter.dispatch("make_temp_table_relation", "elementary")(base_relation, suffix)) %}
@@ -44,7 +44,7 @@
 {% endmacro %}
 
 {% macro databricks__make_temp_table_relation(base_relation, suffix) %}
-    {% set tmp_identifier = base_relation.identifier ~ suffix %}
+    {% set tmp_identifier = elementary.table_name_with_suffix(base_relation.identifier, suffix) %}
     {% set tmp_relation = api.Relation.create(
         identifier=tmp_identifier,
         schema=base_relation.schema,

--- a/models/edr/run_results/model_run_results.sql
+++ b/models/edr/run_results/model_run_results.sql
@@ -29,6 +29,7 @@ SELECT
     run_results.compile_started_at,
     run_results.compile_completed_at,
     run_results.compiled_code,
+    run_results.adapter_response,
     run_results.thread_id,
     models.database_name,
     models.schema_name,

--- a/models/edr/run_results/snapshot_run_results.sql
+++ b/models/edr/run_results/snapshot_run_results.sql
@@ -29,6 +29,7 @@ SELECT
     run_results.compile_started_at,
     run_results.compile_completed_at,
     run_results.compiled_code,
+    run_results.adapter_response,
     run_results.thread_id,
     snapshots.database_name,
     snapshots.schema_name,

--- a/models/run_results.yml
+++ b/models/run_results.yml
@@ -218,6 +218,10 @@ models:
       - name: thread_id
         data_type: string
         description: Id of the thread of this resource run.
+      
+      - name: adapter_response
+        data_type: string
+        description: Response returned by the adapter (Fields will be different for each adapters).
 
   - name: elementary_test_results
     description: >

--- a/models/run_results.yml
+++ b/models/run_results.yml
@@ -218,7 +218,7 @@ models:
       - name: thread_id
         data_type: string
         description: Id of the thread of this resource run.
-      
+
       - name: adapter_response
         data_type: string
         description: Response returned by the adapter (Fields will be different for each adapters).


### PR DESCRIPTION
## Description:

Added `adapter_response` field to `dbt_run_results` as different adapter returns different sets of fields. 
 
This might solve issues [[ELE-60] Obtain model run billing metrics](https://github.com/elementary-data/elementary/issues/420) and [Fill query_id for BigQuery](https://github.com/elementary-data/elementary/issues/1081)

