### PR TITLE
Add support for detection delay

### DIFF
--- a/integration_tests/tests/test_freshness_anomalies.py
+++ b/integration_tests/tests/test_freshness_anomalies.py
@@ -1,3 +1,4 @@
+from copy import copy
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
@@ -16,22 +17,39 @@ class FreshnessAnomaliesConfig:
     step: timedelta
     days_back: int
     backfill_days: int
+    detection_delay_hours: int
 
 
 HOURLY_CONFIG = FreshnessAnomaliesConfig(
-    period="hour", step=timedelta(minutes=10), days_back=14, backfill_days=2
+    period="hour",
+    step=timedelta(minutes=10),
+    days_back=14,
+    backfill_days=2,
+    detection_delay_hours=0,
 )
 
 DAILY_CONFIG = FreshnessAnomaliesConfig(
-    period="day", step=timedelta(hours=2), days_back=30, backfill_days=3
+    period="day",
+    step=timedelta(hours=2),
+    days_back=30,
+    backfill_days=3,
+    detection_delay_hours=0,
 )
 
 WEEKLY_CONFIG = FreshnessAnomaliesConfig(
-    period="week", step=timedelta(hours=12), days_back=7 * 15, backfill_days=14
+    period="week",
+    step=timedelta(hours=12),
+    days_back=7 * 15,
+    backfill_days=14,
+    detection_delay_hours=0,
 )
 
 MONTHLY_CONFIG = FreshnessAnomaliesConfig(
-    period="month", step=timedelta(days=2), days_back=30 * 15, backfill_days=60
+    period="month",
+    step=timedelta(days=2),
+    days_back=30 * 15,
+    backfill_days=60,
+    detection_delay_hours=0,
 )
 
 
@@ -47,6 +65,7 @@ class TestFreshnessAnomalies:
             days_back=config.days_back,
             backfill_days=config.backfill_days,
             time_bucket=dict(period=config.period, count=1),
+            detection_delay=dict(period='hour', count=config.detection_delay_hours),
         )
 
     def _skip_redshift_monthly(
@@ -93,6 +112,28 @@ class TestFreshnessAnomalies:
             test_id, TEST_NAME, self._get_test_config(config), data=data
         )
         assert result["status"] == "fail"
+
+    def test_stop_with_delay(
+        self,
+        test_id: str,
+        dbt_project: DbtProject,
+        config: FreshnessAnomaliesConfig,
+        target: str,
+    ):
+        self._skip_redshift_monthly(target, config)
+        anomaly_date = datetime.now() - timedelta(days=config.backfill_days)
+        data = [
+            {TIMESTAMP_COLUMN: date.strftime(DATE_FORMAT)}
+            for date in generate_dates(
+                anomaly_date, step=config.step, days_back=(config.days_back)
+            )
+        ]
+        delayed_config = copy(config)
+        delayed_config.detection_delay_hours = 24 * config.backfill_days
+        result = dbt_project.test(
+            test_id, TEST_NAME, self._get_test_config(delayed_config), data=data
+        )
+        assert result["status"] == "pass"
 
     def test_slower_rate(
         self,

--- a/macros/edr/data_monitoring/anomaly_detection/get_anomaly_scores_query.sql
+++ b/macros/edr/data_monitoring/anomaly_detection/get_anomaly_scores_query.sql
@@ -28,7 +28,8 @@
     {%- else %}
         {%- set bucket_seasonality_expr = elementary.const_as_text('no_seasonality') %}
     {%- endif %}
-    {%- set min_bucket_start_expr = elementary.get_trunc_min_bucket_start_expr(metric_properties, test_configuration.days_back) %}
+    {%- set detection_end = elementary.get_detection_end(test_configuration.detection_delay) %}
+    {%- set min_bucket_start_expr = elementary.get_trunc_min_bucket_start_expr(detection_end, metric_properties, test_configuration.days_back) %}
 
     {%- set anomaly_scores_query %}
 

--- a/macros/edr/tests/test_all_columns_anomalies.sql
+++ b/macros/edr/tests/test_all_columns_anomalies.sql
@@ -1,4 +1,4 @@
-{% test all_columns_anomalies(model, column_anomalies, exclude_prefix, exclude_regexp, timestamp_column, where_expression, anomaly_sensitivity, anomaly_direction, min_training_set_size, time_bucket, days_back, backfill_days, seasonality, sensitivity) %}
+{% test all_columns_anomalies(model, column_anomalies, exclude_prefix, exclude_regexp, timestamp_column, where_expression, anomaly_sensitivity, anomaly_direction, min_training_set_size, time_bucket, days_back, backfill_days, seasonality, sensitivity, detection_delay) %}
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('dbt_run_results') }}
@@ -34,7 +34,8 @@
                                                                                                    days_back=days_back,
                                                                                                    backfill_days=backfill_days,
                                                                                                    seasonality=seasonality,
-                                                                                                   sensitivity=sensitivity) %}
+                                                                                                   sensitivity=sensitivity,
+                                                                                                   detection_delay=detection_delay) %}
         {%- if not test_configuration %}
             {{ exceptions.raise_compiler_error("Failed to create test configuration dict for test `{}`".format(test_table_name)) }}
         {%- endif %}
@@ -56,6 +57,7 @@
                         {%- set min_bucket_start, max_bucket_end = elementary.get_test_buckets_min_and_max(model_relation=model_relation,
                                                                                                 backfill_days=test_configuration.backfill_days,
                                                                                                 days_back=test_configuration.days_back,
+                                                                                                detection_delay=test_configuration.detection_delay,
                                                                                                 monitors=column_monitors,
                                                                                                 column_name=column_name,
                                                                                                 metric_properties=metric_properties) %}

--- a/macros/edr/tests/test_column_anomalies.sql
+++ b/macros/edr/tests/test_column_anomalies.sql
@@ -1,4 +1,4 @@
-{% test column_anomalies(model, column_name, column_anomalies, timestamp_column, where_expression, anomaly_sensitivity, anomaly_direction, min_training_set_size, time_bucket, days_back, backfill_days, seasonality, sensitivity) %}
+{% test column_anomalies(model, column_name, column_anomalies, timestamp_column, where_expression, anomaly_sensitivity, anomaly_direction, min_training_set_size, time_bucket, days_back, backfill_days, seasonality, sensitivity, detection_delay) %}
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('dbt_run_results') }}
@@ -32,7 +32,8 @@
                                                                                                    days_back=days_back,
                                                                                                    backfill_days=backfill_days,
                                                                                                    seasonality=seasonality,
-                                                                                                   sensitivity=sensitivity) %}
+                                                                                                   sensitivity=sensitivity,
+                                                                                                   detection_delay=detection_delay) %}
         {%- if not test_configuration %}
             {{ exceptions.raise_compiler_error("Failed to create test configuration dict for test `{}`".format(test_table_name)) }}
         {%- endif %}
@@ -50,6 +51,7 @@
             {%- set min_bucket_start, max_bucket_end = elementary.get_test_buckets_min_and_max(model_relation=model_relation,
                                                                                     backfill_days=test_configuration.backfill_days,
                                                                                     days_back=test_configuration.days_back,
+                                                                                    detection_delay=test_configuration.detection_delay,
                                                                                     monitors=column_monitors,
                                                                                     column_name=column_name,
                                                                                     metric_properties=metric_properties) %}

--- a/macros/edr/tests/test_configuration/get_anomalies_test_configuration.sql
+++ b/macros/edr/tests/test_configuration/get_anomalies_test_configuration.sql
@@ -17,7 +17,8 @@
                                           event_timestamp_column,
                                           dimensions,
                                           sensitivity,
-                                          ignore_small_changes) %}
+                                          ignore_small_changes,
+                                          detection_delay) %}
 
     {%- set model_graph_node = elementary.get_model_graph_node(model_relation) %}
 
@@ -34,6 +35,7 @@
     {%- set time_bucket = elementary.get_time_bucket(time_bucket, model_graph_node) %}
     {%- set days_back = elementary.get_days_back(days_back, model_graph_node, seasonality) %}
     {%- set seasonality = elementary.get_seasonality(seasonality, model_graph_node, time_bucket, timestamp_column) %}
+    {%- set detection_delay = elementary.get_detection_delay(detection_delay, model_graph_node) %}
 
     {%- set ignore_small_changes = elementary.get_test_argument('ignore_small_changes', ignore_small_changes, model_graph_node) %}
     {# Validate ignore_small_changes #}
@@ -51,7 +53,8 @@
        'freshness_column': freshness_column,
        'event_timestamp_column': event_timestamp_column,
        'dimensions': dimensions,
-       'ignore_small_changes': ignore_small_changes
+       'ignore_small_changes': ignore_small_changes,
+       'detection_delay': detection_delay
         } %}
     {%- set test_configuration = elementary.empty_dict_keys_to_none(test_configuration) -%}
     {%- do elementary.validate_mandatory_configuration(test_configuration, mandatory_params) -%}

--- a/macros/edr/tests/test_configuration/get_detection_delay.sql
+++ b/macros/edr/tests/test_configuration/get_detection_delay.sql
@@ -1,0 +1,72 @@
+{% macro get_no_detection_delay() %}
+  {% do return({"period": "hour", "count": 0}) %}
+{% endmacro %}
+
+{% macro get_default_detection_delay() %}
+  {% do return(elementary.get_no_detection_delay()) %}
+{% endmacro %}
+
+{% macro get_detection_delay_supported_periods() %}
+  {% do return(["hour", "day", "week"]) %}
+{% endmacro %}
+
+{% macro get_detection_delay(detection_delay, model_graph_node) %}
+    {%- set configured_detection_delay = elementary.get_test_argument('detection_delay', detection_delay, model_graph_node) %}
+    {%- do elementary.validate_detection_delay(configured_detection_delay) %}
+    {%- set default_detection_delay = elementary.get_default_detection_delay() %}
+
+    {%- if not configured_detection_delay %}
+        {{ return(default_detection_delay) }}
+    {%- else %}
+        {%- set detection_delay = default_detection_delay.copy() %}
+        {%- do detection_delay.update(configured_detection_delay) %}
+        {{ return(detection_delay) }}
+    {%- endif %}
+{% endmacro %}
+
+{% macro validate_detection_delay(detection_delay) %}
+    {% if detection_delay %}
+        {%- if detection_delay is not mapping %}
+            {% do exceptions.raise_compiler_error(
+            "
+            Invalid detection_delay format. Expected format:
+
+               detection_delay:
+                 count: int
+                 period: string
+            ") %}
+        {%- endif %}
+        {%- if detection_delay is mapping %}
+            {%- set invalid_keys = [] %}
+            {%- set valid_keys = ['period', 'count'] %}
+            {%- for key, value in detection_delay.items() %}
+                {%- if key not in valid_keys %}
+                    {%- do invalid_keys.append(key) -%}
+                {%- endif %}
+            {%- endfor %}
+            {%- if invalid_keys | length > 0 %}
+                {% do exceptions.raise_compiler_error(
+                ("
+                Found invalid keys in detection_delay: {0}.
+                Supported keys: {1}.
+                Expected format:
+
+                   detection_delay:
+                     count: int
+                     period: string
+                ").format(invalid_keys, valid_keys)) %}
+            {%- endif %}
+        {%- endif %}
+
+        {% if detection_delay.count and detection_delay.count is not integer %}
+            {% do exceptions.raise_compiler_error("detection_delay.count expects valid integer, got: {} (If it's an integer, try to remove quotes)".format(detection_delay.count)) %}
+        {% endif %}
+        {% if detection_delay.count < 0 %}
+            {% do exceptions.raise_compiler_error("detection_delay.count can't be negative, got: {})".format(detection_delay.count)) %}
+        {% endif %}
+        {% set supported_periods = elementary.get_detection_delay_supported_periods() %}
+        {% if detection_delay.period and detection_delay.period not in supported_periods %}
+            {% do exceptions.raise_compiler_error("detection_delay.period value should be one of {0}, got: {1}".format(supported_periods, detection_delay.period)) %}
+        {% endif %}
+    {% endif %}
+{% endmacro %}

--- a/macros/edr/tests/test_dimension_anomalies.sql
+++ b/macros/edr/tests/test_dimension_anomalies.sql
@@ -1,4 +1,4 @@
-{% test dimension_anomalies(model, dimensions, timestamp_column, where_expression, anomaly_sensitivity, anomaly_direction, min_training_set_size, time_bucket, days_back, backfill_days, seasonality, sensitivity) %}
+{% test dimension_anomalies(model, dimensions, timestamp_column, where_expression, anomaly_sensitivity, anomaly_direction, min_training_set_size, time_bucket, days_back, backfill_days, seasonality, sensitivity, detection_delay) %}
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('dbt_run_results') }}
@@ -35,7 +35,8 @@
                                                                                                    backfill_days=backfill_days,
                                                                                                    seasonality=seasonality,
                                                                                                    dimensions=dimensions,
-                                                                                                   sensitivity=sensitivity) %}
+                                                                                                   sensitivity=sensitivity,
+                                                                                                   detection_delay=detection_delay,) %}
         {%- if not test_configuration %}
             {{ exceptions.raise_compiler_error("Failed to create test configuration dict for test `{}`".format(test_table_name)) }}
         {%- endif %}
@@ -44,6 +45,7 @@
         {%- set min_bucket_start, max_bucket_end = elementary.get_test_buckets_min_and_max(model_relation=model_relation,
                                                                                 backfill_days=test_configuration.backfill_days,
                                                                                 days_back=test_configuration.days_back,
+                                                                                detection_delay=test_configuration.detection_delay,
                                                                                 metric_properties=metric_properties) %}
 
         {{ elementary.debug_log('min_bucket_start - ' ~ min_bucket_start) }}

--- a/macros/edr/tests/test_event_freshness_anomalies.sql
+++ b/macros/edr/tests/test_event_freshness_anomalies.sql
@@ -1,4 +1,4 @@
-{% test event_freshness_anomalies(model, event_timestamp_column, update_timestamp_column, where_expression, anomaly_sensitivity, anomaly_direction, min_training_set_size, time_bucket, days_back, backfill_days, sensitivity) %}
+{% test event_freshness_anomalies(model, event_timestamp_column, update_timestamp_column, where_expression, anomaly_sensitivity, anomaly_direction, min_training_set_size, time_bucket, days_back, backfill_days, sensitivity, detection_delay) %}
   -- depends_on: {{ ref('monitors_runs') }}
   -- depends_on: {{ ref('data_monitoring_metrics') }}
   -- depends_on: {{ ref('dbt_run_results') }}
@@ -29,7 +29,8 @@
       backfill_days=backfill_days,
       event_timestamp_column=event_timestamp_column,
       mandatory_params=['event_timestamp_column'],
-      sensitivity=sensitivity
+      sensitivity=sensitivity,
+      detection_delay=detection_delay
     )
   }}
 {% endtest %}

--- a/macros/edr/tests/test_freshness_anomalies.sql
+++ b/macros/edr/tests/test_freshness_anomalies.sql
@@ -1,4 +1,4 @@
-{% test freshness_anomalies(model, timestamp_column, where_expression, anomaly_sensitivity, anomaly_direction, min_training_set_size, time_bucket, days_back, backfill_days, seasonality, sensitivity) %}
+{% test freshness_anomalies(model, timestamp_column, where_expression, anomaly_sensitivity, anomaly_direction, min_training_set_size, time_bucket, days_back, backfill_days, seasonality, sensitivity, detection_delay) %}
   -- depends_on: {{ ref('monitors_runs') }}
   -- depends_on: {{ ref('data_monitoring_metrics') }}
   -- depends_on: {{ ref('dbt_run_results') }}
@@ -16,7 +16,8 @@
       backfill_days=backfill_days,
       mandatory_params=['timestamp_column'],
       seasonality=seasonality,
-      sensitivity=sensitivity
+      sensitivity=sensitivity,
+      detection_delay=detection_delay
     )
   }}
 {% endtest %}

--- a/macros/edr/tests/test_table_anomalies.sql
+++ b/macros/edr/tests/test_table_anomalies.sql
@@ -1,4 +1,4 @@
-{% test table_anomalies(model, table_anomalies, timestamp_column, where_expression, anomaly_sensitivity, anomaly_direction, min_training_set_size, time_bucket, days_back, backfill_days, seasonality, mandatory_params=none, event_timestamp_column=none, freshness_column=none, sensitivity=none, ignore_small_changes={"spike_failure_percent_threshold": none, "drop_failure_percent_threshold": none}) %}
+{% test table_anomalies(model, table_anomalies, timestamp_column, where_expression, anomaly_sensitivity, anomaly_direction, min_training_set_size, time_bucket, days_back, backfill_days, seasonality, mandatory_params=none, event_timestamp_column=none, freshness_column=none, sensitivity=none, ignore_small_changes={"spike_failure_percent_threshold": none, "drop_failure_percent_threshold": none}, detection_delay=none) %}
     -- depends_on: {{ ref('monitors_runs') }}
     -- depends_on: {{ ref('data_monitoring_metrics') }}
     -- depends_on: {{ ref('dbt_run_results') }}
@@ -35,17 +35,19 @@
                                                                                                    seasonality=seasonality,
                                                                                                    event_timestamp_column=event_timestamp_column,
                                                                                                    sensitivity=sensitivity,
-                                                                                                   ignore_small_changes=ignore_small_changes) %}
-                {% if not test_configuration %}
+                                                                                                   ignore_small_changes=ignore_small_changes,
+                                                                                                   detection_delay=detection_delay) %}
+        {% if not test_configuration %}
             {{ exceptions.raise_compiler_error("Failed to create test configuration dict for test `{}`".format(test_table_name)) }}
         {% endif %}
         {{ elementary.debug_log('test configuration - ' ~ test_configuration) }}
         {%- set table_monitors = elementary.get_final_table_monitors(table_anomalies) %}
         {{ elementary.debug_log('table_monitors - ' ~ table_monitors) }}
         {% if test_configuration.timestamp_column %}
-            {%- set min_bucket_start, max_bucket_end = elementary.get_test_buckets_min_and_max(model_relation,
-                                                                                            test_configuration.backfill_days,
-                                                                                            test_configuration.days_back,
+            {%- set min_bucket_start, max_bucket_end = elementary.get_test_buckets_min_and_max(model_relation=model_relation,
+                                                                                            backfill_days=test_configuration.backfill_days,
+                                                                                            days_back=test_configuration.days_back,
+                                                                                            detection_delay=test_configuration.detection_delay,
                                                                                             monitors=table_monitors,
                                                                                             metric_properties=metric_properties) %}
         {%- endif %}

--- a/macros/edr/tests/test_volume_anomalies.sql
+++ b/macros/edr/tests/test_volume_anomalies.sql
@@ -1,4 +1,4 @@
-{% test volume_anomalies(model, timestamp_column, where_expression, anomaly_sensitivity, anomaly_direction, min_training_set_size, time_bucket, days_back, backfill_days, seasonality, sensitivity, ignore_small_changes) %}
+{% test volume_anomalies(model, timestamp_column, where_expression, anomaly_sensitivity, anomaly_direction, min_training_set_size, time_bucket, days_back, backfill_days, seasonality, sensitivity, ignore_small_changes, detection_delay) %}
   -- depends_on: {{ ref('monitors_runs') }}
   -- depends_on: {{ ref('data_monitoring_metrics') }}
   -- depends_on: {{ ref('dbt_run_results') }}
@@ -17,7 +17,8 @@
       backfill_days=backfill_days,
       seasonality=seasonality,
       sensitivity=sensitivity,
-      ignore_small_changes=ignore_small_changes
+      ignore_small_changes=ignore_small_changes,
+      detection_delay=detection_delay
     )
   }}
 {% endtest %}


### PR DESCRIPTION
Initial implementation for https://github.com/elementary-data/elementary/issues/911

Since I'm not fully familiar with the elementary project as a developer, I'm expecting a lot of feedback and wanted to get this out before I spend too much time on the implementation.

One thing is that I added detection_delay_hours as a parameter as it didn't seem likely the delay would need specifying different time intervals.
I also implemented it as a shift in both the start and end time in the buckets. This matches my particular use-case but wanted to see if there are drawbacks compared to only changing the end time.

Also having issue getting tests to run successfully locally. Not sure why that is, but I'll keep trying to get them to succeed.

I'm sure I'm missing a bunch of things, like adding documentation, but that can be tackled as a follow-up.