### PR TITLE
added conditional statement to quote temp_table_name if adapter quoting config is set to False 

### DIFF
--- a/macros/edr/tests/test_utils/create_elementary_test_table.sql
+++ b/macros/edr/tests/test_utils/create_elementary_test_table.sql
@@ -2,7 +2,7 @@
     {% if execute %}
         {% set temp_table_name = elementary.table_name_with_suffix(test_name, "__" ~ table_type ~ elementary.get_timestamped_table_suffix()).replace("*", "") %}
         
-        default_identifier_quoting = api.Relation.get_default_quote_policy().get_part("identifier")        
+        {% set default_identifier_quoting = api.Relation.get_default_quote_policy().get_part("identifier") %}        
         {% if adapter.config.quoting.get("identifier",default_identifier_quoting) %}
             {% set temp_table_name = adapter.quote(temp_table_name) %}
         {% endif %}

--- a/macros/edr/tests/test_utils/create_elementary_test_table.sql
+++ b/macros/edr/tests/test_utils/create_elementary_test_table.sql
@@ -1,6 +1,10 @@
 {% macro create_elementary_test_table(database_name, schema_name, test_name, table_type, sql_query) %}
     {% if execute %}
         {% set temp_table_name = elementary.table_name_with_suffix(test_name, "__" ~ table_type ~ elementary.get_timestamped_table_suffix()).replace("*", "") %}
+        {% if adapter.type() == 'snowflake'}
+            {% set temp_table_name = adapter.quote(temp_table_name) %}
+        {% endif %}
+
         {{ elementary.debug_log(table_type ~ ' table: ' ~ database_name ~ '.' ~ schema_name ~ '.' ~ temp_table_name) }}
 
         {% set _, temp_table_relation = dbt.get_or_create_relation(database=database_name,

--- a/macros/edr/tests/test_utils/create_elementary_test_table.sql
+++ b/macros/edr/tests/test_utils/create_elementary_test_table.sql
@@ -1,7 +1,9 @@
 {% macro create_elementary_test_table(database_name, schema_name, test_name, table_type, sql_query) %}
     {% if execute %}
         {% set temp_table_name = elementary.table_name_with_suffix(test_name, "__" ~ table_type ~ elementary.get_timestamped_table_suffix()).replace("*", "") %}
-        {% if adapter.type() == 'snowflake'}
+        
+        default_identifier_quoting = api.Relation.get_default_quote_policy().get_part("identifier")        
+        {% if adapter.config.quoting.get("identifier",default_identifier_quoting) %}
             {% set temp_table_name = adapter.quote(temp_table_name) %}
         {% endif %}
 

--- a/macros/edr/tests/test_utils/create_elementary_test_table.sql
+++ b/macros/edr/tests/test_utils/create_elementary_test_table.sql
@@ -3,7 +3,7 @@
         {% set temp_table_name = elementary.table_name_with_suffix(test_name, "__" ~ table_type ~ elementary.get_timestamped_table_suffix()).replace("*", "") %}
         
         {% set default_identifier_quoting = api.Relation.get_default_quote_policy().get_part("identifier") %}        
-        {% if not adapter.config.quoting.get("identifier",default_identifier_quoting) %}
+        {% if not adapter.config.quoting.get("identifier", default_identifier_quoting) %}
             {% set temp_table_name = adapter.quote(temp_table_name) %}
         {% endif %}
 

--- a/macros/edr/tests/test_utils/create_elementary_test_table.sql
+++ b/macros/edr/tests/test_utils/create_elementary_test_table.sql
@@ -3,7 +3,7 @@
         {% set temp_table_name = elementary.table_name_with_suffix(test_name, "__" ~ table_type ~ elementary.get_timestamped_table_suffix()).replace("*", "") %}
         
         {% set default_identifier_quoting = api.Relation.get_default_quote_policy().get_part("identifier") %}        
-        {% if adapter.config.quoting.get("identifier",default_identifier_quoting) %}
+        {% if not adapter.config.quoting.get("identifier",default_identifier_quoting) %}
             {% set temp_table_name = adapter.quote(temp_table_name) %}
         {% endif %}
 


### PR DESCRIPTION
added conditional statement to check if dbt adapter equals 'snowflake' and if so then add quotes around temp_table_name for elementary test table to handle hyphen names in model for snowflake adapter (since default quoting config is set to False for Snowflake according to dbt docs)