### PR TITLE
Add generic test for exposure schema validation

### DIFF
--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -78,6 +78,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.8.17"
+          cache: "pip"
 
       - name: Install Spark requirements
         if: inputs.warehouse-type == 'spark'

--- a/integration_tests/dbt_project/dbt_project.yml
+++ b/integration_tests/dbt_project/dbt_project.yml
@@ -6,7 +6,7 @@ profile: "elementary_tests"
 model-paths: ["models"]
 analysis-paths: ["analyses"]
 test-paths: ["tests"]
-seed-paths: ["data"]
+seed-paths: ["data", "seeds"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 

--- a/integration_tests/dbt_project/models/customers.sql
+++ b/integration_tests/dbt_project/models/customers.sql
@@ -1,0 +1,1 @@
+ select * from {{ ref('stg_customers') }}

--- a/integration_tests/dbt_project/models/exposures.yml
+++ b/integration_tests/dbt_project/models/exposures.yml
@@ -1,0 +1,42 @@
+version: 2
+
+exposures:
+  - name: customers
+    label: CustomersFTW
+    type: dashboard
+    maturity: high
+    url: https://bi.tool/dashboards/1
+    description: >
+      Did someone say "exponential growth"?
+
+    depends_on:
+      - ref('customers')
+
+    owner:
+      name: Callum McData
+      email: data@jaffleshop.com
+    meta:
+      referenced_columns:
+        - column_name: id
+          data_type: numeric
+          node: ref('customers')
+
+  - name: orders
+    label: Returned Orders
+    type: dashboard
+    maturity: high
+    url: https://bi.tool/dashboards/2
+    description: >
+      Did someone say "exponential growth"?
+
+    depends_on:
+      - ref('orders')
+
+    owner:
+      name: Callum McData
+      email: data@jaffleshop.com
+    meta:
+      referenced_columns:
+        - column_name: "order_id"
+          data_type: "string"
+        - column_name: "ZOMG"

--- a/integration_tests/dbt_project/models/orders.sql
+++ b/integration_tests/dbt_project/models/orders.sql
@@ -1,0 +1,1 @@
+select order_id, customer_id, amount from {{ ref('stg_orders') }}

--- a/integration_tests/dbt_project/models/schema.yml
+++ b/integration_tests/dbt_project/models/schema.yml
@@ -1,0 +1,35 @@
+version: 2
+
+models:
+  - name: customers
+    description: This table has basic information about a customer, as well as some derived facts based on a customer's orders
+    tests:
+      - elementary.exposure_schema_validity:
+          tags: [exposure_customers]
+
+    columns:
+      - name: id
+        description: This is a unique identifier for a customer
+
+      - name: name
+        description: Customer's name.
+
+  - name: orders
+    description: This table has basic information about orders, as well as some derived facts based on payments
+
+    tests:
+      - elementary.exposure_schema_validity:
+          tags: [exposure_orders]
+
+    columns:
+      - name: order_id
+        description: This is a unique identifier for an order
+
+      - name: customer_id
+        description: Foreign key to the customers table
+
+      - name: order_date
+        description: Date (UTC) that the order was placed
+
+      - name: amount
+        description: Total amount (AUD) of the order

--- a/integration_tests/dbt_project/seeds/stg_customers.csv
+++ b/integration_tests/dbt_project/seeds/stg_customers.csv
@@ -1,0 +1,3 @@
+id,name
+1,Erik
+2,Zaadi

--- a/integration_tests/dbt_project/seeds/stg_orders.csv
+++ b/integration_tests/dbt_project/seeds/stg_orders.csv
@@ -1,0 +1,6 @@
+order_id,customer_id,amount
+1,1,42
+2,1,42
+3,1,42
+4,1,42
+5,2,42

--- a/integration_tests/tests/test_exposure_schema_validity.py
+++ b/integration_tests/tests/test_exposure_schema_validity.py
@@ -1,0 +1,192 @@
+from typing import List
+
+import pytest
+from dbt_project import DbtProject
+
+DBT_TEST_NAME = "elementary.exposure_schema_validity"
+
+
+def seed(dbt_project: DbtProject):
+    seed_result = dbt_project.dbt_runner.seed(full_refresh=True)
+    assert seed_result is True
+
+
+def validate_failing_query_output(
+    dbt_dir: str,
+    test_output: str,
+    table_name: str,
+    expected_content_strings: List[str],
+):
+    generated_query = f"target/compiled/elementary_tests/models/schema.yml/elementary_exposure_schema_validity_{table_name}_.sql"
+    assert generated_query in test_output
+    output_file = f"{dbt_dir}/{generated_query}"
+    with open(output_file) as f:
+        generated_query_content = f.read()
+        for content_string_to_validate in expected_content_strings:
+            assert content_string_to_validate in generated_query_content
+
+
+def test_exposure_schema_validity_existing_exposure_yml_invalid(
+    test_id: str, dbt_project: DbtProject
+):
+    seed(dbt_project)
+    run_result = dbt_project.dbt_runner.run(
+        models="orders", full_refresh=True, quiet=True
+    )
+    assert run_result is True
+    test_result, test_output = dbt_project.dbt_runner._run_command(
+        command_args=["test", "-s", "tag:exposure_orders"],
+        log_format="text",
+        capture_output=True,
+        quiet=True,
+        log_output=False,
+    )
+    assert test_result is False
+    validate_failing_query_output(
+        dbt_project.project_dir_path,
+        test_output,
+        "orders",
+        [
+            "different data type for the column order_id string vs",
+            "ZOMG column missing in the model",
+        ],
+    )
+
+
+def test_exposure_schema_validity_existing_exposure_yml_valid(
+    test_id: str, dbt_project: DbtProject
+):
+    seed(dbt_project)
+    run_result = dbt_project.dbt_runner.run(
+        models="customers", full_refresh=True, quiet=True
+    )
+    assert run_result is True
+    test_result, test_output = dbt_project.dbt_runner._run_command(
+        command_args=["test", "-s", "tag:exposure_customers"],
+        capture_output=True,
+        quiet=True,
+        log_output=False,
+    )
+    assert test_result is True
+
+
+@pytest.mark.skip_targets(["spark"])
+def test_exposure_schema_validity_no_exposures(test_id: str, dbt_project: DbtProject):
+    test_result = dbt_project.test(test_id, DBT_TEST_NAME)
+    assert test_result["status"] == "pass"
+
+
+@pytest.mark.skip_targets(["spark"])
+def test_exposure_schema_validity_correct_columns_and_types(
+    test_id: str, dbt_project: DbtProject
+):
+    explicit_target_for_bigquery = (
+        "other"
+        if dbt_project.dbt_runner.target in ["bigquery", "snowflake", ""]
+        else "string"
+    )
+    DBT_TEST_ARGS = {
+        "node": "models.exposures_test",
+        "columns": [{"name": "order_id", "dtype": "string"}],
+        "exposures": {
+            "ZOMG": {
+                "meta": {
+                    "referenced_columns": [
+                        {
+                            "column_name": "order_id",
+                            "data_type": explicit_target_for_bigquery,
+                        }
+                    ]
+                },
+                "url": "http://bla.com",
+                "name": "ZOMG",
+                "depends_on": {"nodes": ["models.exposures_test"]},
+            }
+        },
+    }
+    test_result = dbt_project.test(
+        test_id, DBT_TEST_NAME, DBT_TEST_ARGS, columns=[dict(name="bla")], as_model=True
+    )
+    assert test_result["status"] == "pass"
+
+
+@pytest.mark.skip_targets(["spark"])
+def test_exposure_schema_validity_correct_columns_and_invalid_type(
+    test_id: str, dbt_project: DbtProject
+):
+    DBT_TEST_ARGS = {
+        "node": "models.exposures_test",
+        "columns": [{"name": "order_id", "dtype": "numeric"}],
+        "exposures": {
+            "ZOMG": {
+                "meta": {
+                    "referenced_columns": [
+                        {"column_name": "order_id", "data_type": "string"}
+                    ]
+                },
+                "url": "http://bla.com",
+                "name": "ZOMG",
+                "depends_on": {"nodes": ["models.exposures_test"]},
+            }
+        },
+    }
+    test_result = dbt_project.test(
+        test_id, DBT_TEST_NAME, DBT_TEST_ARGS, columns=[dict(name="bla")], as_model=True
+    )
+
+    assert (
+        "different data type for the column order_id string vs"
+        in test_result["test_results_query"]
+    )
+    assert test_result["status"] == "fail"
+
+
+@pytest.mark.skip_targets(["spark"])
+def test_exposure_schema_validity_correct_columns_and_missing_type(
+    test_id: str, dbt_project: DbtProject
+):
+    DBT_TEST_ARGS = {
+        "node": "models.exposures_test",
+        "columns": [{"name": "order_id", "dtype": "numeric"}],
+        "exposures": {
+            "ZOMG": {
+                "meta": {"referenced_columns": [{"column_name": "order_id"}]},
+                "url": "http://bla.com",
+                "name": "ZOMG",
+                "depends_on": {"nodes": ["models.exposures_test"]},
+            }
+        },
+    }
+    test_result = dbt_project.test(
+        test_id, DBT_TEST_NAME, DBT_TEST_ARGS, columns=[dict(name="bla")], as_model=True
+    )
+
+    assert test_result["status"] == "pass"
+
+
+@pytest.mark.skip_targets(["spark"])
+def test_exposure_schema_validity_missing_columns(
+    test_id: str, dbt_project: DbtProject
+):
+    DBT_TEST_ARGS = {
+        "node": "models.exposures_test",
+        "columns": [{"name": "order", "dtype": "numeric"}],
+        "exposures": {
+            "ZOMG": {
+                "meta": {
+                    "referenced_columns": [
+                        {"column_name": "order_id", "data_type": "string"}
+                    ]
+                },
+                "url": "http://bla.com",
+                "name": "ZOMG",
+                "depends_on": {"nodes": ["models.exposures_test"]},
+            }
+        },
+    }
+    test_result = dbt_project.test(
+        test_id, DBT_TEST_NAME, DBT_TEST_ARGS, columns=[dict(name="bla")], as_model=True
+    )
+
+    assert "order_id column missing in the model" in test_result["test_results_query"]
+    assert test_result["status"] == "fail"

--- a/macros/edr/materializations/test/test.sql
+++ b/macros/edr/materializations/test/test.sql
@@ -82,7 +82,8 @@
   {% set test_type_handler_map = {
     "anomaly_detection": elementary.handle_anomaly_test,
     "schema_change": elementary.handle_schema_changes_test,
-    "dbt_test": elementary.handle_dbt_test
+    "dbt_test": elementary.handle_dbt_test,
+    "integrity": elementary.handle_dbt_test
   } %}
   {% set test_type_handler = test_type_handler_map.get(test_type) %}
   {% if not test_type_handler %}

--- a/macros/edr/tests/test_exposure_schema_validity.sql
+++ b/macros/edr/tests/test_exposure_schema_validity.sql
@@ -1,0 +1,91 @@
+{% test exposure_schema_validity(model, exposures, node, columns) %}
+    {%- if not execute -%}
+        {%- do return(none) -%}
+    {%- endif -%}
+
+    {%- if dbt_version <= '1.3.0' -%}
+        {# attached_node is only available on newer dbt versions #}
+        {%- set base_node = context['model']['depends_on']['nodes'][0] -%}
+    {%- else -%}
+        {%- set base_node = context['model']['attached_node'] -%}
+    {%- endif -%}
+
+    {# Parameters used only for dependency injection in integration tests #}
+    {%- set node = node or base_node -%}
+    {%- set exposures = (exposures or graph.exposures).values() -%}
+    {%- set columns = columns or adapter.get_columns_in_relation(model)  -%}
+
+    {%- set model_relation = elementary.get_model_relation_for_test(model, context["model"]) -%}
+    {%- set full_table_name = elementary.relation_to_full_name(model_relation) -%}
+    {{- elementary.test_log('start', full_table_name, 'exposure validation') -}}
+
+    {%- set matching_exposures = [] -%}
+
+    {%- for exposure in exposures -%}
+        {#
+
+        We need the 'meta' property to be defined in the exposure, since column level info is not available on exposures.
+        The 'meta' property needs to have a 'referenced_columns' array (see properties in the next comment)
+
+        #}
+        {%- if node in exposure.depends_on.nodes and (exposure['meta'] or none) is not none -%}
+            {%- do matching_exposures.append(exposure) -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {%- if matching_exposures | length > 0 -%}
+        {%- set columns_dict = {} -%}
+        {%- for column in columns -%}
+            {%- do columns_dict.update({ column['name'].strip('"').strip("'") | upper : elementary.normalize_data_type(column['dtype']) }) -%}
+        {%- endfor -%}
+        {%- set invalid_exposures = [] -%}
+        {%- for exposure in matching_exposures -%}
+            {%- set meta = exposure['meta'] or none -%}
+            {%- if meta != none and (meta['referenced_columns'] or none) is iterable -%}
+                {%- for exposure_column in meta['referenced_columns'] -%}
+                    {#
+                        Each column in 'referenced_columns' has the following property:
+
+                        'column_name'
+
+                        Optionally, you can specify the following properties:
+
+                        'data_type' - the specific data type of the column
+
+                        'node' - the ref to the source node of the specific column used in the exposure
+
+                    #}
+                    {%- if matching_exposures | length == 1 or (context['render'](exposure_column['node'] or '')) == node -%}
+                        {%- if exposure_column['column_name'] | upper not in columns_dict.keys() -%}
+                            {%- do invalid_exposures.append({
+                                    'exposure': exposure['name'],
+                                    'url': exposure['url'],
+                                    'error': exposure_column['column_name'] ~ ' column missing in the model'
+                                    })
+                            -%}
+                        {%- elif (exposure_column['data_type'] or '') != '' and exposure_column['data_type'] != columns_dict[exposure_column['column_name'] | upper] -%}
+                            {%- do invalid_exposures.append({
+                                    'exposure': exposure['name'],
+                                    'url': exposure['url'],
+                                    'error': 'different data type for the column ' ~ exposure_column['column_name'] ~ ' ' ~ exposure_column['data_type'] ~ ' vs ' ~ columns_dict[exposure_column['name'] | upper]
+                                    })
+                            -%}
+                        {%- endif -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- else -%}
+                {%- do elementary.edr_log("Warning - missing meta property for the exposure: " ~ exposure['name'] ~ ", We're not able to verify the column level dependencies of this exposure") -%}
+            {%- endif -%}
+        {%- endfor -%}
+        {%- if invalid_exposures | length > 0 -%}
+            {%- for invalid_exposure in invalid_exposures %}
+                {{ 'UNION ALL ' if not loop.first }}SELECT '{{ invalid_exposure['exposure'] }}' as exposure, '{{ invalid_exposure['url'] }}' as url, '{{ invalid_exposure['error'] }}' as error
+            {%- endfor -%}
+        {%- else -%}
+            {{ elementary.no_results_query() }}
+        {%- endif -%}
+    {%- else -%}
+    {{ elementary.no_results_query() }}
+
+    {%- endif -%}
+    {{ elementary.test_log('end', full_table_name, 'exposure validation') }}
+{% endtest %}

--- a/macros/edr/tests/test_utils/get_test_type.sql
+++ b/macros/edr/tests/test_utils/get_test_type.sql
@@ -6,7 +6,7 @@
     {%- if elementary_test_type and elementary_test_type != "python_test" %}
         {{ return(elementary_test_type) }}
     {%- else %}
-        {{ return("dbt_test") }}
+        {{ return("integrity") }}
     {%- endif %}
 {% endmacro %}
 
@@ -23,12 +23,15 @@
     {%- set schema_changes_tests = [
         'schema_changes',
         'schema_changes_from_baseline',
-        'json_schema'
+        'json_schema',
     ] %}
     {%- set python_tests = [
         'python',
         'json_schema'
-    ]   %}
+    ] %}
+    {%- set integrity_tests = [
+        'exposure_schema_validity'
+    ] %}
 
   {% if flattened_test.test_namespace == "elementary" %}
     {% if flattened_test.short_name | lower in anomaly_detection_tests %}
@@ -37,6 +40,8 @@
       {% do return("schema_change") %}
     {% elif flattened_test.short_name | lower in python_tests %}
         {% do return("python_test") %}
+    {% elif flattened_test.short_name | lower in integrity_tests %}
+        {% do return("integrity") %}
     {% endif %}
   {% endif %}
 {% endmacro %}

--- a/macros/utils/common_test_configs.sql
+++ b/macros/utils/common_test_configs.sql
@@ -340,6 +340,9 @@
         },
         "column_anomalies": {
           "description": "Column-level anomaly monitors (null_count, null_percent, zero_count, string_length, variance, etc.) on the column according to its data type."
+        },
+        "exposure_schema_validity": {
+            "description": "Column level exposure validation according to the meta.columns property in exposures.yml"
         }
       }
     } %}


### PR DESCRIPTION
Added a generic test that will validate model columns and data types pending that the `meta` attribute is populated with a dict in the following schema:

```json
{ 
    "referenced_columns": [
        {
            "column_name": "column_A",
            "data_type": "string"
        },
        {
            "column_name": "column_B",
            "data_type": "numeric",
            "node": "ref('table')"
        } 
    ]
}
```

Where the `data_type` is optional.

`source` is optional if you only have 1 `depends_on`  node.

E.g in a `exposures.yml`:

```yml
exposures:

  - name: customers
    label: CustomersFTW
    type: dashboard
    maturity: high
    url: https://bi.tool/dashboards/1
    description: >
      Did someone say "exponential growth"?

    depends_on:
      - ref('customers')

    owner:
      name: Callum McData
      email: data@jaffleshop.com
    meta:
      referenced_columns:
        - column_name: "customer_id"
          data_type: "numeric"
        - column_name: 'ZOMG'
          data_type: "string"
        - name: 'WithNoDataType'
          node: ref('customers')
```
