### PR TITLE
Change the severity if length of INSERT exceeds `query_max_size`

### DIFF
--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -70,7 +70,7 @@
 
           {% if new_insert_query | length > query_max_size %}
             {% do elementary.file_log("Oversized row for insert_rows: {}".format(query_with_row)) %}
-            {% do exceptions.raise_compiler_error("Row to be inserted exceeds var('query_max_size'). Consider increasing its value.") %}
+            {% do exceptions.warn("Row to be inserted exceeds var('query_max_size'). Consider increasing its value.") %}
           {% endif %}
 
           {% if current_query.data != base_insert_query %}


### PR DESCRIPTION
## Overview

We can change the severity, if the length of INSERT statements generated by `get_insert_rows_queries` exceeds `query_max_size`. We can also refactor the macro to handle the limitation of the length an INSERT statement.

First, the current implementation might have a pitfall if the length of `new_insert_query` after adding `row_sql` exceeds `query_max_size` due to the large `row_sql`. We may be able to avoid the issue by increasing the value of `query_max_size`. However, there are some warehouses which have the limitations on the length of an INSERT statement as BigQuery.  Those can be the length as string or the number of elements in the `VALUES` clause. 

Second, if the length of an INSERT statement is large, a warehouse might raise an issue. So, it might be ok for elementary to show warning messages which can be clues to inspect what happens. I think elementary just focus on how to chunk values to an INSERT statement.

https://github.com/elementary-data/dbt-data-reliability/blob/ea690c42601f340ea8d927afff0e2d82d688e6b1/macros/utils/table_operations/insert_rows.sql#L55-L87