### PR TITLE
Use google cloud function for inserts

### DIFF
--- a/macros/edr/system/hooks/on_run_end.sql
+++ b/macros/edr/system/hooks/on_run_end.sql
@@ -5,12 +5,10 @@
         {% do return("") %}
       {% endif %}
 
-      {# comment
       {% if flags.WHICH in ['run', 'build'] %}
         {% do elementary.insert_metrics() %}
       {% endif %}
-      #}
-
+      
       {# Update metadata for all dbt artifacts. #}
       {% if not elementary.get_config_var('disable_dbt_artifacts_autoupload') %}
         {% do elementary.upload_dbt_artifacts() %}

--- a/macros/edr/system/hooks/on_run_end.sql
+++ b/macros/edr/system/hooks/on_run_end.sql
@@ -5,14 +5,18 @@
         {% do return("") %}
       {% endif %}
 
+      {# comment
       {% if flags.WHICH in ['run', 'build'] %}
         {% do elementary.insert_metrics() %}
       {% endif %}
+      #}
 
+      {# Update metadata for all dbt artifacts. #}
       {% if not elementary.get_config_var('disable_dbt_artifacts_autoupload') %}
         {% do elementary.upload_dbt_artifacts() %}
       {% endif %}
 
+      {# Update run results of dbt invocations. #}
       {% if not elementary.get_config_var('disable_run_results') %}
         {% do elementary.upload_run_results() %}
       {% endif %}
@@ -21,6 +25,7 @@
         {% do elementary.handle_tests_results() %}
       {% endif %}
 
+      {# Attributes associated with each dbt invocation. #}
       {% if not elementary.get_config_var('disable_dbt_invocation_autoupload') %}
         {% do elementary.upload_dbt_invocation() %}
       {% endif %}

--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -30,6 +30,9 @@
         {% set insert_rows_query = elementary.get_chunk_insert_query(table_relation, columns, rows_chunk) %}
         {% do elementary.run_query(insert_rows_query) %}
       {% endfor %}
+    {% elif insert_rows_method == 'gcp-cloud-function' %}
+      {% set insert_rows_query = elementary.get_cloud_function_insert_query(table_relation, columns, rows) %}
+      {% do elementary.run_query(insert_rows_query) %}
     {% else %}
       {% do exceptions.raise_compiler_error("Specified invalid value for 'insert_rows_method' var.") %}
     {% endif %}
@@ -120,6 +123,10 @@
             {%- endfor -%}
     {% endset %}
     {{ return(insert_rows_query) }}
+{%- endmacro %}
+
+{% macro get_cloud_function_insert_query(table_relation, columns, rows) -%}
+    
 {%- endmacro %}
 
 {% macro escape_special_chars(string_value) %}


### PR DESCRIPTION
Added support for handle_tests_results and insert_rows to use a new insert_rows_method method called gcp-cloud-function which calls a UDF to push results into BigQuery via Pub/Sub rather than direct insert queries.  This significantly increases Elementary's capacity to insert records/test results when using BigQuery.