### PR TITLE
:bug: Fixed exposure schema validity test err messages

### DIFF
--- a/macros/edr/tests/test_exposure_schema_validity.sql
+++ b/macros/edr/tests/test_exposure_schema_validity.sql
@@ -66,7 +66,7 @@
                             {%- do invalid_exposures.append({
                                     'exposure': exposure['name'],
                                     'url': exposure['url'],
-                                    'error': 'different data type for the column ' ~ exposure_column['column_name'] ~ ' ' ~ exposure_column['data_type'] ~ ' vs ' ~ columns_dict[exposure_column['name'] | upper]
+                                    'error': 'different data type for the column ' ~ exposure_column['column_name'] ~ ' ' ~ exposure_column['data_type'] ~ ' vs ' ~ columns_dict[exposure_column['column_name'] | upper]
                                     })
                             -%}
                         {%- endif -%}


### PR DESCRIPTION
Problem:
When the exposure schema validity test fails for data type mismatches, it doesn't show what was the received type.
Example:
```
different data type for the column ASOF_DATE DATE vs 
```
This PR fixes that, and adds a new test for it.

Note:
- The added test can be also merged together with `test_exposure_schema_validity_correct_columns_and_invalid_type` test, but I wasn't sure.