### PR TITLE
fix: change generate profile args macro name for Athena

### DIFF
--- a/macros/utils/cross_db_utils/generate_elementary_profile_args.sql
+++ b/macros/utils/cross_db_utils/generate_elementary_profile_args.sql
@@ -1,7 +1,7 @@
 {% macro generate_elementary_profile_args(method=none, overwrite_values=none) %}
   {#
     Returns a list of parameters for elementary profile.
-    Each parameter consists of a dict consisting of: 
+    Each parameter consists of a dict consisting of:
       name
       value
       comment
@@ -102,7 +102,7 @@
   {% do return(parameters) %}
 {% endmacro %}
 
-{% macro athena__generate_elementary_cli_profile(method, elementary_database, elementary_schema) %}
+{% macro athena__generate_elementary_profile_args(method, elementary_database, elementary_schema) %}
   {% set parameters = [
     _parameter("type", target.type),
     _parameter("s3_staging_dir", target.s3_staging_dir),


### PR DESCRIPTION
Resovles #1381

Rename macros `generate_elementary_profile_args` to generate template profiles.yml using macro:
```
16:53:07  Running with dbt=1.7.3
16:53:07  Registered adapter: athena=1.7.1
16:53:08  Found 37 models, 3 operations, 33 tests, 1 source, 0 exposures, 0 metrics, 1507 macros, 0 groups, 0 semantic models
16:53:08  

elementary:
  outputs:
    default:
      type: "athena"
      s3_staging_dir: "s3://stage-dwh-athena/results/dbt/"
      region_name: "eu-central-1"
      database: "awsdatacatalog"
      aws_profile_name: None
      work_group: "dbt"
      aws_access_key_id: "<AWS_ACCESS_KEY_ID>"
      aws_secret_access_key: "<AWS_SECRET_ACCESS_KEY>"
      catalog: "awsdatacatalog"
      schema: "elementary"
      token: "<TOKEN>"
      threads: 4

```
instead of get error in logs:
```
16:51:51  Running with dbt=1.7.3
16:51:51  Registered adapter: athena=1.7.1
16:51:52  Found 37 models, 3 operations, 33 tests, 1 source, 0 exposures, 0 metrics, 1507 macros, 0 groups, 0 semantic models
16:51:52  

Adapter "athena" is not supported on Elementary.
```