### PR TITLE
Add `unique_combination_of_columns` to `common_tests_configs_mapping`

### DIFF
--- a/macros/utils/common_test_configs.sql
+++ b/macros/utils/common_test_configs.sql
@@ -312,7 +312,7 @@
         },
         "unique_combination_of_columns": {
           "quality_dimension": "uniqueness",
-          "failed_row_count_calc": "sum(num_rows)"
+          "failed_row_count_calc": "count(*)"
         }
       },
       "elementary": {

--- a/macros/utils/common_test_configs.sql
+++ b/macros/utils/common_test_configs.sql
@@ -309,6 +309,10 @@
         "accepted_range": {
           "quality_dimension": "validity",
           "failed_row_count_calc": "count(*)"
+        },
+        "unique_combination_of_columns": {
+          "quality_dimension": "uniqueness",
+          "failed_row_count_calc": "sum(num_rows)"
         }
       },
       "elementary": {


### PR DESCRIPTION
We use `unique_combination_of_columns` from dbt_utils very often. We would like to be able to include the value of `quality_dimension` when using `unique_combination_of_columns`. Therefore, we have added `unique_combination_of_columns` to `common_tests_configs_mapping`.