### PR TITLE
fix: add arg chunk_size when calling `insert_rows`

### DIFF
--- a/macros/edr/dbt_artifacts/upload_dbt_invocation.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_invocation.sql
@@ -45,7 +45,7 @@
       'account_id': elementary.get_var("account_id", ["DBT_ACCOUNT_ID"]),
       'target_adapter_specific_fields': elementary.get_target_adapter_specific_fields()
   } %}
-  {% do elementary.insert_rows(relation, [dbt_invocation], should_commit=true) %}
+  {% do elementary.insert_rows(relation, [dbt_invocation], should_commit=true, chunk_size=elementary.get_config_var('dbt_artifacts_chunk_size')) %}
   {% do elementary.file_log("Uploaded dbt invocation successfully.") %}
 {% endmacro %}
 

--- a/macros/edr/tests/on_run_end/handle_tests_results.sql
+++ b/macros/edr/tests/on_run_end/handle_tests_results.sql
@@ -15,11 +15,11 @@
     {% do elementary.insert_schema_columns_snapshot(database_name, schema_name, test_columns_snapshot_tables) %}
     {% if test_result_rows %}
       {% set test_result_rows_relation = elementary.get_elementary_relation('test_result_rows') %}
-      {% do elementary.insert_rows(test_result_rows_relation, test_result_rows, should_commit=True) %}
+      {% do elementary.insert_rows(test_result_rows_relation, test_result_rows, should_commit=True, chunk_size=elementary.get_config_var('dbt_artifacts_chunk_size')) %}
     {% endif %}
     {% if elementary_test_results %}
       {% set elementary_test_results_relation = elementary.get_elementary_relation('elementary_test_results') %}
-      {% do elementary.insert_rows(elementary_test_results_relation, elementary_test_results, should_commit=True) %}
+      {% do elementary.insert_rows(elementary_test_results_relation, elementary_test_results, should_commit=True, chunk_size=elementary.get_config_var('dbt_artifacts_chunk_size')) %}
     {% endif %}
     {% do elementary.file_log("Handled test results successfully.") %}
     {% do return('') %}

--- a/macros/edr/tests/on_run_end/insert_metrics.sql
+++ b/macros/edr/tests/on_run_end/insert_metrics.sql
@@ -7,5 +7,5 @@
   {% endif %}
 
   {{ elementary.file_log("Inserting {} metrics into {}.".format(metrics | length, target_relation)) }}
-  {% do elementary.insert_rows(target_relation, metrics, should_commit=true) %}
+  {% do elementary.insert_rows(target_relation, metrics, should_commit=true, chunk_size=elementary.get_config_var('dbt_artifacts_chunk_size')) %}
 {% endmacro %}

--- a/macros/edr/tests/test_utils/backfill_result_rows.sql
+++ b/macros/edr/tests/test_utils/backfill_result_rows.sql
@@ -31,6 +31,6 @@
             }) %}
         {% endfor %}
     {% endfor %}
-    {% do elementary.insert_rows(this, test_result_rows_rows) %}
+    {% do elementary.insert_rows(this, test_result_rows_rows, should_commit=false, chunk_size=elementary.get_config_var('dbt_artifacts_chunk_size')) %}
     {% do return('') %}
 {% endmacro %}

--- a/macros/edr/tests/test_utils/create_model_baseline_table.sql
+++ b/macros/edr/tests/test_utils/create_model_baseline_table.sql
@@ -3,6 +3,6 @@
     {% set baseline_table_relation = elementary.create_elementary_test_table(database_name, schema_name,
                                                                              test_name | lower, 'schema_baseline',
                                                                              empty_table_query) %}
-    {% do elementary.insert_rows(baseline_table_relation, baseline_columns, should_commit=True) %}
+    {% do elementary.insert_rows(baseline_table_relation, baseline_columns, should_commit=True, chunk_size=elementary.get_config_var('dbt_artifacts_chunk_size')) %}
     {% do return(baseline_table_relation) %}
 {% endmacro %}


### PR DESCRIPTION
Environment
```markdown
- dbt=1.7.8
- adapter: bigquery=1.7.4
- elementary-data/elementary=0.13.2
```

Variables
```yaml
elementary:
    "insert_rows_method": "chunk"
    "dbt_artifacts_chunk_size": 500
```


When we run our dbt models, we encountered this error during on-run-end. 

```
2024-02-21 20:09:20.440828 (MainThread): 20:09:20  Elementary: Inserting 3402 rows to table `my-bigquery-project`.`elementary`.`data_monitoring_metrics`
2024-02-21 20:09:38.338637 (MainThread): 20:09:38  On master: /* {"app": "dbt", "dbt_version": "1.7.8", "profile_name": "user", "target_name": "prod", "connection_name": "master"} */
.....
2024-02-21 20:09:54.469827 (MainThread): 20:09:54    on-run-end failed, error:
 Resources exceeded during query execution: Not enough resources for query planning - too many subqueries or query is too complex.
2024-02-21 20:09:54.472993 (MainThread): 20:09:54  
2024-02-21 20:09:54.473454 (MainThread): 20:09:54
2024-02-21 20:09:54.473454 (MainThread): 20:09:54  Done. PASS=2847 WARN=0 ERROR=1 SKIP=0 TOTAL=2848
```

The **Maximum number of resources referenced per query are 1,000 resources** ([source](https://cloud.google.com/bigquery/quotas)), but this query is trying to insert 3,402 rows even though we have set the `dbt_artifacts_chunk_size` to 500.

We also noticed that when calling the function `insert_rows`, there are some places that did not use the `dbt_artifacts_chunk_size` from the config file, but the [default value 5000](https://github.com/elementary-data/dbt-data-reliability/blob/ced5c8a982462f8cdad45[…]2b2f9535556d5344b/macros/utils/table_operations/insert_rows.sql)
Therefore, we believe the `dbt_artifacts_chunk_size` should be explicitly used when calling `insert_rows` even during on-run-end.


