### PR TITLE
improvement: bigquery specific for query_table_metrics

### DIFF
--- a/macros/edr/materializations/model/metrics.sql
+++ b/macros/edr/materializations/model/metrics.sql
@@ -25,8 +25,8 @@
 {% macro bigquery__query_table_metrics() %}
     select
       {{ modules.datetime.datetime.utcnow().timestamp() }} as build_timestamp,
-      row_count
-    from {{ this.schema }}.__TABLES__
+      total_rows AS row_count
+    from {{ this.database }}.{{ this.schema }}.INFORMATION_SCHEMA.TABLE_STORAGE
     where table_id = '{{ this.name }}'
   {% endset %}
 

--- a/macros/edr/materializations/model/metrics.sql
+++ b/macros/edr/materializations/model/metrics.sql
@@ -23,6 +23,7 @@
 {% endmacro %}
 
 {% macro bigquery__query_table_metrics() %}
+  {% set query %}
     select
       {{ modules.datetime.datetime.utcnow().timestamp() }} as build_timestamp,
       total_rows AS row_count

--- a/macros/edr/materializations/model/metrics.sql
+++ b/macros/edr/materializations/model/metrics.sql
@@ -33,7 +33,11 @@
   {% set metrics = [] %}
   {% for metric_column in elementary.run_query(query).columns %}
     {% set metric_name = metric_column.name %}
-    {% set metric_value = metric_column[0] %}
+    {% if metric_column | length == 0 %}
+      {% set metric_value = none %} {# this shouldn't happen, but mainly to avoid edge cases / never fail here #}
+    {% else %}
+      {% set metric_value = metric_column[0] %}
+    {% endif %}
     {% do metrics.append({
       "id": "{}.{}".format(invocation_id, this),
       "full_table_name": elementary.relation_to_full_name(this),

--- a/macros/edr/materializations/model/metrics.sql
+++ b/macros/edr/materializations/model/metrics.sql
@@ -22,6 +22,30 @@
   {% do return(metrics) %}
 {% endmacro %}
 
+{% macro bigquery__query_table_metrics() %}
+    select
+      {{ modules.datetime.datetime.utcnow().timestamp() }} as build_timestamp,
+      row_count
+    from {{ this.schema }}.__TABLES__
+    where table_id = '{{ this.name }}'
+  {% endset %}
+
+  {% set metrics = [] %}
+  {% for metric_column in elementary.run_query(query).columns %}
+    {% set metric_name = metric_column.name %}
+    {% set metric_value = metric_column[0] %}
+    {% do metrics.append({
+      "id": "{}.{}".format(invocation_id, this),
+      "full_table_name": elementary.relation_to_full_name(this),
+      "column_name": none,
+      "metric_name": metric_name,
+      "metric_value": metric_value,
+      "updated_at": elementary.datetime_now_utc_as_string()
+    }) %}
+  {% endfor %}
+  {% do return(metrics) %}
+{% endmacro %}
+  
 {% macro can_query_metrics() %}
   {% if not elementary.get_config_var('collect_metrics') %}
     {% do return(false) %}


### PR DESCRIPTION
Using information schema to get row count is much more performant than doing a full table scan

https://cloud.google.com/bigquery/docs/information-schema-table-storage#schema