### PR TITLE
Update get_relation_max_length for redshift from 127 to 125 because of duplicate quoting

### DIFF
--- a/macros/utils/table_operations/get_relation_max_length.sql
+++ b/macros/utils/table_operations/get_relation_max_length.sql
@@ -12,7 +12,7 @@
 {% endmacro %}
 
 {% macro redshift__get_relation_max_name_length(temporary, relation, sql_query) %}
-    {{ return(127) }}
+    {{ return(125) }}
 {% endmacro %}
 
 {% macro postgres__get_relation_max_name_length(temporary, relation, sql_query) %}


### PR DESCRIPTION
explained in [this issue](https://github.com/elementary-data/dbt-data-reliability/issues/695)