### PR TITLE
Fixed Athena temp tables cleaning

### DIFF
--- a/macros/edr/tests/on_run_end/handle_tests_results.sql
+++ b/macros/edr/tests/on_run_end/handle_tests_results.sql
@@ -111,8 +111,7 @@
     {% do elementary.run_query(insert_query) %}
 
     {% if not elementary.has_temp_table_support() %}
-        {% do adapter.drop_relation(temp_relation) %}
-        {% do adapter.clean_up_table(temp_relation) %}
+        {% do elementary.fully_drop_relation(temp_relation) %}
     {% endif %}
 {% endmacro %}
 

--- a/macros/edr/tests/on_run_end/handle_tests_results.sql
+++ b/macros/edr/tests/on_run_end/handle_tests_results.sql
@@ -112,7 +112,7 @@
 
     {% if not elementary.has_temp_table_support() %}
         {% do adapter.drop_relation(temp_relation) %}
-        {% do adapter.clean_up_table(relation) %}
+        {% do adapter.clean_up_table(temp_relation) %}
     {% endif %}
 {% endmacro %}
 
@@ -161,7 +161,7 @@
 
     {% if not elementary.has_temp_table_support() %}
         {% do adapter.drop_relation(temp_relation) %}
-        {% do adapter.clean_up_table(relation) %}
+        {% do adapter.clean_up_table(temp_relation) %}
     {% endif %}
 {% endmacro %}
 

--- a/macros/edr/tests/on_run_end/handle_tests_results.sql
+++ b/macros/edr/tests/on_run_end/handle_tests_results.sql
@@ -112,6 +112,7 @@
 
     {% if not elementary.has_temp_table_support() %}
         {% do adapter.drop_relation(temp_relation) %}
+        {% do adapter.clean_up_table(relation) %}
     {% endif %}
 {% endmacro %}
 

--- a/macros/edr/tests/on_run_end/handle_tests_results.sql
+++ b/macros/edr/tests/on_run_end/handle_tests_results.sql
@@ -160,6 +160,7 @@
 
     {% if not elementary.has_temp_table_support() %}
         {% do adapter.drop_relation(temp_relation) %}
+        {% do adapter.clean_up_table(relation) %}
     {% endif %}
 {% endmacro %}
 

--- a/macros/edr/tests/on_run_end/handle_tests_results.sql
+++ b/macros/edr/tests/on_run_end/handle_tests_results.sql
@@ -159,7 +159,7 @@
     {% do elementary.run_query(insert_query) %}
 
     {% if not elementary.has_temp_table_support() %}
-        {% do adapter.fully_drop_relation(temp_relation) %}
+        {% do elementary.fully_drop_relation(temp_relation) %}
     {% endif %}
 {% endmacro %}
 

--- a/macros/edr/tests/on_run_end/handle_tests_results.sql
+++ b/macros/edr/tests/on_run_end/handle_tests_results.sql
@@ -159,8 +159,7 @@
     {% do elementary.run_query(insert_query) %}
 
     {% if not elementary.has_temp_table_support() %}
-        {% do adapter.drop_relation(temp_relation) %}
-        {% do adapter.clean_up_table(temp_relation) %}
+        {% do adapter.fully_drop_relation(temp_relation) %}
     {% endif %}
 {% endmacro %}
 

--- a/macros/edr/tests/test_utils/clean_elementary_test_tables.sql
+++ b/macros/edr/tests/test_utils/clean_elementary_test_tables.sql
@@ -36,6 +36,7 @@
     {% set queries = [] %}
     {% for test_relation in test_table_relations %}
         {% do queries.append("DROP TABLE IF EXISTS {}".format(test_relation.render_pure())) %}
+        {% do adapter.clean_up_table(test_relation) %}
     {% endfor %}
     {% do return(queries) %}
 {% endmacro %}

--- a/macros/edr/tests/test_utils/clean_elementary_test_tables.sql
+++ b/macros/edr/tests/test_utils/clean_elementary_test_tables.sql
@@ -8,6 +8,9 @@
             {% endfor %}
         {% endfor %}
 
+        {# Extra entry-point to clean up tables before dropping the relation #}
+        {% do elementary.clean_up_tables(test_table_relations) %}
+
         {% do elementary.file_log("Deleting temporary Elementary test tables: {}".format(test_table_relations)) %}
         {% set queries = elementary.get_clean_elementary_test_tables_queries(test_table_relations) %}
         {% for query in queries %}
@@ -36,7 +39,6 @@
     {% set queries = [] %}
     {% for test_relation in test_table_relations %}
         {% do queries.append("DROP TABLE IF EXISTS {}".format(test_relation.render_pure())) %}
-        {% do adapter.clean_up_table(test_relation) %}
     {% endfor %}
     {% do return(queries) %}
 {% endmacro %}

--- a/macros/edr/tests/test_utils/clean_up_tables.sql
+++ b/macros/edr/tests/test_utils/clean_up_tables.sql
@@ -1,0 +1,13 @@
+{% macro clean_up_tables(relations) %}
+    {{ return(adapter.dispatch('clean_up_tables', 'elementary')(relations)) }}
+{% endmacro %}
+
+{% macro default__clean_up_tables(relations) %}
+    {# Default implementation does nothing #}
+{% endmacro %}
+
+{% macro athena__clean_up_tables(relations) %}
+    {% for relation in relations %}
+        {% do adapter.clean_up_table(relation) %}
+    {% endfor %}
+{% endmacro %}

--- a/macros/utils/table_operations/fully_drop_relation.sql
+++ b/macros/utils/table_operations/fully_drop_relation.sql
@@ -1,0 +1,12 @@
+{% macro fully_drop_relation(relation) %}
+    {{ return(adapter.dispatch('fully_drop_relation', 'elementary')(relation)) }}
+{% endmacro %}
+
+{% macro default__fully_drop_relation(relation) %}
+    {% do adapter.drop_relation(relation) %}
+{% endmacro %}
+
+{% macro athena__fully_drop_relation(relation) %}
+    {% do adapter.clean_up_table(relation) %}
+    {% do adapter.drop_relation(relation) %}
+{% endmacro %}

--- a/macros/utils/table_operations/has_temp_table_support.sql
+++ b/macros/utils/table_operations/has_temp_table_support.sql
@@ -14,3 +14,7 @@
     {% do return(false) %}
 {% endmacro %}
 
+{% macro athena__has_temp_table_support() %}
+    {% do return(false) %}
+{% endmacro %}
+


### PR DESCRIPTION
Solves [#1514](https://github.com/elementary-data/elementary/issues/1514).

Specifically for dbt-athena-community, this fix aims to clean the temporary tables in a better way, including dropping files from S3 in case of external tables.