### PR TITLE
ele-1641 add training_period parameter to the event_freshness_anomalies

### DIFF
--- a/macros/edr/tests/test_event_freshness_anomalies.sql
+++ b/macros/edr/tests/test_event_freshness_anomalies.sql
@@ -1,4 +1,4 @@
-{% test event_freshness_anomalies(model, event_timestamp_column, update_timestamp_column, where_expression, anomaly_sensitivity, anomaly_direction, min_training_set_size, time_bucket, days_back, backfill_days, sensitivity, ignore_small_changes, detection_delay, anomaly_exclude_metrics) %}
+{% test event_freshness_anomalies(model, event_timestamp_column, update_timestamp_column, where_expression, anomaly_sensitivity, anomaly_direction, min_training_set_size, time_bucket, days_back, backfill_days, sensitivity, ignore_small_changes, detection_delay, anomaly_exclude_metrics, training_period) %}
   {{ config(tags = ['elementary-tests']) }}
   {% if execute and elementary.is_test_command() and elementary.is_elementary_enabled() %}
     {% set model_relation = elementary.get_model_relation_for_test(model, context["model"]) %}
@@ -29,7 +29,8 @@
       sensitivity=sensitivity,
       ignore_small_changes=ignore_small_changes,
       detection_delay=detection_delay,
-      anomaly_exclude_metrics=anomaly_exclude_metrics
+      anomaly_exclude_metrics=anomaly_exclude_metrics,
+      training_period=training_period
     )
   }}
 {% endtest %}


### PR DESCRIPTION
Fix for https://github.com/elementary-data/elementary/issues/1641

Added `training_period` parameter to the event_freshness_anomalies test