### PR TITLE
feat: collect job run id from env vars

### DIFF
--- a/macros/edr/dbt_artifacts/upload_dbt_invocation.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_invocation.sql
@@ -8,7 +8,7 @@
   {% set now_str = elementary.datetime_now_utc_as_string() %}
   {% set orchestrator = elementary.get_orchestrator() %}
   {% set job_id = elementary.get_var("job_id", ["JOB_ID", "DBT_JOB_ID", "DBT_CLOUD_JOB_ID"]) %}
-  {% set job_run_id = elementary.get_var("job_run_id", ["DBT_JOB_RUN_ID", "DBT_CLOUD_RUN_ID", "GITHUB_RUN_ID"]) %}
+  {% set job_run_id = elementary.get_var("job_run_id", ["JOB_RUN_ID","DBT_JOB_RUN_ID", "DBT_CLOUD_RUN_ID", "GITHUB_RUN_ID"]) %}
   {% set dbt_invocation = {
       'invocation_id': invocation_id,
       'run_started_at': elementary.run_started_at_as_string(),


### PR DESCRIPTION
This PR adds collection of JOB_RUN_ID from env_vars.

[The doc specifies those](https://github.com/elementary-data/elementary/blob/master/docs/_snippets/guides/collect-job-data.mdx) env vars should be collected : ORCHESTRATOR, JOB_NAME, JOB_ID, JOB_URL, JOB_RUN_ID, JOB_RUN_URL

But JOB_RUN_ID is currently missing.