### PR TITLE
Fix CVE-2023-43804 - urllib3

### DIFF
--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -3,4 +3,4 @@ pytest-xdist
 pytest-parametrization
 pytest-html
 filelock
-urllib3==2.0.4
+urllib3==2.0.6


### PR DESCRIPTION
Updates urllib3 to 2.0.6 to avoid [CVE-2023-43804](https://nvd.nist.gov/vuln/detail/CVE-2023-43804). Even though this is just in integration test requirements, it still causes vuln scanning tools to flag this CVE as being present in this package.