### PR TITLE
Update split_list_to_chunks.sql

### DIFF
--- a/macros/utils/list_utils/split_list_to_chunks.sql
+++ b/macros/utils/list_utils/split_list_to_chunks.sql
@@ -12,7 +12,7 @@
             {% set current_length = 0 %}
         {% endif %}
         {% do current_chunk.append(item) %}
-        {% do current_length + item | length %}
+        {% set current_length = current_length + item | length %}
     {% endfor %}
     {% if current_chunk %}
         {% do chunks.append(current_chunk) %}


### PR DESCRIPTION
The old method mentioned is incorrectly calculating and updating the iteration for BQ load. 
The correction should fix the issue for dbt artifact loads. 