### PR TITLE
fix: filter dbt models to upload only current project

### DIFF
--- a/macros/edr/dbt_artifacts/upload_dbt_columns.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_columns.sql
@@ -1,7 +1,7 @@
 {%- macro upload_dbt_columns(should_commit=false, metadata_hashes=none) -%}
     {% set relation = elementary.get_elementary_relation('dbt_columns') %}
     {% if execute and relation %}
-        {% set tables = graph.nodes.values() | selectattr("package_name", "equalto", project_name) | list + graph.sources.values() | list %}
+        {% set tables = graph.nodes.values() | selectattr('package_name', '==', project_name) | list + graph.sources.values() | selectattr('package_name', '==', project_name) | list %}
         {% do elementary.upload_artifacts_to_table(relation, tables, elementary.flatten_table_columns, should_commit=should_commit, metadata_hashes=metadata_hashes) %}
     {%- endif -%}
     {{- return('') -}}

--- a/macros/edr/dbt_artifacts/upload_dbt_exposures.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_exposures.sql
@@ -1,7 +1,7 @@
 {%- macro upload_dbt_exposures(should_commit=false, metadata_hashes=none) -%}
     {% set relation = elementary.get_elementary_relation('dbt_exposures') %}
     {% if execute and relation %}
-        {% set exposures = graph.exposures.values() | selectattr('resource_type', '==', 'exposure') | selectattr("package_name", "equalto", project_name) %}
+        {% set exposures = graph.exposures.values() | selectattr('resource_type', '==', 'exposure') | selectattr('package_name', '==', project_name) %}
         {% do elementary.upload_artifacts_to_table(relation, exposures, elementary.flatten_exposure, should_commit=should_commit, metadata_hashes=metadata_hashes) %}
     {%- endif -%}
     {{- return('') -}}

--- a/macros/edr/dbt_artifacts/upload_dbt_models.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_models.sql
@@ -1,7 +1,7 @@
 {%- macro upload_dbt_models(should_commit=false, metadata_hashes=none) -%}
     {% set relation = elementary.get_elementary_relation('dbt_models') %}
     {% if execute and relation %}
-        {% set models = graph.nodes.values() | selectattr('resource_type', '==', 'model' ) | selectattr("package_name", "equalto", project_name) %}
+        {% set models = graph.nodes.values() | selectattr('resource_type', '==', 'model' ) | selectattr('package_name', '==', project_name) %}
         {% do elementary.upload_artifacts_to_table(relation, models, elementary.flatten_model, should_commit=should_commit, metadata_hashes=metadata_hashes) %}
     {%- endif -%}
     {{- return('') -}}

--- a/macros/edr/dbt_artifacts/upload_dbt_seeds.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_seeds.sql
@@ -1,7 +1,7 @@
 {%- macro upload_dbt_seeds(should_commit=false, metadata_hashes=none) -%}
     {% set relation = elementary.get_elementary_relation('dbt_seeds') %}
     {% if execute and relation %}
-        {% set seeds = graph.nodes.values() | selectattr('resource_type', '==', 'seed') | selectattr("package_name", "equalto", project_name) %}
+        {% set seeds = graph.nodes.values() | selectattr('resource_type', '==', 'seed') | selectattr('package_name', '==', project_name) %}
         {% do elementary.upload_artifacts_to_table(relation, seeds, elementary.flatten_seed, should_commit=should_commit, metadata_hashes=metadata_hashes) %}
     {%- endif -%}
     {{- return('') -}}

--- a/macros/edr/dbt_artifacts/upload_dbt_snapshots.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_snapshots.sql
@@ -1,7 +1,7 @@
 {%- macro upload_dbt_snapshots(should_commit=false, metadata_hashes=none) -%}
     {% set relation = elementary.get_elementary_relation('dbt_snapshots') %}
     {% if execute and relation %}
-        {% set snapshots = graph.nodes.values() | selectattr('resource_type', '==', 'snapshot')  | selectattr("package_name", "equalto", project_name) %}
+        {% set snapshots = graph.nodes.values() | selectattr('resource_type', '==', 'snapshot')  | selectattr('package_name', '==', project_name) %}
         {% do elementary.upload_artifacts_to_table(relation, snapshots, elementary.flatten_model, should_commit=should_commit, metadata_hashes=metadata_hashes) %}
     {%- endif -%}
     {{- return('') -}}

--- a/macros/edr/dbt_artifacts/upload_dbt_sources.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_sources.sql
@@ -1,7 +1,7 @@
 {%- macro upload_dbt_sources(should_commit=false, metadata_hashes=none) -%}
     {% set relation = elementary.get_elementary_relation('dbt_sources') %}
     {% if execute and relation %}
-        {% set sources = graph.sources.values() | selectattr('resource_type', '==', 'source') | selectattr("package_name", "equalto", project_name) %}
+        {% set sources = graph.sources.values() | selectattr('resource_type', '==', 'source') | selectattr('package_name', '==', project_name) %}
         {% do elementary.upload_artifacts_to_table(relation, sources, elementary.flatten_source, should_commit=should_commit, metadata_hashes=metadata_hashes) %}
     {%- endif -%}
     {{- return('') -}}

--- a/macros/edr/dbt_artifacts/upload_dbt_tests.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_tests.sql
@@ -1,7 +1,7 @@
 {%- macro upload_dbt_tests(should_commit=false, metadata_hashes=none) -%}
     {% set relation = elementary.get_elementary_relation('dbt_tests') %}
     {% if execute and relation %}
-        {% set tests = graph.nodes.values() | selectattr('resource_type', '==', 'test') | selectattr("package_name", "equalto", project_name) %}
+        {% set tests = graph.nodes.values() | selectattr('resource_type', '==', 'test') | selectattr('package_name', '==', project_name) %}
         {% do elementary.upload_artifacts_to_table(relation, tests, elementary.flatten_test, should_commit=should_commit, metadata_hashes=metadata_hashes) %}
     {%- endif -%}
     {{- return('') -}}


### PR DESCRIPTION
When you are using some tools like [dbt-loom](https://github.com/nicholasyager/dbt-loom), `graph.nodes.values()` returns nodes from multiples project.

dbt-loom works by fetching public model definitions from your dbt artifacts, and injecting those models into your dbt project.

The goal of this PR is to only retrieve nodes from the current project using [project_name](https://docs.getdbt.com/reference/dbt-jinja-functions/project_name) selection to avoid uploading of unnecessary information. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact filtering to ensure all dbt artifacts (models, seeds, snapshots, sources, tests, columns, and exposures) are properly scoped to the current project during upload operations, preventing cross-project artifact mixing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->