### PR TITLE
BQ - save execution_project in adapter-specific fields

### DIFF
--- a/macros/edr/dbt_artifacts/upload_dbt_invocation.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_invocation.sql
@@ -58,7 +58,7 @@
     {{ return('') }}
 {% endmacro %}
 
-{% macro bigquery__get_target_adapter_specific_fields %}
+{% macro bigquery__get_target_adapter_specific_fields() %}
     {{ return({"execution_project": target.execution_project}) }}
 {% endmacro %}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for capturing BigQuery-specific target adapter fields during artifact uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->