### PR TITLE
initializng the config_dict of the metrics because currently it throw…

### DIFF
--- a/macros/edr/dbt_artifacts/upload_dbt_metrics.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_metrics.sql
@@ -38,6 +38,7 @@
 {% macro flatten_metric(node_dict) %}
     {% set depends_on_dict = elementary.safe_get_with_default(node_dict, 'depends_on', {}) %}
     {% set meta_dict = elementary.safe_get_with_default(node_dict, 'meta', {}) %}
+    {% set config_dict = elementary.safe_get_with_default(node_dict, 'config', {}) %}
     {% set tags = elementary.safe_get_with_default(node_dict, 'tags', []) %}
     {% set flatten_metric_metadata_dict = {
         'unique_id': node_dict.get('unique_id'),


### PR DESCRIPTION
…s undefiend exception

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for including the metric group name in metric metadata displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->