### PR TITLE
Support dbt Fusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target/
 dbt_packages/
 logs/
 scripts/
+package-lock.yml
 
 .idea
 .DS_Store
@@ -11,6 +12,7 @@ integration_tests/data
 edr_target
 
 venv/
+.venv/
 elementary*.html
 elementary*.json
 
@@ -24,3 +26,4 @@ __pycache__/
 
 # vscode
 .vscode/
+dbt_internal_packages/

--- a/macros/edr/system/hooks/on_run_end.sql
+++ b/macros/edr/system/hooks/on_run_end.sql
@@ -35,4 +35,10 @@
         {% do elementary.clean_elementary_temp_tables() %}
       {% endif %}
   {% endif %}
+
+  {% set dummy_query %}
+  -- This query is needed for Elementary to work correctly with dbt Fusion
+  select 'on-run-end'
+  {% endset %}
+  {{ return(dummy_query) }}
 {% endmacro %}

--- a/macros/edr/system/hooks/on_run_end.sql
+++ b/macros/edr/system/hooks/on_run_end.sql
@@ -36,6 +36,7 @@
       {% endif %}
   {% endif %}
 
+  {# The hook will always run a query, so we need to pass something back #}
   {% set dummy_query %}
   -- This query is needed for Elementary to work correctly with dbt Fusion
   select 'on-run-end'

--- a/macros/edr/system/hooks/on_run_start.sql
+++ b/macros/edr/system/hooks/on_run_start.sql
@@ -22,4 +22,6 @@
   {% if elementary.is_test_command() %}
     {{ elementary.create_elementary_tests_schema() }}
   {% endif %}
+
+  {{ return("select 'on-run-start'") }}
 {% endmacro %}

--- a/macros/edr/system/hooks/on_run_start.sql
+++ b/macros/edr/system/hooks/on_run_start.sql
@@ -23,5 +23,10 @@
     {{ elementary.create_elementary_tests_schema() }}
   {% endif %}
 
-  {{ return("select 'on-run-start'") }}
+  {# The hook will always run a query, so we need to pass something back #}
+  {% set dummy_query %}
+  -- This query is needed for Elementary to work correctly with dbt Fusion
+  select 'on-run-start'
+  {% endset %}
+  {{ return(dummy_query) }}
 {% endmacro %}

--- a/models/run_results.yml
+++ b/models/run_results.yml
@@ -136,11 +136,12 @@ models:
       Each row is the invocation result of a single resource (model, test, snapshot, etc).
       New data is loaded to this model on an on-run-end hook named 'elementary.upload_run_results' from each invocation that produces a result object.
       This is an incremental model.
-    meta:
-      deprecated_columns:
-        - name: compiled_sql
-          data_type: string
-          description: The compiled SQL executed against the database.
+    config:
+      meta:
+        deprecated_columns:
+          - name: compiled_sql
+            data_type: string
+            description: The compiled SQL executed against the database.
 
     columns:
       - name: model_execution_id


### PR DESCRIPTION
To tackle [this issue](https://github.com/elementary-data/dbt-data-reliability/issues/839).

Note on the `on-run-start/end` part: I don't really like the solution. Trouble is that this method will fire a query at the database. In Core this was failing silently, but in Fusion you will get an explicit error. A better solution would be to run an operation on at the start/end, but I don't think we can do that. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Run start and end hooks now return simple SQL statements, improving visibility and compatibility with downstream tooling.
- Chores
  - Updated ignore list to exclude package-lock.yml, .venv/, and dbt_internal_packages/.
  - Relocated deprecation metadata for compiled_sql in the run results model to config.meta for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->