### PR TITLE
Fix datetime casting macro for ClickHouse

### DIFF
--- a/macros/utils/data_types/cast_column.sql
+++ b/macros/utils/data_types/cast_column.sql
@@ -23,8 +23,7 @@
 
 {%- macro clickhouse__edr_cast_as_timestamp(timestamp_field) -%}
     coalesce(
-        toDateTime(
-            left(splitByChar('+', toString({{ timestamp_field }}))[1], 19)),
+        parseDateTimeBestEffortOrNull(toString({{ timestamp_field }})),
         toDateTime('1970-01-01 00:00:00')
     )
 {%- endmacro -%}

--- a/macros/utils/data_types/cast_column.sql
+++ b/macros/utils/data_types/cast_column.sql
@@ -23,8 +23,8 @@
 
 {%- macro clickhouse__edr_cast_as_timestamp(timestamp_field) -%}
     coalesce(
-        parseDateTimeBestEffortOrNull(toString({{ timestamp_field }})),
-        toDateTime('1970-01-01 00:00:00')
+        parseDateTimeBestEffortOrNull(toString({{ timestamp_field }}), 'UTC'),
+        toDateTime('1970-01-01 00:00:00', 'UTC')
     )
 {%- endmacro -%}
 


### PR DESCRIPTION
Previously, when a `NULL` value was encountered in the `timestamp_field`, the `toString` function would convert this NULL value to a `Nullable(String)`. This would result in the split function not working properly, since it expects non-nullable input values. The datetime parsing can be simplified by using `parseDateTimeBestEffortOrNull` instead of doing manual parsing of the date, bypassing the issue of `Nullable` types entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved timestamp parsing for ClickHouse sources: now uses best-effort, UTC-aware parsing to handle varied or unexpected formats and reduce ingestion failures.
  - Ensures a safe fallback to the Unix epoch in UTC when parsing fails.

- Other
  - No changes to public interfaces or configuration required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->