### PR TITLE
removed render_pure() when deleting table since quoting is needed

### DIFF
--- a/macros/edr/tests/test_utils/clean_elementary_test_tables.sql
+++ b/macros/edr/tests/test_utils/clean_elementary_test_tables.sql
@@ -42,7 +42,7 @@
 {% macro athena__get_clean_elementary_test_tables_queries(test_table_relations) %}
     {% set queries = [] %}
     {% for test_relation in test_table_relations %}
-        {% do queries.append("DROP TABLE IF EXISTS {}".format(test_relation.render_pure())) %}
+        {% do queries.append("DROP TABLE IF EXISTS {}".format(test_relation)) %}
     {% endfor %}
     {% do return(queries) %}
 {% endmacro %}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of test table cleanup in Athena environments, ensuring DROP statements target the correct tables and preventing leftover artifacts or teardown failures during test runs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->