### PR TITLE
only check if fork on pull requests

### DIFF
--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -11,7 +11,6 @@ on:
           - snowflake
           - bigquery
           - redshift
-          - databricks
           - databricks_catalog
           - spark
           - athena
@@ -62,7 +61,7 @@ jobs:
       - name: Set requires approval output
         id: set-output
         run: |
-          if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+          if [[ "${{ github.event_name }}" =~ ^pull_request && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
             echo "requires_approval=true" >> $GITHUB_OUTPUT
           else
             echo "requires_approval=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI workflow dispatch options by removing the “Databricks” warehouse type from the selectable options when triggering the workflow manually.
  - Adjusted approval gating so it applies only to pull request runs: PRs from forks now require approval; PRs from the same repository do not. Non-PR runs are unaffected.
  - Contributors will see fewer manual trigger options and clearer approval behavior depending on the event and source of the PR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->