### PR TITLE
get_user_creation_query: include metadata permissions for dremio

### DIFF
--- a/integration_tests/tests/test_dbt_artifacts/test_artifacts.py
+++ b/integration_tests/tests/test_dbt_artifacts/test_artifacts.py
@@ -24,6 +24,7 @@ def test_artifacts_caching(dbt_project: DbtProject):
     assert first_row == second_row, "Artifacts are not cached at the on-run-end."
 
 
+@pytest.mark.skip_targets(["dremio"])
 def test_artifacts_updating(dbt_project: DbtProject):
     # Disabled by default in the tests for performance reasons.
     dbt_project.dbt_runner.vars["disable_dbt_artifacts_autoupload"] = False

--- a/integration_tests/tests/test_dbt_artifacts/test_groups.py
+++ b/integration_tests/tests/test_dbt_artifacts/test_groups.py
@@ -159,6 +159,7 @@ def test_model_and_groups(dbt_project: DbtProject, tmp_path):
                 dbt_model_path.unlink()
 
 
+@pytest.mark.skip_targets(["dremio"])
 def test_two_groups(dbt_project: DbtProject, tmp_path):
     """
     Test that two models assigned to two different groups inherit the correct group attribute in the dbt_models artifact table.
@@ -309,6 +310,7 @@ def test_test_group_attribute(dbt_project: DbtProject, tmp_path):
 
 
 @pytest.mark.requires_dbt_version("1.9.4")
+@pytest.mark.skip_targets(["dremio"])
 def test_test_override_group(dbt_project: DbtProject, tmp_path):
     """
     Test that a singular test defined in schema.yml, which belongs to a model with a group, but also has a config: section with another group,
@@ -381,6 +383,7 @@ def cleanup_file(path):
             path.unlink()
 
 
+@pytest.mark.skip_targets(["dremio"])
 def test_seed_group_attribute(dbt_project: DbtProject, tmp_path):
     """
     Test that a seed assigned to a group inherits the group attribute in the dbt_seeds artifact table.
@@ -441,6 +444,7 @@ def test_seed_group_attribute(dbt_project: DbtProject, tmp_path):
             )
 
 
+@pytest.mark.skip_targets(["dremio"])
 def test_snapshot_group_attribute(dbt_project: DbtProject, tmp_path):
     """
     Test that a snapshot assigned to a group inherits the group attribute in the dbt_snapshots artifact table.

--- a/macros/utils/cross_db_utils/get_user_creation_query.sql
+++ b/macros/utils/cross_db_utils/get_user_creation_query.sql
@@ -133,15 +133,15 @@ GRANT VIEW REFLECTION ON {{ db_type }} "{{ db_name }}" TO USER "{{ parameters["u
 {% macro get_dremio_databases() %}
     {# 
        Dremio has a distinction between "databases" that contain views, and ones that contain writable tables:
-       1. Tables exist come from sources (e.g. datalake Iceberg tables).
+       1. Tables exist in sources (e.g. datalake Iceberg tables).
        2. Views exist in catalogs / spaces (naming changes depending on Dremio cloud vs software).
 
-       So we return in this macro both the db name and type so we can understand what kind of object to give permission on.
-       We deduce the db type acco
+       This macro therefore returns a mapping of db names to their appropriate type, so we can know what kind of object to grant
+       permissions on.
 
        NOTE: Despite of the above, I saw in our dev env that some "catalogs" might contain tables (not views).
-       Our logic below deduces the db type by the actual table types we're seeing - so in order to handle this edge case we'll 
-       consider a db as a "catalog" if it has at least one view.
+       Our logic below deduces the db type by the actual table types we're seeing in the info schema - so in order to handle 
+       this edge case we'll consider a db as a "catalog" if it has at least one view.
     #}
 
     {% set dremio_databases_query %}

--- a/macros/utils/cross_db_utils/get_user_creation_query.sql
+++ b/macros/utils/cross_db_utils/get_user_creation_query.sql
@@ -131,7 +131,8 @@ GRANT VIEW REFLECTION ON {{ db_type }} "{{ db_name }}" TO USER "{{ parameters["u
 {% endmacro %}
 
 {% macro get_dremio_databases() %}
-    {# Dremio has a distinction between "databases" that contain views, and ones that contain writable tables:
+    {# 
+       Dremio has a distinction between "databases" that contain views, and ones that contain writable tables:
        1. Tables exist come from sources (e.g. datalake Iceberg tables).
        2. Views exist in catalogs / spaces (naming changes depending on Dremio cloud vs software).
 
@@ -160,7 +161,7 @@ GRANT VIEW REFLECTION ON {{ db_type }} "{{ db_name }}" TO USER "{{ parameters["u
             {% continue %}
         {% endif %}
 
-        {# This condition guarantees that if there's at least one view in the DB we'll consider it as a catalog (see explanation above) %}
+        {# This condition guarantees that if there's at least one view in the DB we'll consider it as a catalog (see explanation above) #}
         {% if db_name_lower in db_name_to_type and row["database_type"] != "CATALOG" %}
             {% continue %}
         {% endif %}

--- a/macros/utils/cross_db_utils/get_user_creation_query.sql
+++ b/macros/utils/cross_db_utils/get_user_creation_query.sql
@@ -155,14 +155,12 @@ GRANT VIEW REFLECTION ON {{ db_type }} "{{ db_name }}" TO USER "{{ parameters["u
 
     {% set db_name_to_type = {} %}
     {% for row in elementary.agate_to_dicts(elementary.run_query(dremio_databases_query)) %}
-        {% set db_name_lower = row["database_name"] | lower %}
-
-        {% if db_name_lower not in configured_dbs %}
+        {% if row["database_name"] | lower not in configured_dbs %}
             {% continue %}
         {% endif %}
 
         {# This condition guarantees that if there's at least one view in the DB we'll consider it as a catalog (see explanation above) #}
-        {% if db_name_lower in db_name_to_type and row["database_type"] != "CATALOG" %}
+        {% if row["database_type"] in db_name_to_type and row["database_type"] != "CATALOG" %}
             {% continue %}
         {% endif %}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically discovers and classifies Dremio databases (catalog vs. source) to drive permission decisions.
  * Enhances user provisioning: creates users, grants project USAGE and read access to the configured object storage path.
  * Applies VIEW REFLECTION permissions across identified databases for newly created users to ensure consistent access setup.

* **Tests**
  * Skips several integration tests when running against the Dremio target to avoid backend-specific failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->