### PR TITLE
is_dbt_fusion: check that the major is exactly 2

### DIFF
--- a/macros/edr/system/system_utils/is_dbt_fusion.sql
+++ b/macros/edr/system/system_utils/is_dbt_fusion.sql
@@ -1,5 +1,5 @@
 {% macro is_dbt_fusion() %}
-    {% if dbt_version.split(".")[0] | int > 1 %}
+    {% if dbt_version.split(".")[0] | int == 2 %}
         {% do return(true) %}
     {% endif %}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected dbt Fusion version detection to recognize only major version 2, preventing misclassification on other major versions and ensuring accurate feature gating and behavior across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->