### PR TITLE
in dremio, removing the micro/nano seconds because dremio support mil…

### DIFF
--- a/macros/utils/data_types/cast_column.sql
+++ b/macros/utils/data_types/cast_column.sql
@@ -29,7 +29,7 @@
 {%- endmacro -%}
 
 {%- macro dremio__edr_cast_as_timestamp(timestamp_field) -%}
-    cast({{ timestamp_field }} as {{ elementary.edr_type_timestamp() }})
+    cast(REGEXP_REPLACE({{ timestamp_field }}, '(\.\d{3})\d+', '$1') as {{ elementary.edr_type_timestamp() }})
 {%- endmacro -%}
 
 {%- macro edr_cast_as_float(column) -%}


### PR DESCRIPTION
…i seconds only when filtering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp casting to handle inputs with fractional seconds by trimming them to millisecond precision before conversion. This reduces parsing errors and ensures consistent timestamp values across sources.
  * Enhances compatibility with datasets that include extended fractional seconds, preventing failed loads or inconsistent results during transformations and queries.
  * Provides more predictable behavior when working with time-based fields, improving data reliability in downstream reports and analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->