### PR TITLE
CI - restrict postgres version

### DIFF
--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   postgres:
-    image: postgres
+    image: postgres:15
     ports:
       - "127.0.0.1:5432:5432"
     command: postgres -c max_connections=500


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration test infrastructure to use a pinned Postgres version, ensuring consistent and reliable test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->