### PR TITLE
Raize error if columns can't be detected

### DIFF
--- a/macros/edr/data_monitoring/schema_changes/get_columns_snapshot_query.sql
+++ b/macros/edr/data_monitoring/schema_changes/get_columns_snapshot_query.sql
@@ -14,6 +14,13 @@
 
     {% set columns = adapter.get_columns_in_relation(model_relation) %}
 
+    {% if not columns %}
+        {% set no_columns_error -%}
+            Failed to detect columns for {{ model_relation }}. Ensure it exists and authorized.
+        {%- endset %}
+        exceptions.raise_compiler_error(no_columns_error)
+    {% endif %}
+
     with table_info as (
         select
             {{ elementary.edr_cast_as_string(elementary.edr_quote(full_table_name)) }} as full_table_name,


### PR DESCRIPTION
When dbt user has no permissions for a table, Elementary `schema_changes_from_baseline` test fails with unclear message (at least in Snowflake):

```
001003 (42000): SQL compilation error:
syntax error line 44 at position 12 unexpected ')'.
```

It happens because dbt swallows DB error in `adapter.get_columns_in_relation()` when a user has not enough permissions.

It our case it was hard to detect because of Snowflake Secondary roles, which allowed human users to read from source DB, but not for CI users.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced schema monitoring validation to detect when model attributes cannot be properly identified, providing clear diagnostic messages instead of silent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->