### PR TITLE
made the description of the anomaly test more accurate

### DIFF
--- a/macros/edr/alerts/anomaly_detection_description.sql
+++ b/macros/edr/alerts/anomaly_detection_description.sql
@@ -10,7 +10,7 @@
 {% endmacro %}
 
 {% macro freshness_description() %}
-    'Last update was at ' || anomalous_value || ', ' || {{ elementary.edr_cast_as_string('abs(round(' ~ elementary.edr_cast_as_numeric('metric_value/3600') ~ ', 2))') }} || ' hours before the execution of this test. Usually the table is updated within ' || {{ elementary.edr_cast_as_string('abs(round(' ~ elementary.edr_cast_as_numeric('training_avg/3600') ~ ', 2))') }} || ' hours.'
+    'Last update was at ' || anomalous_value || ', ' || 'which is' || {{ elementary.edr_cast_as_string('abs(round(' ~ elementary.edr_cast_as_numeric('metric_value/3600') ~ ', 2))') }} || ' hours without updates (only full buckets are considered). Usually the table is updated within ' || {{ elementary.edr_cast_as_string('abs(round(' ~ elementary.edr_cast_as_numeric('training_avg/3600') ~ ', 2))') }} || ' hours.'
 {% endmacro %}
 
 {% macro table_metric_description() %}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated anomaly alert wording to clarify freshness: instead of a simple "hours ago" timestamp, descriptions now explain that the alert reflects "X hours without updates (only full buckets are considered)" and retain the last-update time and usual update window for clearer temporal context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->