### PR TITLE
Bump package compatibility version

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: "elementary"
 version: "0.20.1"
 
-require-dbt-version: [">=1.0.0", "<2.0.0"]
+require-dbt-version: [">=1.0.0", "<3.0.0"]
 
 config-version: 2
 profile: "elementary"


### PR DESCRIPTION
Updates `require-dbt-version` to prevent compatibility warnings in Fusion and ensure correct display on dbt Hub.

After merging, please publish a new tagged release so the update is picked up by Hub.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended DBT version compatibility to support version 3.x releases alongside existing supported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->