### PR TITLE
changed failures and affected_rows fields to be bigint in schema, so …

### DIFF
--- a/models/run_results.yml
+++ b/models/run_results.yml
@@ -197,7 +197,7 @@ models:
         description: End time of resource compile action.
 
       - name: rows_affected
-        data_type: int
+        data_type: bigint
         description: ""
 
       - name: full_refresh
@@ -209,7 +209,7 @@ models:
         description: The compiled code (SQL / Python) executed against the database.
 
       - name: failures
-        data_type: int
+        data_type: bigint
         description: Number of failures in this run.
 
       - name: query_id


### PR DESCRIPTION
…it will match the code of the table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded numeric capacity for key result tracking metrics to support larger values without overflow limitations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->