### PR TITLE
feat: add min_value parameter for anomaly detection tests

### DIFF
--- a/integration_tests/tests/test_anomaly_test_configuration.py
+++ b/integration_tests/tests/test_anomaly_test_configuration.py
@@ -61,6 +61,7 @@ PARAM_VALUES = {
         {"count": 90, "period": "day"},
     ),
     "exclude_final_results": ParamValues(*(["1 = 1"] * 3)),
+    "min_value": ParamValues(0.5, 1.0, 2.0),
 }
 
 
@@ -88,6 +89,7 @@ def _get_expected_adapted_config(values_type: Literal["vars", "model", "test"]):
         "freshness_column": None,  # Deprecated
         "dimensions": None,  # should only be set at the test level,
         "exclude_final_results": get_value("exclude_final_results"),
+        "min_value": get_value("min_value"),
         "exclude_detection_period_from_training": None,
     }
 

--- a/integration_tests/tests/test_column_anomalies.py
+++ b/integration_tests/tests/test_column_anomalies.py
@@ -217,16 +217,16 @@ def test_volume_anomaly_static_data_drop(
 
 @Parametrization.autodetect_parameters()
 @Parametrization.case(
-    name="anomaly_detected_without_min_value",
+    name="detected",
     expected_result="fail",
     min_value=None,
 )
 @Parametrization.case(
-    name="anomaly_suppressed_with_min_value",
+    name="suppressed",
     expected_result="pass",
     min_value=5,
 )
-def test_column_anomalies_with_min_value(
+def test_col_anom_min_value(
     test_id: str,
     dbt_project: DbtProject,
     expected_result: str,

--- a/integration_tests/tests/test_column_anomalies.py
+++ b/integration_tests/tests/test_column_anomalies.py
@@ -215,6 +215,60 @@ def test_volume_anomaly_static_data_drop(
     assert test_result["status"] == expected_result
 
 
+@Parametrization.autodetect_parameters()
+@Parametrization.case(
+    name="anomaly_detected_without_min_value",
+    expected_result="fail",
+    min_value=None,
+)
+@Parametrization.case(
+    name="anomaly_suppressed_with_min_value",
+    expected_result="pass",
+    min_value=5,
+)
+def test_column_anomalies_with_min_value(
+    test_id: str,
+    dbt_project: DbtProject,
+    expected_result: str,
+    min_value,
+):
+    now = datetime.utcnow()
+    data = [
+        {TIMESTAMP_COLUMN: cur_date.strftime(DATE_FORMAT), "superhero": "Batman"}
+        for cur_date in generate_dates(base_date=now, step=timedelta(days=1))
+        if cur_date < now - timedelta(days=1)
+    ] * 50
+    data += [
+        {
+            TIMESTAMP_COLUMN: (now - timedelta(days=1)).strftime(DATE_FORMAT),
+            "superhero": "Batman",
+        }
+    ] * 47
+    data += [
+        {
+            TIMESTAMP_COLUMN: (now - timedelta(days=1)).strftime(DATE_FORMAT),
+            "superhero": None,
+        }
+    ] * 3
+
+    # Training: 50 rows/day, 0 nulls -> null_count = 0
+    # Detection: 50 rows, 3 nulls -> null_count = 3
+    # Without min_value: null_count 3 vs training avg 0 -> anomaly detected (fail)
+    # With min_value=5: null_count 3 < 5 -> anomaly suppressed (pass)
+
+    test_args = {
+        **DBT_TEST_ARGS,
+        "time_bucket": {"period": "day", "count": 1},
+        "column_anomalies": ["null_count"],
+    }
+    if min_value is not None:
+        test_args["min_value"] = min_value
+    test_result = dbt_project.test(
+        test_id, DBT_TEST_NAME, test_args, data=data, test_column="superhero"
+    )
+    assert test_result["status"] == expected_result
+
+
 def test_anomalyless_column_anomalies_group(test_id: str, dbt_project: DbtProject):
     utc_today = datetime.utcnow().date()
     data: List[Dict[str, Any]] = [

--- a/macros/edr/system/system_utils/get_test_argument.sql
+++ b/macros/edr/system/system_utils/get_test_argument.sql
@@ -1,5 +1,5 @@
 {% macro get_test_argument(argument_name, value, model_graph_node) %}
-    {% if value %} {% do return(value) %} {%- endif %}
+    {% if value is defined and value is not none %} {% do return(value) %} {%- endif %}
     {%- if model_graph_node %}
         {% set elementary_config = elementary.get_elementary_config_from_node(
             model_graph_node

--- a/macros/edr/tests/test_all_columns_anomalies.sql
+++ b/macros/edr/tests/test_all_columns_anomalies.sql
@@ -20,7 +20,7 @@
     detection_period,
     training_period,
     dimensions,
-    min_value,
+    min_value=none,
     exclude_detection_period_from_training=false
 ) %}
     {{ config(tags=["elementary-tests"]) }}

--- a/macros/edr/tests/test_all_columns_anomalies.sql
+++ b/macros/edr/tests/test_all_columns_anomalies.sql
@@ -21,7 +21,7 @@
     training_period,
     dimensions,
     min_value=none,
-    exclude_detection_period_from_training=false
+    exclude_detection_period_from_training=none
 ) %}
     {{ config(tags=["elementary-tests"]) }}
     {%- if execute and elementary.is_test_command() and elementary.is_elementary_enabled() %}

--- a/macros/edr/tests/test_all_columns_anomalies.sql
+++ b/macros/edr/tests/test_all_columns_anomalies.sql
@@ -20,6 +20,7 @@
     detection_period,
     training_period,
     dimensions,
+    min_value,
     exclude_detection_period_from_training=false
 ) %}
     {{ config(tags=["elementary-tests"]) }}
@@ -89,6 +90,7 @@
                 detection_period=detection_period,
                 training_period=training_period,
                 dimensions=dimensions,
+                min_value=min_value,
                 exclude_detection_period_from_training=exclude_detection_period_from_training,
             )
         ) %}

--- a/macros/edr/tests/test_column_anomalies.sql
+++ b/macros/edr/tests/test_column_anomalies.sql
@@ -20,7 +20,7 @@
     training_period,
     dimensions,
     min_value=none,
-    exclude_detection_period_from_training=false
+    exclude_detection_period_from_training=none
 ) %}
     {{ config(tags=["elementary-tests"]) }}
     {%- if execute and elementary.is_test_command() and elementary.is_elementary_enabled() %}

--- a/macros/edr/tests/test_column_anomalies.sql
+++ b/macros/edr/tests/test_column_anomalies.sql
@@ -19,7 +19,7 @@
     detection_period,
     training_period,
     dimensions,
-    min_value,
+    min_value=none,
     exclude_detection_period_from_training=false
 ) %}
     {{ config(tags=["elementary-tests"]) }}

--- a/macros/edr/tests/test_column_anomalies.sql
+++ b/macros/edr/tests/test_column_anomalies.sql
@@ -19,6 +19,7 @@
     detection_period,
     training_period,
     dimensions,
+    min_value,
     exclude_detection_period_from_training=false
 ) %}
     {{ config(tags=["elementary-tests"]) }}
@@ -79,6 +80,7 @@
                 detection_period=detection_period,
                 training_period=training_period,
                 dimensions=dimensions,
+                min_value=min_value,
                 exclude_detection_period_from_training=exclude_detection_period_from_training,
             )
         ) %}

--- a/macros/edr/tests/test_configuration/get_anomalies_test_configuration.sql
+++ b/macros/edr/tests/test_configuration/get_anomalies_test_configuration.sql
@@ -95,11 +95,9 @@
         } %}
     {%- endif %}
 
-    {%- if min_value is none %}
-        {%- set min_value = elementary.get_test_argument(
-            "min_value", none, model_graph_node
-        ) %}
-    {%- endif %}
+    {%- set min_value = elementary.get_test_argument(
+        "min_value", min_value, model_graph_node
+    ) %}
 
     {% set anomaly_exclude_metrics = elementary.get_test_argument(
         "anomaly_exclude_metrics", anomaly_exclude_metrics, model_graph_node

--- a/macros/edr/tests/test_configuration/get_anomalies_test_configuration.sql
+++ b/macros/edr/tests/test_configuration/get_anomalies_test_configuration.sql
@@ -24,6 +24,7 @@
     detection_period,
     training_period,
     exclude_final_results,
+    min_value,
     exclude_detection_period_from_training
 ) %}
 
@@ -94,6 +95,10 @@
         } %}
     {%- endif %}
 
+    {%- set min_value = elementary.get_test_argument(
+        "min_value", min_value, model_graph_node
+    ) %}
+
     {% set anomaly_exclude_metrics = elementary.get_test_argument(
         "anomaly_exclude_metrics", anomaly_exclude_metrics, model_graph_node
     ) %}
@@ -120,6 +125,7 @@
         "seasonality": seasonality,
         "ignore_small_changes": ignore_small_changes,
         "fail_on_zero": fail_on_zero,
+        "min_value": min_value,
         "detection_delay": detection_delay,
         "anomaly_exclude_metrics": anomaly_exclude_metrics,
         "exclude_final_results": exclude_final_results,

--- a/macros/edr/tests/test_configuration/get_anomalies_test_configuration.sql
+++ b/macros/edr/tests/test_configuration/get_anomalies_test_configuration.sql
@@ -95,9 +95,11 @@
         } %}
     {%- endif %}
 
-    {%- set min_value = elementary.get_test_argument(
-        "min_value", min_value, model_graph_node
-    ) %}
+    {%- if min_value is none %}
+        {%- set min_value = elementary.get_test_argument(
+            "min_value", none, model_graph_node
+        ) %}
+    {%- endif %}
 
     {% set anomaly_exclude_metrics = elementary.get_test_argument(
         "anomaly_exclude_metrics", anomaly_exclude_metrics, model_graph_node

--- a/macros/edr/tests/test_dimension_anomalies.sql
+++ b/macros/edr/tests/test_dimension_anomalies.sql
@@ -18,7 +18,7 @@
     detection_period,
     training_period,
     exclude_final_results,
-    min_value,
+    min_value=none,
     exclude_detection_period_from_training=false
 ) %}
     {{ config(tags=["elementary-tests"]) }}

--- a/macros/edr/tests/test_dimension_anomalies.sql
+++ b/macros/edr/tests/test_dimension_anomalies.sql
@@ -18,6 +18,7 @@
     detection_period,
     training_period,
     exclude_final_results,
+    min_value,
     exclude_detection_period_from_training=false
 ) %}
     {{ config(tags=["elementary-tests"]) }}
@@ -81,6 +82,7 @@
                 detection_period=detection_period,
                 training_period=training_period,
                 exclude_final_results=exclude_final_results,
+                min_value=min_value,
                 exclude_detection_period_from_training=exclude_detection_period_from_training,
             )
         ) %}

--- a/macros/edr/tests/test_dimension_anomalies.sql
+++ b/macros/edr/tests/test_dimension_anomalies.sql
@@ -19,7 +19,7 @@
     training_period,
     exclude_final_results,
     min_value=none,
-    exclude_detection_period_from_training=false
+    exclude_detection_period_from_training=none
 ) %}
     {{ config(tags=["elementary-tests"]) }}
     {%- if execute and elementary.is_test_command() and elementary.is_elementary_enabled() %}

--- a/macros/edr/tests/test_event_freshness_anomalies.sql
+++ b/macros/edr/tests/test_event_freshness_anomalies.sql
@@ -16,7 +16,7 @@
     anomaly_exclude_metrics,
     detection_period,
     training_period,
-    exclude_detection_period_from_training=false
+    exclude_detection_period_from_training=none
 ) %}
     {{ config(tags=["elementary-tests"]) }}
     {% if execute and elementary.is_test_command() and elementary.is_elementary_enabled() %}

--- a/macros/edr/tests/test_freshness_anomalies.sql
+++ b/macros/edr/tests/test_freshness_anomalies.sql
@@ -15,7 +15,7 @@
     anomaly_exclude_metrics,
     detection_period,
     training_period,
-    exclude_detection_period_from_training=false
+    exclude_detection_period_from_training=none
 ) %}
     {{ config(tags=["elementary-tests"]) }}
     {{

--- a/macros/edr/tests/test_table_anomalies.sql
+++ b/macros/edr/tests/test_table_anomalies.sql
@@ -23,6 +23,7 @@
     anomaly_exclude_metrics=none,
     detection_period=none,
     training_period=none,
+    min_value,
     exclude_detection_period_from_training=false
 ) %}
     {{ config(tags=["elementary-tests"]) }}
@@ -82,6 +83,7 @@
                 anomaly_exclude_metrics=anomaly_exclude_metrics,
                 detection_period=detection_period,
                 training_period=training_period,
+                min_value=min_value,
                 exclude_detection_period_from_training=exclude_detection_period_from_training,
             )
         ) %}

--- a/macros/edr/tests/test_table_anomalies.sql
+++ b/macros/edr/tests/test_table_anomalies.sql
@@ -18,13 +18,13 @@
         "spike_failure_percent_threshold": none,
         "drop_failure_percent_threshold": none,
     },
-    fail_on_zero=false,
+    fail_on_zero=none,
     detection_delay=none,
     anomaly_exclude_metrics=none,
     detection_period=none,
     training_period=none,
     min_value=none,
-    exclude_detection_period_from_training=false
+    exclude_detection_period_from_training=none
 ) %}
     {{ config(tags=["elementary-tests"]) }}
     {%- if execute and elementary.is_test_command() and elementary.is_elementary_enabled() %}

--- a/macros/edr/tests/test_table_anomalies.sql
+++ b/macros/edr/tests/test_table_anomalies.sql
@@ -23,7 +23,7 @@
     anomaly_exclude_metrics=none,
     detection_period=none,
     training_period=none,
-    min_value,
+    min_value=none,
     exclude_detection_period_from_training=false
 ) %}
     {{ config(tags=["elementary-tests"]) }}

--- a/macros/edr/tests/test_utils/get_anomaly_query.sql
+++ b/macros/edr/tests/test_utils/get_anomaly_query.sql
@@ -230,10 +230,8 @@
 {% endmacro %}
 
 {% macro min_value_condition(min_value) %}
-    {% if min_value is not none %}
-        (metric_value >= {{ min_value }})
-    {% else %}
-        (1 = 1)
+    {% if min_value is not none %}(metric_value >= {{ min_value }})
+    {% else %}(1 = 1)
     {% endif %}
 {% endmacro %}
 
@@ -257,8 +255,7 @@
                         test_configuration.anomaly_direction,
                     )
                 }}
-                and
-                {{ elementary.min_value_condition(test_configuration.min_value) }}
+                and {{ elementary.min_value_condition(test_configuration.min_value) }}
             )
         )
     )

--- a/macros/edr/tests/test_utils/get_anomaly_query.sql
+++ b/macros/edr/tests/test_utils/get_anomaly_query.sql
@@ -229,6 +229,14 @@
     (metric_value = 0 and {% if fail_on_zero %} 1 = 1 {% else %} 1 = 2 {% endif %})
 {% endmacro %}
 
+{% macro min_value_condition(min_value) %}
+    {% if min_value is not none %}
+        (metric_value >= {{ min_value }})
+    {% else %}
+        (1 = 1)
+    {% endif %}
+{% endmacro %}
+
 {% macro anomaly_score_condition(test_configuration) %}
     (
         anomaly_score is not null
@@ -249,6 +257,8 @@
                         test_configuration.anomaly_direction,
                     )
                 }}
+                and
+                {{ elementary.min_value_condition(test_configuration.min_value) }}
             )
         )
     )

--- a/macros/edr/tests/test_volume_anomalies.sql
+++ b/macros/edr/tests/test_volume_anomalies.sql
@@ -16,7 +16,7 @@
     anomaly_exclude_metrics,
     detection_period,
     training_period,
-    exclude_detection_period_from_training=false
+    exclude_detection_period_from_training=none
 ) %}
     {{ config(tags=["elementary-tests"]) }}
 


### PR DESCRIPTION
## Summary

Adds an optional `min_value` parameter to all anomaly detection tests (`column_anomalies`, `all_columns_anomalies`, `table_anomalies`, `dimension_anomalies`). When set, an anomaly is only flagged if `metric_value >= min_value`, providing an absolute floor that prevents false positives on small but statistically significant values.

**Motivation:** When monitoring metrics like `null_percent`, z-score-based detection can trigger on tiny absolute changes (e.g., 0% → 0.5% nulls) that are statistically anomalous but practically insignificant. The existing `ignore_small_changes` parameter uses relative thresholds that break down when the training mean is near zero. `min_value` gives users a simple, business-meaningful absolute threshold.

Closes elementary-data/elementary#2177

## Changes

- **`test_column_anomalies.sql`**, **`test_all_columns_anomalies.sql`**, **`test_table_anomalies.sql`**, **`test_dimension_anomalies.sql`** — added `min_value` to macro signatures and forwarded to configuration.
- **`get_anomalies_test_configuration.sql`** — resolves `min_value` via `get_test_argument` (supports vars/model/test precedence) and stores it in `test_configuration`.
- **`get_anomaly_query.sql`** — new `min_value_condition` macro integrated into `anomaly_score_condition`, inside the z-score branch (so `fail_on_zero` still works independently).
- **`test_anomaly_test_configuration.py`** — added `min_value` to configuration precedence test.
- **`test_column_anomalies.py`** — added parametrized behavioral test validating anomaly suppression when `metric_value < min_value`.

## Usage example

```yaml
models:
  - name: my_model
    columns:
      - name: my_column
        tests:
          - elementary.column_anomalies:
              column_anomalies:
                - null_percent
              min_value: 5  # Only flag if null_percent >= 5%
```

## Test plan

- [ ] Configuration precedence test (`test_anomaly_test_configuration`) validates `min_value` is resolved correctly from vars, model config, and test config
- [ ] Behavioral test (`test_column_anomalies_with_min_value`) validates anomaly is detected without `min_value` and suppressed with `min_value` above the metric value
- [ ] Run integration tests on contributor's platform

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a min_value parameter for anomaly detection tests to suppress anomalies when metric values are below a configured threshold.
  * Anomaly evaluation now respects the configured minimum threshold when determining anomalous metrics.

* **Tests**
  * New integration tests validate that min_value is applied and changes pass/fail outcomes as expected.

* **Bug Fixes**
  * Explicitly provided falsy test arguments (e.g., 0) are now accepted instead of being ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/elementary-data/dbt-data-reliability/pull/979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
