### PR TITLE
fix: allow _with_context tests to collect sample rows

### DIFF
--- a/integration_tests/tests/test_with_context_sampling.py
+++ b/integration_tests/tests/test_with_context_sampling.py
@@ -1,0 +1,46 @@
+import json
+
+from dbt_project import DbtProject
+
+COLUMN_NAME = "some_column"
+CONTEXT_COLUMN = "context_column"
+
+TEST_SAMPLE_ROW_COUNT = 7
+
+
+def test_with_context_test_is_sampled(test_id: str, dbt_project: DbtProject):
+    """with_context tests must produce result rows.
+
+    They live in the elementary namespace, but unlike the anomaly and schema-change tests they do
+    not report their own results -- they are ordinary "return the failing rows" tests, and
+    get_test_type classifies them as dbt_test. They therefore rely on the elementary test
+    materialization to capture samples. Regression test for the materialization skipping them
+    because it branched on the namespace rather than the test type, which left them with no
+    result rows at all.
+    """
+    null_count = 50
+    data = [
+        {COLUMN_NAME: None, CONTEXT_COLUMN: f"context-{index}"}
+        for index in range(null_count)
+    ]
+    test_result = dbt_project.test(
+        test_id,
+        "elementary.not_null_with_context",
+        dict(column_name=COLUMN_NAME, context_columns=[CONTEXT_COLUMN]),
+        data=data,
+        test_vars={
+            "enable_elementary_test_materialization": True,
+            "test_sample_row_count": TEST_SAMPLE_ROW_COUNT,
+        },
+    )
+    assert test_result["status"] == "fail"
+
+    samples = [
+        json.loads(row["result_row"])
+        for row in dbt_project.run_query(dbt_project.samples_query(test_id))
+    ]
+    assert len(samples) == TEST_SAMPLE_ROW_COUNT
+    # The requested context column travels with the failing row; that is the whole point.
+    for sample in samples:
+        assert sample[COLUMN_NAME] is None
+        assert sample[CONTEXT_COLUMN].startswith("context-")

--- a/integration_tests/tests/test_with_context_sampling.py
+++ b/integration_tests/tests/test_with_context_sampling.py
@@ -9,15 +9,7 @@ TEST_SAMPLE_ROW_COUNT = 7
 
 
 def test_with_context_test_is_sampled(test_id: str, dbt_project: DbtProject):
-    """with_context tests must produce result rows.
-
-    They live in the elementary namespace, but unlike the anomaly and schema-change tests they do
-    not report their own results -- they are ordinary "return the failing rows" tests, and
-    get_test_type classifies them as dbt_test. They therefore rely on the elementary test
-    materialization to capture samples. Regression test for the materialization skipping them
-    because it branched on the namespace rather than the test type, which left them with no
-    result rows at all.
-    """
+    """with_context tests rely on the test materialization to capture their failing rows."""
     null_count = 50
     data = [
         {COLUMN_NAME: None, CONTEXT_COLUMN: f"context-{index}"}
@@ -34,12 +26,8 @@ def test_with_context_test_is_sampled(test_id: str, dbt_project: DbtProject):
         },
     )
     assert test_result["status"] == "fail"
-    # calculate_failed_count also sits after the early return, so it was skipped too and left
-    # failed_row_count null. Asserting it here covers that second path.
     assert test_result["failed_row_count"] == null_count
-    # get_elementary_test_type returns a distinct "with_context" type so the materialization can
-    # exempt these tests explicitly, but the reported test_type must stay "dbt_test": the alerts
-    # models partition on it exactly, so any other value would leave these tests raising no alerts.
+    # Must stay dbt_test: the alerts models partition on test_type exactly.
     assert test_result["test_type"] == "dbt_test"
 
     samples = [
@@ -47,9 +35,7 @@ def test_with_context_test_is_sampled(test_id: str, dbt_project: DbtProject):
         for row in dbt_project.run_query(dbt_project.samples_query(test_id))
     ]
     assert len(samples) == TEST_SAMPLE_ROW_COUNT
-    # The requested context column travels with the failing row, carrying its real value; that is
-    # the whole point of the family. Membership rather than equality because sampling returns an
-    # arbitrary TEST_SAMPLE_ROW_COUNT of the null_count failing rows.
+    # Membership, since sampling returns an arbitrary TEST_SAMPLE_ROW_COUNT of the failing rows.
     expected_context_values = {f"context-{index}" for index in range(null_count)}
     for sample in samples:
         assert sample[COLUMN_NAME] is None

--- a/integration_tests/tests/test_with_context_sampling.py
+++ b/integration_tests/tests/test_with_context_sampling.py
@@ -37,6 +37,10 @@ def test_with_context_test_is_sampled(test_id: str, dbt_project: DbtProject):
     # calculate_failed_count also sits after the early return, so it was skipped too and left
     # failed_row_count null. Asserting it here covers that second path.
     assert test_result["failed_row_count"] == null_count
+    # get_elementary_test_type returns a distinct "with_context" type so the materialization can
+    # exempt these tests explicitly, but the reported test_type must stay "dbt_test": the alerts
+    # models partition on it exactly, so any other value would leave these tests raising no alerts.
+    assert test_result["test_type"] == "dbt_test"
 
     samples = [
         json.loads(row["result_row"])

--- a/integration_tests/tests/test_with_context_sampling.py
+++ b/integration_tests/tests/test_with_context_sampling.py
@@ -34,13 +34,19 @@ def test_with_context_test_is_sampled(test_id: str, dbt_project: DbtProject):
         },
     )
     assert test_result["status"] == "fail"
+    # calculate_failed_count also sits after the early return, so it was skipped too and left
+    # failed_row_count null. Asserting it here covers that second path.
+    assert test_result["failed_row_count"] == null_count
 
     samples = [
         json.loads(row["result_row"])
         for row in dbt_project.run_query(dbt_project.samples_query(test_id))
     ]
     assert len(samples) == TEST_SAMPLE_ROW_COUNT
-    # The requested context column travels with the failing row; that is the whole point.
+    # The requested context column travels with the failing row, carrying its real value; that is
+    # the whole point of the family. Membership rather than equality because sampling returns an
+    # arbitrary TEST_SAMPLE_ROW_COUNT of the null_count failing rows.
+    expected_context_values = {f"context-{index}" for index in range(null_count)}
     for sample in samples:
         assert sample[COLUMN_NAME] is None
-        assert sample[CONTEXT_COLUMN].startswith("context-")
+        assert sample[CONTEXT_COLUMN] in expected_context_values

--- a/macros/edr/materializations/test/test.sql
+++ b/macros/edr/materializations/test/test.sql
@@ -28,8 +28,11 @@
     {% endif %}
 
     {% set test_namespace = model.get("test_metadata", {}).get("namespace") %}
-    {% if test_namespace == "elementary" %}
-        {# Custom test materialization is needed only for non-elementary tests #}
+    {% set test_name = model.get("test_metadata", {}).get("name", "") %}
+    {% if test_namespace == "elementary" and not test_name.endswith("_with_context") %}
+        {# Custom test materialization is needed only for non-elementary tests.
+           _with_context tests are elementary-namespaced but behave like regular dbt
+           tests (they return failing rows) so they go through the standard sampling path. #}
         {% do return(materialization_macro()) %}
     {% endif %}
 

--- a/macros/edr/materializations/test/test.sql
+++ b/macros/edr/materializations/test/test.sql
@@ -28,12 +28,15 @@
     {% endif %}
 
     {% set test_namespace = model.get("test_metadata", {}).get("namespace") %}
-    {% set test_name = model.get("test_metadata", {}).get("name", "") %}
-    {% if test_namespace == "elementary" and not test_name.endswith("_with_context") %}
-        {# Custom test materialization is needed only for non-elementary tests.
-           _with_context tests are elementary-namespaced but behave like regular dbt
-           tests (they return failing rows) so they go through the standard sampling path. #}
-        {% do return(materialization_macro()) %}
+    {% if test_namespace == "elementary" %}
+        {% set short_name = model.get("test_metadata", {}).get("name", "") | lower %}
+        {% set elementary_test_type = elementary.get_elementary_test_type(
+            {"short_name": short_name, "test_namespace": "elementary"}
+        ) %}
+        {% if elementary_test_type %}
+            {# Anomaly detection and schema change tests handle their own result row collection #}
+            {% do return(materialization_macro()) %}
+        {% endif %}
     {% endif %}
 
     {% set flattened_test = elementary.flatten_test(model) %}

--- a/macros/edr/materializations/test/test.sql
+++ b/macros/edr/materializations/test/test.sql
@@ -34,9 +34,7 @@
             {"short_name": short_name, "test_namespace": "elementary"}
         ) %}
         {% if elementary_test_type and elementary_test_type != "with_context" %}
-            {# Anomaly detection and schema change tests handle their own result row collection.
-               with_context tests do not -- they return the failing rows and need this
-               materialization to sample them -- so they are exempted explicitly. #}
+            {# Anomaly detection and schema change tests handle their own result row collection #}
             {% do return(materialization_macro()) %}
         {% endif %}
     {% endif %}

--- a/macros/edr/materializations/test/test.sql
+++ b/macros/edr/materializations/test/test.sql
@@ -33,8 +33,10 @@
         {% set elementary_test_type = elementary.get_elementary_test_type(
             {"short_name": short_name, "test_namespace": "elementary"}
         ) %}
-        {% if elementary_test_type %}
-            {# Anomaly detection and schema change tests handle their own result row collection #}
+        {% if elementary_test_type and elementary_test_type != "with_context" %}
+            {# Anomaly detection and schema change tests handle their own result row collection.
+               with_context tests do not -- they return the failing rows and need this
+               materialization to sample them -- so they are exempted explicitly. #}
             {% do return(materialization_macro()) %}
         {% endif %}
     {% endif %}

--- a/macros/edr/tests/test_utils/get_test_type.sql
+++ b/macros/edr/tests/test_utils/get_test_type.sql
@@ -4,7 +4,9 @@
             flattened_test
         ) %}
     {% endif %}
-    {% if elementary_test_type == "with_context" %} {% do return("dbt_test") %} {% endif %}
+    {% if elementary_test_type == "with_context" %}
+        {% do return("dbt_test") %}
+    {% endif %}
     {% do return(elementary_test_type or "dbt_test") %}
 {% endmacro %}
 

--- a/macros/edr/tests/test_utils/get_test_type.sql
+++ b/macros/edr/tests/test_utils/get_test_type.sql
@@ -4,6 +4,16 @@
             flattened_test
         ) %}
     {% endif %}
+    {#
+      with_context tests are reported as dbt_test. They behave like plain dbt tests -- they return
+      failing rows and rely on the test materialization to collect them -- and the alerts models
+      partition on this value exactly (alerts_dbt_tests filters test_type = 'dbt_test',
+      alerts_anomaly_detection 'anomaly_detection', alerts_schema_changes 'schema_change'). Any
+      other value would match none of them, so these tests would raise no alerts at all. The
+      distinct "with_context" type exists so the test materialization can identify them
+      explicitly; it is deliberately not surfaced as a test_type.
+    #}
+    {% if elementary_test_type == "with_context" %} {% do return("dbt_test") %} {% endif %}
     {% do return(elementary_test_type or "dbt_test") %}
 {% endmacro %}
 
@@ -22,11 +32,26 @@
         "schema_changes_from_baseline",
         "json_schema",
     ] %}
+    {#
+      Unlike the two families above, these do not collect their own result rows -- they return the
+      failing rows and depend on the test materialization to sample them. Naming them explicitly
+      lets the materialization exempt them from its early return.
+    #}
+    {%- set with_context_tests = [
+        "accepted_range_with_context",
+        "expect_column_values_to_be_unique_with_context",
+        "expect_column_values_to_match_regex_with_context",
+        "expect_column_values_to_not_be_null_with_context",
+        "not_null_with_context",
+        "relationships_with_context",
+    ] %}
 
     {% if flattened_test.short_name | lower in anomaly_detection_tests %}
         {% do return("anomaly_detection") %}
     {% elif flattened_test.short_name | lower in schema_changes_tests %}
         {% do return("schema_change") %}
+    {% elif flattened_test.short_name | lower in with_context_tests %}
+        {% do return("with_context") %}
     {% endif %}
     {% do return(none) %}
 {% endmacro %}

--- a/macros/edr/tests/test_utils/get_test_type.sql
+++ b/macros/edr/tests/test_utils/get_test_type.sql
@@ -4,15 +4,6 @@
             flattened_test
         ) %}
     {% endif %}
-    {#
-      with_context tests are reported as dbt_test. They behave like plain dbt tests -- they return
-      failing rows and rely on the test materialization to collect them -- and the alerts models
-      partition on this value exactly (alerts_dbt_tests filters test_type = 'dbt_test',
-      alerts_anomaly_detection 'anomaly_detection', alerts_schema_changes 'schema_change'). Any
-      other value would match none of them, so these tests would raise no alerts at all. The
-      distinct "with_context" type exists so the test materialization can identify them
-      explicitly; it is deliberately not surfaced as a test_type.
-    #}
     {% if elementary_test_type == "with_context" %} {% do return("dbt_test") %} {% endif %}
     {% do return(elementary_test_type or "dbt_test") %}
 {% endmacro %}
@@ -32,11 +23,6 @@
         "schema_changes_from_baseline",
         "json_schema",
     ] %}
-    {#
-      Unlike the two families above, these do not collect their own result rows -- they return the
-      failing rows and depend on the test materialization to sample them. Naming them explicitly
-      lets the materialization exempt them from its early return.
-    #}
     {%- set with_context_tests = [
         "accepted_range_with_context",
         "expect_column_values_to_be_unique_with_context",


### PR DESCRIPTION
## Summary
- `_with_context` tests are Elementary-namespaced but behave like regular dbt tests (they return failing rows rather than handling their own result row collection)
- The test materialization was early-returning for all `elementary`-namespaced tests, bypassing the sampling logic entirely
- This meant `_with_context` tests never wrote rows to `test_result_rows`, even when tagged with `show_sample_rows`

## Fix
Check if the test name ends with `_with_context` before early-returning, allowing these tests to go through the standard `handle_dbt_test` sampling path.

## Test plan
- [ ] Run a failing `_with_context` test (e.g. `not_null_with_context`) and verify rows appear in `test_result_rows`
- [ ] Verify non-`_with_context` Elementary tests (anomaly, schema change) still early-return and handle their own result rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of elementary tests by applying specialized processing only to recognized test types.
  * Ensured other elementary-namespaced tests, including context-aware tests, follow the standard processing flow.
  * Fixed sampling for `not_null_with_context` tests so configured sample counts are respected and context values are preserved in sampled results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->