### PR TITLE
feat; add deprecation_date key to dbt_models metadata model

### DIFF
--- a/macros/edr/dbt_artifacts/upload_dbt_models.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_models.sql
@@ -40,6 +40,7 @@
         ("incremental_strategy", "string"),
         ("group_name", "string"),
         ("access", "string"),
+        ("deprecation_date", "string"),
     ] %}
     {% if target.type == "bigquery" or elementary.get_config_var(
         "include_other_warehouse_specific_columns"
@@ -114,6 +115,8 @@
         "bigquery_cluster_by": config_dict.get("cluster_by"),
         "group_name": config_dict.get("group") or node_dict.get("group"),
         "access": config_dict.get("access") or node_dict.get("access"),
+        "deprecation_date": config_dict.get("deprecation_date")
+        or node_dict.get("deprecation_date"),
     } %}
     {% do flatten_model_metadata_dict.update(
         {

--- a/macros/edr/dbt_artifacts/upload_dbt_models.sql
+++ b/macros/edr/dbt_artifacts/upload_dbt_models.sql
@@ -115,8 +115,7 @@
         "bigquery_cluster_by": config_dict.get("cluster_by"),
         "group_name": config_dict.get("group") or node_dict.get("group"),
         "access": config_dict.get("access") or node_dict.get("access"),
-        "deprecation_date": config_dict.get("deprecation_date")
-        or node_dict.get("deprecation_date"),
+        "deprecation_date": node_dict.get("deprecation_date"),
     } %}
     {% do flatten_model_metadata_dict.update(
         {

--- a/models/dbt_artifacts.yml
+++ b/models/dbt_artifacts.yml
@@ -7,8 +7,6 @@ models:
       Each row contains information about a single model.
       Data is loaded every time this model is executed.
       It is recommended to execute the model every time a change is merged to the project.
-      On BigQuery, or when the elementary variable include_other_warehouse_specific_columns is true,
-      the table also includes bigquery_partition_by and bigquery_cluster_by (not listed below).
     columns:
       - name: unique_id
         data_type: string

--- a/models/dbt_artifacts.yml
+++ b/models/dbt_artifacts.yml
@@ -7,6 +7,8 @@ models:
       Each row contains information about a single model.
       Data is loaded every time this model is executed.
       It is recommended to execute the model every time a change is merged to the project.
+      On BigQuery, or when the elementary variable include_other_warehouse_specific_columns is true,
+      the table also includes bigquery_partition_by and bigquery_cluster_by (not listed below).
     columns:
       - name: unique_id
         data_type: string
@@ -72,9 +74,37 @@ models:
         data_type: string
         description: Short path of the model file.
 
+      - name: patch_path
+        data_type: string
+        description: Path to the YAML file that patches this model, if any.
+
       - name: generated_at
         data_type: string
         description: Update time of the table.
+
+      - name: metadata_hash
+        data_type: string
+        description: Hash of the captured model metadata for change detection.
+
+      - name: unique_key
+        data_type: string
+        description: Incremental unique_key from model config, if set.
+
+      - name: incremental_strategy
+        data_type: string
+        description: Incremental strategy from model config, if set.
+
+      - name: group_name
+        data_type: string
+        description: dbt group for the model, if assigned.
+
+      - name: access
+        data_type: string
+        description: Model access level (for example private, protected, or public).
+
+      - name: deprecation_date
+        data_type: string
+        description: Model deprecation_date property from the dbt graph, if set.
 
   - name: dbt_tests
     description: >


### PR DESCRIPTION
## What

This is a quick attempt to address https://github.com/elementary-data/dbt-data-reliability/issues/986 by adding the column to the `upload_dbt_models` macro that populates the `dbt_models` model. 

I've also added the new column, and several other missing columns, the properties for the model.

## Why

We, and presumably others, leverage this column as a way to flag upcoming model deprecation to developers and also to automatically remove models from our project. If we could have this column in `dbt_models`, it would make analysis, and automated notifications to users easier. As far as I'm aware, there isn't a way to currently do this and I don't see a record of this being discussed previously.

## TODO / Questions

~~I still need to do some testing but thought I might as well create a draft PR to accompany the issue I raised in case this is a non starter.~~

I've tested this locally and the resulting `deprecation_date` column picks up the value as expected. I've also run the integration tests against a postgres target successfully and will attach a log file.

I will do some functional testing against Snowflake using a branch in my repo too.

~~I also need to think about the appropriate data type to use for this column~~

I think leaving this as is the right approach but happy to be contradicted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended the dbt_models artifact table with seven new metadata fields: `deprecation_date`, `patch_path`, `metadata_hash`, `unique_key`, `incremental_strategy`, `group_name`, and `access`. These additions enhance model metadata tracking and capture additional configuration properties from dbt graph sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->