### PR TITLE
harden bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -13,58 +13,66 @@ on:
         type: string
         required: true
 
+permissions: {}
+
 jobs:
   validate-version:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
-      validated-dbt-package-version: ${{ steps.validate-dbt-package-input.outputs.dbt-package-validation }}
+      version: ${{ steps.validate.outputs.version }}
     steps:
-      - name: validate dbt package version
-        id: validate-dbt-package-input
-        run: echo "dbt-package-validation=$(echo ${{ inputs.dbt-package-version }} | sed -n '/^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$/p')" >> $GITHUB_OUTPUT
-      - name: echo versions
+      - name: Validate dbt package version
+        id: validate
+        env:
+          VERSION: ${{ inputs.dbt-package-version }}
         run: |
-          echo "dbt package version: ${{ steps.validate-dbt-package-input.outputs.dbt-package-validation }}"
-      - name: fail on invalid input
-        if: ${{ steps.validate-dbt-package-input.outputs.dbt-package-validation == '' }}
-        uses: actions/github-script@v8
-        with:
-          script: |
-            core.setFailed("Invalid version input - ${{ inputs.dbt-package-version }}")
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version: $VERSION"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
   bump-version:
     needs: validate-version
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.validate-version.outputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Create release branch
-        run: git checkout -b release/${{ inputs.dbt-package-version }}
+        run: git checkout -b "release/$VERSION"
       - name: Initial config
         run: |
           git config user.name "GitHub Actions"
           git config user.email noreply@github.com
       - name: Bump package version
         run: |
-          sed -i 's/version: "[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*"$/version: "${{ inputs.dbt-package-version }}"/' ./dbt_project.yml
+          sed -i 's/version: "[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*"$/version: "'"$VERSION"'"/' ./dbt_project.yml
       - name: Bump readme package version
         run: |
-          sed -i 's/version: [0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$/version: ${{ inputs.dbt-package-version }}/' ./README.md
+          sed -i 's/version: [0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$/version: '"$VERSION"'/' ./README.md
       - name: Commit changes
-        run: git commit -am "release ${{ inputs.dbt-package-version }}"
+        run: git commit -am "release $VERSION"
       - name: Push code
-        run: git push origin release/${{ inputs.dbt-package-version }}
+        run: git push origin "release/$VERSION"
 
   create-pr:
-    needs: bump-version
+    needs: [validate-version, bump-version]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - name: create pull request
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2
         with:
-          source_branch: "release/${{ inputs.dbt-package-version }}"
+          source_branch: "release/${{ needs.validate-version.outputs.version }}"
           destination_branch: "master"
-          pr_title: "release/${{ inputs.dbt-package-version }}"
+          pr_title: "release/${{ needs.validate-version.outputs.version }}"
           pr_body: "Open automatically using bump version workflow"
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     outputs:
-      version: ${{ steps.validate.outputs.version }}
+      validated-dbt-package-version: ${{ steps.validate.outputs.validated-dbt-package-version }}
     steps:
       - name: Validate dbt package version
         id: validate
@@ -31,7 +31,7 @@ jobs:
             echo "::error::Invalid version: $VERSION"
             exit 1
           fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "validated-dbt-package-version=$VERSION" >> "$GITHUB_OUTPUT"
 
   bump-version:
     needs: validate-version
@@ -39,7 +39,7 @@ jobs:
     permissions:
       contents: write
     env:
-      VERSION: ${{ needs.validate-version.outputs.version }}
+      VERSION: ${{ needs.validate-version.outputs.validated-dbt-package-version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -71,8 +71,8 @@ jobs:
       - name: create pull request
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2
         with:
-          source_branch: "release/${{ needs.validate-version.outputs.version }}"
+          source_branch: "release/${{ needs.validate-version.outputs.validated-dbt-package-version }}"
           destination_branch: "master"
-          pr_title: "release/${{ needs.validate-version.outputs.version }}"
+          pr_title: "release/${{ needs.validate-version.outputs.validated-dbt-package-version }}"
           pr_body: "Open automatically using bump version workflow"
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -69,7 +69,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: create pull request
-        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2
+        # repo-sync/pull-request v2.12.1, checked 2026-04-26.
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5
         with:
           source_branch: "release/${{ needs.validate-version.outputs.validated-dbt-package-version }}"
           destination_branch: "master"


### PR DESCRIPTION
## Summary

Hardens the manual release-bump workflow against script injection and supply-chain risk.

- **Input validation is now fail-closed.** `inputs.dbt-package-version` flows through `env:` (no shell-template substitution) and is regex-validated; invalid input fails the job rather than producing an empty filtered string. The validated value is exported as a job output for downstream consumption.
- **All downstream `run:` steps** read the validated version via `needs.validate-version.outputs.version` and pass it through `env:` — no `${{ }}` interpolation inside any shell script.
- **SHA-pinned** `repo-sync/pull-request@v2`.
- **Default-deny `GITHUB_TOKEN`**: top-level `permissions: {}`, job-level overrides for the minimum each job needs (`contents: write` for the push job, `contents: read` + `pull-requests: write` for PR creation).

## Test plan

- [ ] Trigger via Actions UI with a valid version (e.g. `1.2.3`) → release branch + PR created.
- [ ] Trigger with an invalid version (`1.2`, `1.2.3; rm`, ``) → job fails at validation.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release process reliability with enhanced version validation.
  * Strengthened security posture with explicit permission management.
  * Increased stability through locked automation dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->