### PR TITLE
harden remind-docs-and-tests workflow

### DIFF
--- a/.github/workflows/remind-docs-and-tests.yml
+++ b/.github/workflows/remind-docs-and-tests.yml
@@ -10,7 +10,8 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: wow-actions/auto-comment@2fc064c21cfb2505de3c5c10e1473b8eb7beca1a # v1
+      # wow-actions/auto-comment v1.1.2, checked 2026-04-26.
+      - uses: wow-actions/auto-comment@2fc064c21cfb2505de3c5c10e1473b8eb7beca1a
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           pullRequestOpened: |

--- a/.github/workflows/remind-docs-and-tests.yml
+++ b/.github/workflows/remind-docs-and-tests.yml
@@ -2,11 +2,15 @@ name: Remind docs and tests
 on:
   pull_request_target:
     branches: ["master"]
+permissions: {}
 jobs:
   run:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
-      - uses: wow-actions/auto-comment@v1
+      - uses: wow-actions/auto-comment@2fc064c21cfb2505de3c5c10e1473b8eb7beca1a # v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           pullRequestOpened: |


### PR DESCRIPTION
## Summary

Hardens the `pull_request_target`-triggered auto-comment workflow against supply-chain risk.

- **SHA-pinned** `wow-actions/auto-comment@v1`. The action runs against the base repo with a `GITHUB_TOKEN`; pinning to a commit prevents tag-repointing attacks.
- **Default-deny `GITHUB_TOKEN`**: top-level `permissions: {}`, the `run` job gets `contents: read` + `pull-requests: write` only.

## Test plan

- [ ] Open a PR from a fork against `master` — auto-comment posts as before.
- [ ] Open a PR from an internal branch — same behavior.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow security by defining explicit, minimal permission scopes and narrowing permissions at the job level.
  * Increased stability and auditability by pinning a third-party workflow action to a fixed version rather than a floating reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->