### PR TITLE
permissions sweep on simple workflows

### DIFF
--- a/.github/workflows/assign-devin-prs.yml
+++ b/.github/workflows/assign-devin-prs.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened]
 
+permissions: {}
+
 jobs:
   assign:
     if: github.actor == 'devin-ai-integration[bot]'

--- a/.github/workflows/run-precommit.yml
+++ b/.github/workflows/run-precommit.yml
@@ -3,9 +3,13 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions: {}
+
 jobs:
   code-quality:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Elementary
         uses: actions/checkout@v6

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: "30 1 * * *"
 
+permissions: {}
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Mechanical hardening — applies the default-deny `GITHUB_TOKEN` policy to the three workflows that didn't otherwise need any changes.

- **`run-precommit.yml`**: adds top-level `permissions: {}` and `contents: read` on the `code-quality` job (it only needs to checkout).
- **`stale.yml`**: adds top-level `permissions: {}`. Existing job-level scopes for the stale action are unchanged.
- **`assign-devin-prs.yml`**: adds top-level `permissions: {}`. Existing job-level scopes are unchanged.

No behavior changes expected.

## Test plan

- [ ] Open a PR — `run-precommit.yml` runs and pre-commit passes.
- [ ] Devin opens a PR — auto-assignment still works.
- [ ] Daily stale cron — issues/PRs are still labeled/closed.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to refine permission settings across multiple workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->