### PR TITLE
ci: drop static AWS keys from athena profile (CORE-687)

### DIFF
--- a/.github/workflows/cleanup-stale-schemas.yml
+++ b/.github/workflows/cleanup-stale-schemas.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Mint an OIDC token to assume the shared elementary-oss AWS role
+      # (used by the athena matrix entry below).
+      id-token: write
     env:
       WAREHOUSE: ${{ matrix.warehouse-type }}
       MAX_AGE_HOURS: ${{ inputs.max-age-hours || '24' }}
@@ -42,6 +45,13 @@ jobs:
             echo "::error::Invalid max-age-hours: '$MAX_AGE_HOURS' (must be a non-negative integer)"
             exit 1
           fi
+
+      - name: Configure AWS credentials
+        if: matrix.warehouse-type == 'athena'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: eu-west-1
 
       - name: Checkout dbt package
         uses: actions/checkout@v6

--- a/.github/workflows/test-all-warehouses.yml
+++ b/.github/workflows/test-all-warehouses.yml
@@ -138,6 +138,10 @@ jobs:
     needs: [check-fork-status, approve-fork]
     permissions:
       contents: read
+      # Required so the called test-warehouse.yml can mint an OIDC token to
+      # assume the AWS role (only used for the athena matrix entry); per
+      # GitHub, id-token: write must be granted by the calling workflow.
+      id-token: write
     if: |
       ! cancelled() &&
       needs.check-fork-status.result == 'success' &&

--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -63,6 +63,8 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
+      # Mint an OIDC token to assume the shared elementary-oss AWS role.
+      id-token: write
     env:
       WAREHOUSE: ${{ inputs.warehouse-type }}
       DBT_VERSION: ${{ inputs.dbt-version }}
@@ -84,6 +86,13 @@ jobs:
         with:
           path: dbt-data-reliability
           ref: ${{ inputs.dbt-data-reliability-ref }}
+
+      - name: Configure AWS credentials
+        if: inputs.warehouse-type == 'athena'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: eu-west-1
 
       - name: Start Postgres
         if: inputs.warehouse-type == 'postgres'

--- a/integration_tests/profiles/profiles.yml.j2
+++ b/integration_tests/profiles/profiles.yml.j2
@@ -177,8 +177,7 @@
       region_name: {{ athena_region | toyaml }}
       database: awsdatacatalog
       schema: {{ schema }}
-      aws_access_key_id: {{ athena_aws_access_key_id | toyaml }}
-      aws_secret_access_key: {{ athena_aws_secret_access_key | toyaml }}
+      work_group: oss_tests
       threads: 4
 {%- endmacro %}
 


### PR DESCRIPTION
## Summary

Pairs with the elementary-cli + elementary-internal OIDC migration. Drops the static `aws_access_key_id` / `aws_secret_access_key` rendered into the dbt-athena profile (sourced from `CI_WAREHOUSE_SECRETS`) and pins the profile to the dedicated `oss_tests` Athena workgroup. boto3 picks up role credentials from the env vars exported by `aws-actions/configure-aws-credentials` in whichever workflow uses this profile.

## Linked

- Linear: https://linear.app/elementary/issue/CORE-687
- Trust policy + workgroup: https://github.com/elementary-data/elementary-internal/pull/5973
- Consumer workflows: https://github.com/elementary-data/elementary/pull/2215

## Caveat

This integration_tests profile template is also referenced by dbt-data-reliability's own CI workflows (e.g. `test-warehouse.yml`, `cleanup-stale-schemas.yml`). Those workflows still authenticate via the static keys. Once this lands, they'll break for the athena target until they're updated to assume the OIDC role too. Either:

1. Land this PR last (after the consumer-side changes), or
2. Follow up with workflow changes in this repo that mirror what elementary-cli's `test-warehouse.yml` and `cleanup-stale-schemas.yml` do (add `permissions: id-token: write` + `aws-actions/configure-aws-credentials@v4`), and expand the `job_workflow_ref` allow-list in `iac_global/github_actions_oidc.tf` to include this repo's workflows + the `sub` claim to allow `repo:elementary-data/dbt-data-reliability:*`.

## Test plan

- [ ] Land the elementary-internal IAM PR first.
- [ ] Coordinate with the dbt-data-reliability CI follow-up before merging this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced CI/CD security by implementing OIDC token minting across build and test workflows, enabling automatic and secure AWS credential provisioning without explicit key storage
  * Refactored integration test suite to leverage OIDC-based authentication for AWS interactions, improving security posture and reducing credential exposure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->