### PR TITLE
fix(ci): grant id-token: write to test-local (unblocks workflow)

### DIFF
--- a/.github/workflows/test-all-warehouses.yml
+++ b/.github/workflows/test-all-warehouses.yml
@@ -46,6 +46,7 @@ jobs:
     if: github.event_name != 'pull_request_target'
     permissions:
       contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Fixes the workflow validation error introduced when #997 (CORE-687) added \`id-token: write\` to \`test-warehouse.yml\` for the athena AWS-OIDC step:

\`\`\`
Invalid workflow file: .github/workflows/test-all-warehouses.yml#L45
The nested job 'test' is requesting 'id-token: write',
but is only allowed 'id-token: none'.
\`\`\`

\`test-warehouse.yml\` declares \`id-token: write\` at the job level. Reusable-workflow permissions are bounded by the calling job, so any caller must grant it. \`test-cloud\` already does. \`test-local\` was tightened in #996 to \`contents: read\` only, which was fine until #997 added the OIDC requirement to the called workflow.

This grants \`id-token: write\` on \`test-local\` too. The OIDC step in \`test-warehouse.yml\` is gated by \`if: inputs.warehouse-type == 'athena'\`, and athena is not in the local matrix, so no token is ever actually minted from local jobs — the grant just satisfies the static permissions bound check.

## Alternatives considered

- **Splitting the OIDC step into a separate job in \`test-warehouse.yml\`** so only that job declares \`id-token: write\`: cleaner in principle, but a much bigger refactor of the reusable workflow. Not worth it for a single matrix entry.
- **Removing \`id-token: write\` from \`test-warehouse.yml\`**: doesn't work — the called workflow's job still needs to declare permissions it intends to use.

## Test plan

- [ ] CI green on this PR (the validation error should disappear)
- [ ] \`test-local\` jobs run as before; no AWS auth attempted (athena absent from local matrix)
- [ ] \`test-cloud\` athena entry still mints OIDC token successfully

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated so local test jobs can mint OIDC tokens, aligning local and cloud testing behavior.
  * No user-facing changes — internal infrastructure update to improve test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->