### PR TITLE
APP-1086: fix BigQuery nanosecond timestamp cast failure in edr_cast_as_timestamp

### DIFF
--- a/macros/utils/data_types/cast_column.sql
+++ b/macros/utils/data_types/cast_column.sql
@@ -10,6 +10,22 @@
     cast({{ timestamp_field }} as {{ elementary.edr_type_timestamp() }})
 {%- endmacro -%}
 
+{#
+  BigQuery's TIMESTAMP type only supports microsecond precision (6 fractional digits).
+  Some runtimes (e.g. dbt-fusion) write nanosecond-precision strings like
+  '2026-04-03T10:50:50.961498756Z' into Elementary's metadata tables, which fail
+  to cast. This truncates any sub-microsecond fractional digits before casting.
+#}
+{%- macro bigquery__edr_cast_as_timestamp(timestamp_field) -%}
+    cast(
+        regexp_replace(
+            cast({{ timestamp_field }} as {{ elementary.edr_type_string() }}),
+            r'(\.\d{6})\d+',
+            r'\1'
+        ) as {{ elementary.edr_type_timestamp() }}
+    )
+{%- endmacro -%}
+
 {# Athena and Trino needs explicit conversion for ISO8601 timestamps used in buckets_cte #}
 {%- macro athena__edr_cast_as_timestamp(timestamp_field) -%}
     coalesce(


### PR DESCRIPTION
## Summary

Adds a BigQuery-specific override for `edr_cast_as_timestamp` that truncates sub-microsecond fractional digits before casting to `TIMESTAMP`.

BigQuery's `TIMESTAMP` only supports microsecond precision (6 fractional digits). Some runtimes (e.g. dbt-fusion) write nanosecond-precision strings like `2026-04-03T10:50:50.961498756Z` into Elementary's `dbt_run_results` columns (`execute_started_at`, `execute_completed_at`, `compile_started_at`, `compile_completed_at`). The default `cast(field as timestamp)` then fails with `Database Error: Invalid timestamp: '...'` and blocks `edr send-report` / `edr report` until the bad rows age out.

The new `bigquery__edr_cast_as_timestamp` macro wraps the value in `regexp_replace(..., r'(\.\d{6})\d+', r'\1')` before the cast, truncating any extra fractional digits to exactly 6. Strings with ≤ 6 fractional digits are unaffected. This follows the same dispatch pattern as the existing `dremio__edr_cast_as_timestamp` truncation. `bigquery__edr_cast_as_date` chains through `edr_cast_as_timestamp`, so the fix applies there transparently as well.

Linear: [APP-1086](https://linear.app/elementary/issue/APP-1086/fix-bigquery-nanosecond-timestamp-cast-failure-in-edr-cast-as)

## Review & Testing Checklist for Human

- [ ] On a BigQuery target, seed `dbt_run_results` with at least one row where `execute_completed_at` has 9 fractional digits (e.g. `2026-04-03T10:50:50.961498756Z`) and confirm `edr send-report` / `edr report` no longer fails on the `days_back` filter.
- [ ] Confirm existing rows with ≤ 6 fractional digits (or no fractional part) still cast correctly and produce identical results to before this change.
- [ ] Run BigQuery integration tests to verify no regression in anomaly detection / monitoring queries that go through `edr_cast_as_timestamp`.

### Notes

- No version bump or release work is included here per the ticket assignee.
- Postgres/Snowflake/Databricks/Spark are unaffected (native nanosecond support or string parsing); Athena/Trino already use `try_cast` which handles this; Dremio already truncates to millisecond precision.

Link to Devin session: https://app.devin.ai/sessions/3a3eac19b8924571820addc7d6b6a877
Requested by: @MikaKerman

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved BigQuery timestamp handling: input timestamps now truncate sub-microsecond fractional digits before casting, preserving microsecond precision and preventing incorrect conversions. This enhances reliability when importing or transforming timestamp data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elementary-data/dbt-data-reliability/pull/1003?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->