### PR TITLE
fix: handle dbt deferral in get_elementary_relation

### DIFF
--- a/macros/utils/graph/get_elementary_relation.sql
+++ b/macros/utils/graph/get_elementary_relation.sql
@@ -24,13 +24,21 @@
             elementary_database, elementary_schema, identifier_alias
         ) %}
         {% if relation is not none %} {% do return(relation) %} {% endif %}
-        {# Relation not found in the target schema. This can happen when
-           dbt deferral (--favor-state / --defer) is active and the
-           Elementary models exist in the deferred (e.g. prod) schema
-           but were not built in the current target. Construct a relation
-           from the graph node coordinates so the generated SQL references
-           the correct schema instead of rendering "from None". #}
-        {% if identifier_node %}
+        {# Relation not found in the target schema. Under dbt deferral
+           (--favor-state / --defer) the Elementary models may exist only
+           in the deferred (e.g. prod) schema and not in the current
+           target. Construct a relation from the graph node coordinates
+           so the generated SQL references the correct schema instead of
+           rendering "from None". #}
+        {% set is_defer = (
+            (
+                invocation_args_dict.get("defer", false)
+                or invocation_args_dict.get("favor_state", false)
+            )
+            if invocation_args_dict
+            else false
+        ) %}
+        {% if identifier_node and is_defer %}
             {% do return(
                 api.Relation.create(
                     database=elementary_database,

--- a/macros/utils/graph/get_elementary_relation.sql
+++ b/macros/utils/graph/get_elementary_relation.sql
@@ -20,10 +20,24 @@
         {% if this and this.database == elementary_database and this.schema == elementary_schema and this.identifier == identifier_alias %}
             {% do return(this) %}
         {% endif %}
-        {% do return(
-            adapter.get_relation(
-                elementary_database, elementary_schema, identifier_alias
-            )
+        {% set relation = adapter.get_relation(
+            elementary_database, elementary_schema, identifier_alias
         ) %}
+        {% if relation is not none %} {% do return(relation) %} {% endif %}
+        {# Relation not found in the target schema. This can happen when
+           dbt deferral (--favor-state / --defer) is active and the
+           Elementary models exist in the deferred (e.g. prod) schema
+           but were not built in the current target. Construct a relation
+           from the graph node coordinates so the generated SQL references
+           the correct schema instead of rendering "from None". #}
+        {% if identifier_node %}
+            {% do return(
+                api.Relation.create(
+                    database=elementary_database,
+                    schema=elementary_schema,
+                    identifier=identifier_alias,
+                )
+            ) %}
+        {% endif %}
     {%- endif %}
 {% endmacro %}


### PR DESCRIPTION
## Summary

When dbt's `--favor-state` or `--defer` flags are active (common in dbt Cloud CI jobs), Elementary models are deferred to the production schema and not built in the CI target schema. The `get_elementary_relation()` macro uses `adapter.get_relation()` — a physical catalog lookup — to resolve Elementary tables like `data_monitoring_metrics`. This returns `None` when the table doesn't exist in the CI schema, which gets rendered literally as `from None` in the generated SQL, causing all anomaly tests to fail with:

```
Database Error: relation "none" does not exist
LINE 25:             from None
```

This fix adds a fallback **gated on deferral being active** (`invocation_args_dict.defer` or `invocation_args_dict.favor_state`): when `adapter.get_relation()` returns `None` but the model node exists in the dbt graph and deferral is active, we construct a Relation object from the graph node coordinates using `api.Relation.create()`. This allows the generated SQL to reference the correct (deferred) schema instead of failing.

Without deferral, the function returns `None` as before, preserving the existing contract for all callers that use truthiness checks to detect missing tables.

**Affected test types:** all anomaly monitors (volume, freshness, all_columns, dimension), plus `test_execution_sla` and result-handling macros.

**Related:** Pylon #3812, closed PR #1002.

## Review & Testing Checklist for Human

- [ ] **Verify deferral behavior**: Test with a dbt project using `--favor-state` where Elementary models exist in prod but not in the CI schema. Anomaly tests should now generate SQL referencing the deferred schema instead of `from None`.
- [ ] **Verify non-deferral behavior is unchanged**: Run anomaly tests without `--defer`/`--favor-state` — `adapter.get_relation()` should still return a real relation as before, and if the table doesn't exist, `None` is returned (fallback is skipped because deferral is not active).
- [ ] **Verify missing-model error path without deferral**: Run a partial `dbt run` (not including Elementary models) followed by anomaly tests — callers should still get `None` and raise the "missing Elementary models" error as before, since the deferral guard prevents the fallback from firing.

### Notes

The fallback is gated on `invocation_args_dict.get("defer", false) or invocation_args_dict.get("favor_state", false)`, which ensures it only activates during dbt commands that explicitly use deferral. This preserves backward compatibility for all existing callers.

Link to Devin session: https://app.devin.ai/sessions/b9eb2d85cd8f4489bf67686c7b413af0
Requested by: @NoyaArie

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a deferral-aware fallback for relation lookups so missing database/schema entries no longer cause SQL generation failures in deferred scenarios; relations are now constructed with resolved schema and database info when the initial lookup fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elementary-data/dbt-data-reliability/pull/1006)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->