### PR TITLE
fix: cache test materialization temp relations for cleanup

### DIFF
--- a/macros/edr/materializations/test/test.sql
+++ b/macros/edr/materializations/test/test.sql
@@ -187,6 +187,17 @@
     {% set database, schema = elementary.get_package_database_and_schema() %}
     {% set test_id = model["alias"] %}
     {% set relation = elementary.create_temp_table(database, schema, test_id, sql) %}
+
+    {# Register the relation in the temp-table cache so on_run_end cleanup
+       (clean_elementary_test_tables) drops it. Without this, T-SQL adapters
+       (Fabric, SQL Server) accumulate one residue table per test in the
+       elementary schema because fabric__create_temp_table builds a real
+       table (not a #temp) — see comment in create_temp_table.sql. #}
+    {% set test_entry = elementary.get_cache(
+        "temp_test_table_relations_map"
+    ).setdefault(test_id, {}) %}
+    {% do test_entry.update({"test_result": relation}) %}
+
     {% set new_sql %}
     select * from {{ relation }}
     {% endset %}


### PR DESCRIPTION
create_test_result_temp_table builds a temp relation via elementary.create_temp_table but never registers it in the "temp_test_table_relations_map" cache that clean_elementary_test_tables reads on run end.

On T-SQL adapters (Fabric, SQL Server) fabric__create_temp_table intentionally builds a real table instead of a #temp table because the EXEC scope isolation makes #temp tables invisible to the caller. As a result, one residue table per test accumulates in the elementary schema on every dbt test invocation and is never cleaned up.

Other call sites (create_elementary_test_table for anomaly / schema change tests) already register their relations in the same cache, so this aligns the test materialization path with existing behavior.

Fix: register the relation in temp_test_table_relations_map keyed by the test alias so the existing on_run_end cleanup hook drops it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where temporary test tables were not being properly tracked for cleanup during test execution, ensuring resources are released correctly after test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elementary-data/dbt-data-reliability/pull/1008?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->