### PR TITLE
fix(fabric): support elementary schema in a different DB than target

### DIFF
--- a/macros/edr/materializations/test/test.sql
+++ b/macros/edr/materializations/test/test.sql
@@ -261,21 +261,33 @@
        model.schema (per-worker test audit schema) or target.schema (base schema),
        which may not have been created yet in parallel CI runs. #}
     {% set _edr_db, _edr_schema = elementary.get_package_database_and_schema() %}
+    {% set view_db = _edr_db if _edr_db else target.database %}
     {% set view_schema = _edr_schema if _edr_schema else target.schema %}
-    {% set full_view_name = view_schema ~ "." ~ view_name %}
+    {% set short_view_name = "[" ~ view_schema ~ "].[" ~ view_name ~ "]" %}
+    {% set qualified_view_name = "[" ~ view_db ~ "].[" ~ view_schema ~ "].[" ~ view_name ~ "]" %}
 
-    {# Create view from the compiled test SQL #}
-    {% do run_query("create view " ~ full_view_name ~ " as " ~ sql) %}
+    {# Fabric/T-SQL constraints prevent both a 3-part qualified CREATE VIEW
+       (error 166) and `USE [db]; CREATE VIEW ...` in a single batch
+       (error 111). Wrapping the DDL in `EXEC [db]..sp_executesql N'...'`
+       executes it in the elementary database's context with a 2-part name,
+       without leaking session DB state across run_query calls. Required
+       when the elementary schema lives in a different database than
+       target.database. #}
+    {% set create_inner = "create view " ~ short_view_name ~ " as " ~ sql %}
+    {% set create_stmt = "EXEC [" ~ view_db ~ "]..sp_executesql N'" ~ create_inner | replace("'", "''") ~ "'" %}
+    {% do run_query(create_stmt) %}
 
     {% set query %}
         select {% if sample_limit is not none %} top {{ sample_limit }} {% endif %} *
-        from {{ full_view_name }}
+        from {{ qualified_view_name }}
     {% endset %}
 
     {% set result = elementary.agate_to_dicts(elementary.run_query(query)) %}
 
-    {# Clean up the temp view #}
-    {% do run_query("drop view if exists " ~ full_view_name) %}
+    {# Clean up the temp view via sp_executesql in the elementary DB. #}
+    {% set drop_inner = "drop view if exists " ~ short_view_name %}
+    {% set drop_stmt = "EXEC [" ~ view_db ~ "]..sp_executesql N'" ~ drop_inner | replace("'", "''") ~ "'" %}
+    {% do run_query(drop_stmt) %}
 
     {% do return(result) %}
 {% endmacro %}


### PR DESCRIPTION
## Summary

When the elementary schema lives in a different database than `target.database` on dbt-fabric / Fabric DW, the `CREATE VIEW` issued by `fabric__query_test_result_rows` uses a 2-part name (`schema.view`) and lands in the connection's current DB (= `target.database`). If the elementary schema does not exist there, the statement fails with:

```
('42000', '[42000] [Microsoft][ODBC Driver 18 for SQL Server][SQL Server]
The specified schema name "<elementary_schema>" either does not exist
or you do not have permission to use it. (2760)')
```

## Root cause

The compiled test SQL passed into `CREATE VIEW … AS …` references the source table via dbt's Relation API, which produces a 3-part qualified name. The target view, however, is only 2-part qualified, so the target side assumes the connection's current DB matches the elementary database. That assumption breaks when the two DBs differ.

## Why the obvious fixes don't work on Fabric

- A 3-part qualified `CREATE VIEW` is rejected (`error 166: 'CREATE/ALTER VIEW' does not allow specifying the database name as a prefix to the object name`).
- `USE [db]; CREATE VIEW …` in a single batch is rejected (`error 111: 'CREATE VIEW' must be the first statement in a query batch`).

## Fix

Dispatch the `CREATE VIEW` / `DROP VIEW IF EXISTS` via `EXEC [db]..sp_executesql N'...'`. `sp_executesql` invoked with a database prefix executes in that database's context, so the view is created with a 2-part name inside the elementary database. The `SELECT` against the helper view stays 3-part qualified (Fabric already accepts that).

No session DB state is mutated, so this is safe under dbt-fabric's threadsafe connection model.

## Test plan

- [x] `dbt test` on Fabric DW with elementary schema in a separate DB from `target.database` — passes (was failing with 2760)
- [x] `dbt test` on Fabric DW with elementary schema in the same DB as `target.database` — no regression
- [ ] `dbt test` on dbt-sqlserver (inherits `fabric__` via dispatch) — not verified locally, behaviour identical at SQL level


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed test result sampling to properly handle scenarios where the elementary database differs from the target database, ensuring temporary views are created and executed in the correct database context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elementary-data/dbt-data-reliability/pull/1009?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->