### PR TITLE
fix(fabric): drop leaked __dbt_tmp_vw helper view after CTAS

### DIFF
--- a/macros/utils/table_operations/create_table_as.sql
+++ b/macros/utils/table_operations/create_table_as.sql
@@ -111,6 +111,34 @@
     {% endif %}
 {% endmacro %}
 
+{% macro fabric__edr_get_create_table_as_sql(temporary, relation, sql_query) %}
+    {#
+        dbt-fabric's fabric__create_table_as implements CTAS via a helper view
+        `<table>__dbt_tmp_vw`: it creates the view, then issues
+        `CREATE TABLE <table> AS SELECT * FROM <table>__dbt_tmp_vw`. The macro
+        does NOT drop the helper view at the end — it relies on the caller
+        (e.g. dbt-fabric's own incremental materialization) to drop it via
+        `adapter.drop_relation` after the CTAS.
+
+        Elementary's edr_create_table_as does not perform that post-drop, so
+        the helper view leaks in the elementary schema every time
+        edr_create_table_as is invoked on Fabric. Affects every artifact
+        table built this way (dbt_columns, dbt_exposures, dbt_seeds,
+        dbt_sources, dbt_tests, plus their `__tmp_<ts>` intermediates).
+
+        Fix: append `EXEC('DROP VIEW IF EXISTS ...')` to the SQL emitted by
+        dbt.get_create_table_as_sql so the helper view is dropped in the
+        same batch that consumed it. Idempotent — uses IF EXISTS.
+    #}
+    {{ dbt.get_create_table_as_sql(temporary, relation, sql_query) }}
+
+    {% set tmp_vw_relation = relation.incorporate(
+        path={"identifier": relation.identifier ~ '__dbt_tmp_vw'},
+        type='view',
+    ) %}
+    EXEC('DROP VIEW IF EXISTS {{ tmp_vw_relation.include(database=false) }}');
+{% endmacro %}
+
 {% macro fabricspark__edr_get_create_table_as_sql(temporary, relation, sql_query) %}
     {{
         return(


### PR DESCRIPTION
dbt-fabric's fabric__create_table_as implements CTAS via a helper view `<table>__dbt_tmp_vw`: it creates the view, then issues `CREATE TABLE <table> AS SELECT * FROM <table>__dbt_tmp_vw`. The macro does NOT drop the helper view at the end — it relies on the caller (dbt-fabric's own incremental / table materializations) to drop it via `adapter.drop_relation` after the CTAS.

Elementary's edr_create_table_as does not perform that post-drop, so the helper view leaks in the elementary schema every time edr_create_table_as is invoked on Fabric. Affects every artifact table built this way: dbt_columns, dbt_exposures, dbt_seeds, dbt_sources, dbt_tests, plus their __tmp_<ts> intermediates from delete_and_insert. The leaked views accumulate one entry per run and per artifact, eventually polluting the schema.

Add a fabric__edr_get_create_table_as_sql dispatch implementation that calls dbt.get_create_table_as_sql and appends
`EXEC('DROP VIEW IF EXISTS ...')` to the emitted SQL, so the helper view is dropped in the same batch that consumed it. Uses IF EXISTS, so it is safe even if a future dbt-fabric release decides to clean up the helper view itself.

Upstream macro reference:
dbt-fabric/dbt/include/fabric/macros/materializations/models/table/create_table_as.sql

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved CREATE TABLE AS operations in Fabric with automatic cleanup of temporary objects. The cleanup process is now idempotent, ensuring operations can be safely retried without errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elementary-data/dbt-data-reliability/pull/1011?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->