### PR TITLE
Defer get_columns_in_relation when no exposures match in exposure_schema_validity

### DIFF
--- a/macros/edr/tests/test_exposure_schema_validity.sql
+++ b/macros/edr/tests/test_exposure_schema_validity.sql
@@ -10,7 +10,6 @@
     {# Parameters used only for dependency injection in integration tests #}
     {%- set node = node or base_node -%}
     {%- set exposures = (exposures or graph.exposures).values() -%}
-    {%- set columns = columns or adapter.get_columns_in_relation(model) -%}
 
     {%- set model_relation = elementary.get_model_relation_for_test(
         model, elementary.get_test_model()
@@ -28,6 +27,7 @@
 
     {%- set invalid_exposures = [] -%}
     {%- if matching_exposures | length > 0 -%}
+        {%- set columns = columns or adapter.get_columns_in_relation(model) -%}
         {%- set columns_dict = {} -%}
         {%- for column in columns -%}
             {%- do columns_dict.update(


### PR DESCRIPTION
## Summary
- Move `adapter.get_columns_in_relation(model)` inside the `matching_exposures | length > 0` branch in `exposure_schema_validity`
- When no exposures depend on the tested model/source, the test already returns `no_results_query()` and never needs column metadata

## Context
Fusion BigQuery CI fails `test_exposure_schema_validity_no_exposures` because dbt-fusion commit [81458a3f](https://github.com/dbt-labs/dbt-fusion/commit/81458a3f) switched BigQuery `get_columns_in_relation` to ADBC `get_table_schema()` without preserving dbt-core's missing-table → empty-list behavior. The integration test creates a source YAML but does not seed a physical table.

This change avoids the unnecessary warehouse call on the no-exposures path while preserving existing validation behavior when exposures do match.

## Test plan
- [ ] Fusion BigQuery CI: `test_exposure_schema_validity_no_exposures` passes
- [ ] Existing `test_exposure_schema_validity_*` cases still pass on other warehouses
- [ ] Models with real exposures in `exposures.yml` (`customers`, `orders`) still validate columns when exposures match


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized test execution by deferring unnecessary column metadata retrieval when no matching exposures are found, improving overall test performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elementary-data/dbt-data-reliability/pull/1014?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->