### PR TITLE
CORE-877: Fix microbatch integration test for Fabric

### DIFF
--- a/integration_tests/tests/test_dbt_artifacts/test_microbatch_compiled_code.py
+++ b/integration_tests/tests/test_dbt_artifacts/test_microbatch_compiled_code.py
@@ -4,22 +4,21 @@ import pytest
 from dbt_project import DbtProject
 
 
-def _microbatch_source_model_sql(dbt_project: DbtProject) -> str:
-    event_time_data_type = "datetime2" if dbt_project.is_tsql else "timestamp"
-    return f"""
-{{{{ config(event_time='order_date') }}}}
+def _microbatch_source_model_sql() -> str:
+    return """
+{{ config(event_time='order_date') }}
 
 select
     1 as order_id,
     1 as customer_id,
     42 as amount,
-    cast('2024-01-01 00:00:00' as {event_time_data_type}) as order_date
+    cast('2024-01-01 00:00:00' as {{ elementary.edr_type_timestamp() }}) as order_date
 union all
 select
     2 as order_id,
     2 as customer_id,
     84 as amount,
-    cast('2025-01-01 00:00:00' as {event_time_data_type}) as order_date
+    cast('2025-01-01 00:00:00' as {{ elementary.edr_type_timestamp() }}) as order_date
 """
 
 
@@ -59,7 +58,7 @@ def _with_microbatch_test_models(dbt_project: DbtProject, model_suffix: str):
         f"{target_model_name}.sql"
     )
 
-    source_model_path.write_text(_microbatch_source_model_sql(dbt_project))
+    source_model_path.write_text(_microbatch_source_model_sql())
     target_model_path.write_text(_microbatch_model_sql(source_model_name))
     relative_source_model_path = source_model_path.relative_to(
         dbt_project.project_dir_path

--- a/integration_tests/tests/test_dbt_artifacts/test_microbatch_compiled_code.py
+++ b/integration_tests/tests/test_dbt_artifacts/test_microbatch_compiled_code.py
@@ -4,22 +4,22 @@ import pytest
 from dbt_project import DbtProject
 
 
-def _microbatch_source_model_sql() -> str:
-    return """
-{{ config(event_time='order_date') }}
-{% set event_time_data_type = 'datetime2' if target.type == 'sqlserver' else 'timestamp' %}
+def _microbatch_source_model_sql(dbt_project: DbtProject) -> str:
+    event_time_data_type = "datetime2" if dbt_project.is_tsql else "timestamp"
+    return f"""
+{{{{ config(event_time='order_date') }}}}
 
 select
     1 as order_id,
     1 as customer_id,
     42 as amount,
-    cast('2024-01-01 00:00:00' as {{ event_time_data_type }}) as order_date
+    cast('2024-01-01 00:00:00' as {event_time_data_type}) as order_date
 union all
 select
     2 as order_id,
     2 as customer_id,
     84 as amount,
-    cast('2025-01-01 00:00:00' as {{ event_time_data_type }}) as order_date
+    cast('2025-01-01 00:00:00' as {event_time_data_type}) as order_date
 """
 
 
@@ -59,7 +59,7 @@ def _with_microbatch_test_models(dbt_project: DbtProject, model_suffix: str):
         f"{target_model_name}.sql"
     )
 
-    source_model_path.write_text(_microbatch_source_model_sql())
+    source_model_path.write_text(_microbatch_source_model_sql(dbt_project))
     target_model_path.write_text(_microbatch_model_sql(source_model_name))
     relative_source_model_path = source_model_path.relative_to(
         dbt_project.project_dir_path


### PR DESCRIPTION
## Summary
- Use `DbtProject.is_tsql` when generating microbatch source model SQL in integration tests
- Ensures Fabric uses `datetime2` for `event_time` casts (same as SQL Server) instead of invalid `timestamp`

## Test plan
- [ ] Verify microbatch compiled code integration test passes on Fabric
- [ ] Confirm existing SQL Server microbatch test behavior is unchanged


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated microbatch SQL test to standardize timestamp casting in generated queries, ensuring consistent validation of event-time handling across platforms without changing test setup or configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elementary-data/dbt-data-reliability/pull/1015?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->