### PR TITLE
feat: add `elementary_extra_indexes` config var for custom index injection

### DIFF
--- a/macros/edr/system/system_utils/get_config_var.sql
+++ b/macros/edr/system/system_utils/get_config_var.sql
@@ -164,6 +164,7 @@
         "bigquery_disable_partitioning": false,
         "bigquery_disable_clustering": false,
         "upload_only_current_project_artifacts": false,
+        "elementary_extra_indexes": {},
     } %}
     {{- return(default_config) -}}
 {%- endmacro -%}

--- a/macros/edr/system/system_utils/get_indexes_for_model.sql
+++ b/macros/edr/system/system_utils/get_indexes_for_model.sql
@@ -1,4 +1,5 @@
 {% macro get_indexes_for_model(model_name, base_indexes) %}
+    {# dbt's indexes config is Postgres-only. Returns [] for all other targets. #}
     {%- if target.type != "postgres" -%} {{ return([]) }} {%- endif -%}
 
     {% set extra_indexes_config = elementary.get_config_var(
@@ -6,6 +7,7 @@
     ) %}
     {% set extra_indexes = extra_indexes_config.get(model_name, []) %}
 
+    {# Dedup by sorted column set only. Base indexes take precedence on conflicts. #}
     {% set seen_column_sets = [] %}
     {% set merged_indexes = [] %}
 
@@ -18,6 +20,16 @@
     {% endfor %}
 
     {% for idx in extra_indexes %}
+        {% if idx.columns is not defined %}
+            {{
+                exceptions.raise_compiler_error(
+                    "elementary_extra_indexes entry for '"
+                    ~ model_name
+                    ~ "' is missing 'columns': "
+                    ~ idx
+                )
+            }}
+        {% endif %}
         {% set sorted_cols = idx.columns | sort | join(",") %}
         {% if sorted_cols not in seen_column_sets %}
             {% do seen_column_sets.append(sorted_cols) %}

--- a/macros/edr/system/system_utils/get_indexes_for_model.sql
+++ b/macros/edr/system/system_utils/get_indexes_for_model.sql
@@ -1,7 +1,9 @@
 {% macro get_indexes_for_model(model_name, base_indexes) %}
     {%- if target.type != "postgres" -%} {{ return([]) }} {%- endif -%}
 
-    {% set extra_indexes_config = var("elementary_extra_indexes", {}) %}
+    {% set extra_indexes_config = elementary.get_config_var(
+        "elementary_extra_indexes"
+    ) %}
     {% set extra_indexes = extra_indexes_config.get(model_name, []) %}
 
     {% set seen_column_sets = [] %}

--- a/macros/edr/system/system_utils/get_indexes_for_model.sql
+++ b/macros/edr/system/system_utils/get_indexes_for_model.sql
@@ -1,0 +1,27 @@
+{% macro get_indexes_for_model(model_name, base_indexes) %}
+    {%- if target.type != "postgres" -%} {{ return([]) }} {%- endif -%}
+
+    {% set extra_indexes_config = var("elementary_extra_indexes", {}) %}
+    {% set extra_indexes = extra_indexes_config.get(model_name, []) %}
+
+    {% set seen_column_sets = [] %}
+    {% set merged_indexes = [] %}
+
+    {% for idx in base_indexes %}
+        {% set sorted_cols = idx.columns | sort | join(",") %}
+        {% if sorted_cols not in seen_column_sets %}
+            {% do seen_column_sets.append(sorted_cols) %}
+            {% do merged_indexes.append(idx) %}
+        {% endif %}
+    {% endfor %}
+
+    {% for idx in extra_indexes %}
+        {% set sorted_cols = idx.columns | sort | join(",") %}
+        {% if sorted_cols not in seen_column_sets %}
+            {% do seen_column_sets.append(sorted_cols) %}
+            {% do merged_indexes.append(idx) %}
+        {% endif %}
+    {% endfor %}
+
+    {{ return(merged_indexes) }}
+{% endmacro %}

--- a/models/edr/data_monitoring/data_monitoring/data_monitoring_metrics.sql
+++ b/models/edr/data_monitoring/data_monitoring/data_monitoring_metrics.sql
@@ -3,10 +3,11 @@
         materialized="incremental",
         unique_key="id",
         on_schema_change="append_new_columns",
-        indexes=(
-            [{"columns": ["full_table_name", "column_name", "metric_name"]}]
-            if target.type == "postgres"
-            else []
+        indexes=elementary.get_indexes_for_model(
+            "data_monitoring_metrics",
+            [
+                {"columns": ["full_table_name", "column_name", "metric_name"]},
+            ],
         ),
         full_refresh=elementary.get_config_var("elementary_full_refresh"),
         meta={

--- a/models/edr/dbt_artifacts/dbt_run_results.sql
+++ b/models/edr/dbt_artifacts/dbt_run_results.sql
@@ -4,14 +4,13 @@
         transient=False,
         unique_key="model_execution_id",
         on_schema_change="append_new_columns",
-        indexes=(
+        indexes=elementary.get_indexes_for_model(
+            "dbt_run_results",
             [
                 {"columns": ["unique_id"]},
                 {"columns": ["unique_id", "created_at"]},
                 {"columns": ["model_execution_id"]},
-            ]
-            if target.type == "postgres"
-            else []
+            ],
         ),
         partition_by=elementary.get_partition_by(),
         full_refresh=elementary.get_config_var("elementary_full_refresh"),

--- a/models/edr/run_results/dbt_source_freshness_results.sql
+++ b/models/edr/run_results/dbt_source_freshness_results.sql
@@ -10,13 +10,12 @@
         },
         table_type=elementary.get_default_table_type(),
         incremental_strategy=elementary.get_default_incremental_strategy(),
-        indexes=(
+        indexes=elementary.get_indexes_for_model(
+            "dbt_source_freshness_results",
             [
                 {"columns": ["unique_id", "created_at"]},
                 {"columns": ["source_freshness_execution_id"]},
-            ]
-            if target.type == "postgres"
-            else []
+            ],
         ),
     )
 }}

--- a/models/edr/run_results/elementary_test_results.sql
+++ b/models/edr/run_results/elementary_test_results.sql
@@ -10,10 +10,12 @@
         },
         table_type=elementary.get_default_table_type(),
         incremental_strategy=elementary.get_default_incremental_strategy(),
-        indexes=(
-            [{"columns": ["id"]}, {"columns": ["test_unique_id", "detected_at"]}]
-            if target.type == "postgres"
-            else []
+        indexes=elementary.get_indexes_for_model(
+            "elementary_test_results",
+            [
+                {"columns": ["id"]},
+                {"columns": ["test_unique_id", "detected_at"]},
+            ],
         ),
     )
 }}

--- a/models/edr/run_results/test_result_rows.sql
+++ b/models/edr/run_results/test_result_rows.sql
@@ -1,4 +1,3 @@
--- indexes are not supported in all warehouses, relevant to postgres only
 {{
     config(
         materialized="incremental",

--- a/models/edr/run_results/test_result_rows.sql
+++ b/models/edr/run_results/test_result_rows.sql
@@ -3,14 +3,13 @@
     config(
         materialized="incremental",
         on_schema_change="append_new_columns",
-        indexes=(
+        indexes=elementary.get_indexes_for_model(
+            "test_result_rows",
             [
                 {"columns": ["created_at"]},
                 {"columns": ["elementary_test_results_id"]},
                 {"columns": ["detected_at"]},
-            ]
-            if target.type == "postgres"
-            else []
+            ],
         ),
         full_refresh=elementary.get_config_var("elementary_full_refresh"),
         meta={


### PR DESCRIPTION
## Summary

Adds a new `elementary_extra_indexes` dbt var (default `{}`) that lets downstream consumers inject additional PostgreSQL indexes into Elementary models without modifying this package.

**New macro**: `elementary.get_indexes_for_model(model_name, base_indexes)` — merges the model's built-in indexes with any extras from `elementary_extra_indexes`, deduplicating by sorted column set. Returns `[]` on non-postgres targets.

**Usage** — pass a dict mapping model names to index configs via `--vars`:

```yaml
elementary_extra_indexes:
  dbt_run_results:
    - columns: [\"created_at\"]
  elementary_test_results:
    - columns: [\"created_at\"]
```

All 5 models with postgres indexes now use `get_indexes_for_model`: `dbt_run_results`, `elementary_test_results`, `data_monitoring_metrics`, `dbt_source_freshness_results`, `test_result_rows`.

**Motivation**: Elementary Cloud needs cloud-specific indexes (e.g. `(created_at)` for time-range queries) that don't belong in the OSS defaults. This avoids polluting the base package while keeping index definitions co-located with models."

Link to Devin session: https://app.devin.ai/sessions/278ceddbe6d24dbea36a83ecc232f3b6
Requested by: @haritamar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centralized index helper and a new default config key for extra indexes.
* **Refactor**
  * Updated multiple models to use the centralized index helper for index definitions.
  * Centralized index merging and deduplication, keeping Postgres-specific handling intact.
* **Chores**
  * Reduced inline DB-specific conditionals in model configurations for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->