### PR TITLE
fix: add explicit return(none) in get_elementary_relation when relation not found

### DIFF
--- a/macros/utils/graph/get_elementary_relation.sql
+++ b/macros/utils/graph/get_elementary_relation.sql
@@ -47,5 +47,6 @@
                 )
             ) %}
         {% endif %}
+        {% do return(none) %}
     {%- endif %}
 {% endmacro %}


### PR DESCRIPTION
## Summary

The v0.24.0 refactoring in PR #1006 (deferral fallback) broke `get_elementary_relation` for environments where elementary tables don't exist and deferral is not active.

**Before (v0.23.1):** `adapter.get_relation()` result was always explicitly returned:
```sql
{% do return(adapter.get_relation(...)) %}  -- None when table missing
```

**After (v0.24.0):** when `adapter.get_relation()` returns `None` and deferral is off, the macro falls through without calling `return()`. In dbt's Jinja2, this returns the rendered template text (whitespace) instead of `None`. A non-empty whitespace string is truthy, so callers checking `{% if relation %}` proceed as if the table exists — producing `from <whitespace>` in SQL, which causes downstream syntax errors like:

```
Syntax error: Unexpected keyword UNION at [26:17]
```

Example from Current's environment (does no have a `dbt_models` table):

<img width="1502" height="373" alt="image" src="https://github.com/user-attachments/assets/b474e3dd-9ae6-4d3e-abbe-68b5ee404fec" />


**Fix:** add `{% do return(none) %}` at the end of the macro to restore the v0.23.1 contract.


Related: CORE-930

Link to Devin session: https://app.devin.ai/sessions/1fddd97133934bbd9ab85b4137700ec8
Requested by: @elazarlachkar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in relation handling to ensure predictable behavior when no matching relation is found. This addresses edge cases that could result in unexpected outcomes in certain scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->