### PR TITLE
use EXECUTE IMMEDIATE in snowflake clean test tables macro to avoid d…

### DIFF
--- a/macros/edr/tests/test_utils/clean_elementary_test_tables.sql
+++ b/macros/edr/tests/test_utils/clean_elementary_test_tables.sql
@@ -41,6 +41,23 @@
     ) %}
 {% endmacro %}
 
+{% macro snowflake__get_clean_elementary_test_tables_queries(test_table_relations) %}
+    {% set drop_queries = elementary.get_transactionless_clean_elementary_test_tables_queries(test_table_relations) %}
+    {% if not drop_queries %}
+        {% do return([]) %}
+    {% endif %}
+    {% set query %}
+        EXECUTE IMMEDIATE $$
+        BEGIN
+            {% for drop in drop_queries %}
+                {{ drop }};
+            {% endfor %}
+        END;
+        $$
+    {% endset %}
+    {% do return([query]) %}
+{% endmacro %}
+
 {% macro bigquery__get_clean_elementary_test_tables_queries(test_table_relations) %}
     {% do return(
         elementary.get_transactionless_clean_elementary_test_tables_queries(

--- a/macros/edr/tests/test_utils/clean_elementary_test_tables.sql
+++ b/macros/edr/tests/test_utils/clean_elementary_test_tables.sql
@@ -42,10 +42,12 @@
 {% endmacro %}
 
 {% macro snowflake__get_clean_elementary_test_tables_queries(test_table_relations) %}
-    {% set drop_queries = elementary.get_transactionless_clean_elementary_test_tables_queries(test_table_relations) %}
-    {% if not drop_queries %}
-        {% do return([]) %}
-    {% endif %}
+    {% set drop_queries = (
+        elementary.get_transactionless_clean_elementary_test_tables_queries(
+            test_table_relations
+        )
+    ) %}
+    {% if not drop_queries %} {% do return([]) %} {% endif %}
     {% set query %}
         EXECUTE IMMEDIATE $$
         BEGIN


### PR DESCRIPTION
## Problem

On Snowflake, the \`clean_elementary_test_tables\` on-run-end hook was executing each \`DROP TABLE\` as a separate round-trip to the warehouse. With many \`elementary_source_schema_changes\` tests, this adds up significantly (e.g. 74 tables × ~200ms = ~15–20s of pure overhead per run).

The root cause is in dbt-snowflake's \`SnowflakeConnectionManager.execute()\`, which calls [\`_split_queries\`](https://github.com/dbt-labs/dbt-snowflake/blob/v1.8.4/dbt/adapters/snowflake/connections.py#L476) to split any SQL string at semicolons before execution — so even though \`get_transaction_clean_elementary_test_tables_queries\` returns a single \`BEGIN TRANSACTION; ...; COMMIT;\` string, it gets split into N+2 individual \`cursor.execute()\` calls.

## Fix

Add a \`snowflake__get_clean_elementary_test_tables_queries\` override that wraps all drops in an \`EXECUTE IMMEDIATE \$\$ BEGIN...END \$\$\` Snowflake Scripting block. From the connector's perspective this is a single SQL statement, so \`_split_queries\` does not split it — all drops execute server-side in one round-trip.

The \`\$\$\`-quoting is respected by \`snowflake-connector-python\`'s [\`split_statements\`](https://github.com/snowflakedb/snowflake-connector-python/blob/main/src/snowflake/connector/util_text.py#L57) parser, which tracks \`in_double_dollars\` state and skips semicolon detection inside \`\$\$...\$\$\` blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new entry-point to clean only the current run's temporary test tables.
  * Added a stale-test-table cleanup command that detects and removes old temporary tables across adapters.

* **Improvements**
  * Per-adapter logic to identify stale test tables (age-aware where supported).
  * Snowflake optimization: batches transactionless DROPs into a single execution block for efficient teardown.

* **Tests**
  * Integration test verifying stale-table detection and full cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->