### PR TITLE
added a macro that cleans stale test temp tables. Will be usefull for…

### DIFF
--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -276,9 +276,7 @@ jobs:
           PYTEST_PARALLEL: ${{ (inputs.warehouse-type == 'spark' && '4') || '8' }}
           FUSION_RUNNER_FLAG: ${{ (inputs.dbt-version == 'fusion' && '--runner-method fusion') || '' }}
         run: |
-          # TODO: remove -k filter before merging — temporarily scoped to speed up iteration on test_cleanup_stale_test_tables
           py.test -n"$PYTEST_PARALLEL" -vvv --target "$WAREHOUSE" \
-            -k "test_cleanup_stale_test_tables" \
             --junit-xml=test-results.xml \
             --html="detailed_report_${WAREHOUSE}_dbt_${DBT_VERSION}.html" \
             --self-contained-html --clear-on-end $FUSION_RUNNER_FLAG

--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -276,9 +276,7 @@ jobs:
           PYTEST_PARALLEL: ${{ (inputs.warehouse-type == 'spark' && '4') || '8' }}
           FUSION_RUNNER_FLAG: ${{ (inputs.dbt-version == 'fusion' && '--runner-method fusion') || '' }}
         run: |
-          # TODO: remove -k filter before merging
           py.test -n"$PYTEST_PARALLEL" -vvv --target "$WAREHOUSE" \
-            -k "test_cleanup_stale_test_tables" \
             --junit-xml=test-results.xml \
             --html="detailed_report_${WAREHOUSE}_dbt_${DBT_VERSION}.html" \
             --self-contained-html --clear-on-end $FUSION_RUNNER_FLAG

--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -276,7 +276,9 @@ jobs:
           PYTEST_PARALLEL: ${{ (inputs.warehouse-type == 'spark' && '4') || '8' }}
           FUSION_RUNNER_FLAG: ${{ (inputs.dbt-version == 'fusion' && '--runner-method fusion') || '' }}
         run: |
+          # TODO: remove -k filter before merging
           py.test -n"$PYTEST_PARALLEL" -vvv --target "$WAREHOUSE" \
+            -k "test_cleanup_stale_test_tables" \
             --junit-xml=test-results.xml \
             --html="detailed_report_${WAREHOUSE}_dbt_${DBT_VERSION}.html" \
             --self-contained-html --clear-on-end $FUSION_RUNNER_FLAG

--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -276,7 +276,9 @@ jobs:
           PYTEST_PARALLEL: ${{ (inputs.warehouse-type == 'spark' && '4') || '8' }}
           FUSION_RUNNER_FLAG: ${{ (inputs.dbt-version == 'fusion' && '--runner-method fusion') || '' }}
         run: |
+          # TODO: remove -k filter before merging — temporarily scoped to speed up iteration on test_cleanup_stale_test_tables
           py.test -n"$PYTEST_PARALLEL" -vvv --target "$WAREHOUSE" \
+            -k "test_cleanup_stale_test_tables" \
             --junit-xml=test-results.xml \
             --html="detailed_report_${WAREHOUSE}_dbt_${DBT_VERSION}.html" \
             --self-contained-html --clear-on-end $FUSION_RUNNER_FLAG

--- a/integration_tests/dbt_project/macros/test_cleanup_stale_test_tables.sql
+++ b/integration_tests/dbt_project/macros/test_cleanup_stale_test_tables.sql
@@ -1,0 +1,45 @@
+{% macro test_cleanup_stale_test_tables() %}
+    {% set elementary_database, elementary_schema = (
+        elementary.get_package_database_and_schema()
+    ) %}
+
+    {# Create fake temp tables matching the elementary temp table naming pattern #}
+    {% set fake_tables = [
+        "test_aaa000_elementary_source_schema_changes_cleanup_test_source___schema_changes__tmp_20200101120000000000001",
+        "test_aaa000_elementary_source_schema_changes_cleanup_test_source___schema_changes_alerts__tmp_20200101120000000000002",
+    ] %}
+    {% for table_name in fake_tables %}
+        {% set _, relation = dbt.get_or_create_relation(
+            database=elementary_database,
+            schema=elementary_schema,
+            identifier=table_name,
+            type="table",
+        ) %}
+        {% do elementary.create_or_replace(false, relation, "select 1 as id") %}
+    {% endfor %}
+
+    {# Assert tables exist before cleanup #}
+    {% set table_name_pattern = "test%__tmp_%" %}
+    {% set tables_before = elementary.get_stale_test_tables(
+        elementary_database, elementary_schema, 0, table_name_pattern
+    ) %}
+
+    {# Run cleanup #}
+    {% do elementary.cleanup_stale_test_tables(hours=0) %}
+
+    {# Assert tables are gone after cleanup #}
+    {% set tables_after = elementary.get_stale_test_tables(
+        elementary_database, elementary_schema, 0, table_name_pattern
+    ) %}
+
+    {{
+        return(
+            tojson(
+                {
+                    "tables_before_count": tables_before | length,
+                    "tables_after_count": tables_after | length,
+                }
+            )
+        )
+    }}
+{% endmacro %}

--- a/integration_tests/dbt_project/macros/test_cleanup_stale_test_tables.sql
+++ b/integration_tests/dbt_project/macros/test_cleanup_stale_test_tables.sql
@@ -3,10 +3,11 @@
         elementary.get_package_database_and_schema()
     ) %}
 
-    {# Create fake temp tables matching the elementary temp table naming pattern #}
+    {# Create 3 fake temp tables. Names kept short (≤60 chars) for Fabric/SQL Server. #}
     {% set fake_tables = [
         "test_cleanup__tmp_0000001",
         "test_cleanup_alerts__tmp_0000002",
+        "test_cleanup_extra__tmp_0000003",
     ] %}
     {% for table_name in fake_tables %}
         {% set relation = api.Relation.create(
@@ -18,18 +19,19 @@
         {% do elementary.create_or_replace(false, relation, "select 1 as id") %}
     {% endfor %}
 
-    {# Assert tables exist before cleanup #}
     {% set table_name_pattern = "test%__tmp_%" %}
+
+    {# Verify all 3 exist before cleanup #}
     {% set tables_before = elementary.get_stale_test_tables(
-        elementary_database, elementary_schema, 0, table_name_pattern
+        elementary_database, elementary_schema, 0, table_name_pattern, 2000
     ) %}
 
-    {# Run cleanup #}
-    {% do elementary.cleanup_stale_test_tables(hours=0) %}
+    {# Delete only 2 out of 3 via limit=2 #}
+    {% do elementary.cleanup_stale_test_tables(hours=0, limit=2) %}
 
-    {# Assert tables are gone after cleanup #}
+    {# Verify exactly 1 remains #}
     {% set tables_after = elementary.get_stale_test_tables(
-        elementary_database, elementary_schema, 0, table_name_pattern
+        elementary_database, elementary_schema, 0, table_name_pattern, 2000
     ) %}
 
     {% do return(

--- a/integration_tests/dbt_project/macros/test_cleanup_stale_test_tables.sql
+++ b/integration_tests/dbt_project/macros/test_cleanup_stale_test_tables.sql
@@ -32,14 +32,10 @@
         elementary_database, elementary_schema, 0, table_name_pattern
     ) %}
 
-    {{
-        return(
-            tojson(
-                {
-                    "tables_before_count": tables_before | length,
-                    "tables_after_count": tables_after | length,
-                }
-            )
-        )
-    }}
+    {% do return(
+        {
+            "tables_before_count": tables_before | length,
+            "tables_after_count": tables_after | length,
+        }
+    ) %}
 {% endmacro %}

--- a/integration_tests/dbt_project/macros/test_cleanup_stale_test_tables.sql
+++ b/integration_tests/dbt_project/macros/test_cleanup_stale_test_tables.sql
@@ -9,7 +9,7 @@
         "test_cleanup_alerts__tmp_0000002",
     ] %}
     {% for table_name in fake_tables %}
-        {% set _, relation = dbt.get_or_create_relation(
+        {% set relation = api.Relation.create(
             database=elementary_database,
             schema=elementary_schema,
             identifier=table_name,

--- a/integration_tests/dbt_project/macros/test_cleanup_stale_test_tables.sql
+++ b/integration_tests/dbt_project/macros/test_cleanup_stale_test_tables.sql
@@ -3,7 +3,6 @@
         elementary.get_package_database_and_schema()
     ) %}
 
-    {# Create 3 fake temp tables. Names kept short (≤60 chars) for Fabric/SQL Server. #}
     {% set fake_tables = [
         "test_cleanup__tmp_0000001",
         "test_cleanup_alerts__tmp_0000002",

--- a/integration_tests/dbt_project/macros/test_cleanup_stale_test_tables.sql
+++ b/integration_tests/dbt_project/macros/test_cleanup_stale_test_tables.sql
@@ -5,8 +5,8 @@
 
     {# Create fake temp tables matching the elementary temp table naming pattern #}
     {% set fake_tables = [
-        "test_aaa000_elementary_source_schema_changes_cleanup_test_source___schema_changes__tmp_20200101120000000000001",
-        "test_aaa000_elementary_source_schema_changes_cleanup_test_source___schema_changes_alerts__tmp_20200101120000000000002",
+        "test_cleanup__tmp_0000001",
+        "test_cleanup_alerts__tmp_0000002",
     ] %}
     {% for table_name in fake_tables %}
         {% set _, relation = dbt.get_or_create_relation(

--- a/integration_tests/tests/test_cleanup_stale_test_tables.py
+++ b/integration_tests/tests/test_cleanup_stale_test_tables.py
@@ -1,0 +1,20 @@
+"""Integration test for elementary.cleanup_stale_test_tables macro."""
+
+import json
+
+from dbt_project import DbtProject
+
+
+def test_cleanup_stale_test_tables(dbt_project: DbtProject):
+    result = dbt_project.dbt_runner.run_operation(
+        "elementary_tests.test_cleanup_stale_test_tables",
+    )
+    assert result, "run_operation returned no output"
+    data = json.loads(result[0])
+
+    assert (
+        data["tables_before_count"] >= 2
+    ), f"Expected at least 2 temp tables before cleanup, got {data['tables_before_count']}"
+    assert (
+        data["tables_after_count"] == 0
+    ), f"Expected 0 temp tables after cleanup, got {data['tables_after_count']}"

--- a/integration_tests/tests/test_cleanup_stale_test_tables.py
+++ b/integration_tests/tests/test_cleanup_stale_test_tables.py
@@ -7,7 +7,9 @@ from dbt_project import DbtProject
 
 
 # Spark: no information_schema in Hive metastore, no LIKE-pattern catalog API.
-@pytest.mark.skip_targets(["spark"])
+# Dremio: INFORMATION_SCHEMA.table_schema stores the full dot-separated space path
+# (e.g. "space.folder.schema"), so matching on schema name alone returns no rows.
+@pytest.mark.skip_targets(["spark", "dremio"])
 def test_cleanup_stale_test_tables(dbt_project: DbtProject):
     result = dbt_project.dbt_runner.run_operation(
         "elementary_tests.test_cleanup_stale_test_tables",

--- a/integration_tests/tests/test_cleanup_stale_test_tables.py
+++ b/integration_tests/tests/test_cleanup_stale_test_tables.py
@@ -6,6 +6,7 @@ import pytest
 from dbt_project import DbtProject
 
 
+# Spark: no information_schema in Hive metastore, no LIKE-pattern catalog API.
 @pytest.mark.skip_targets(["spark"])
 def test_cleanup_stale_test_tables(dbt_project: DbtProject):
     result = dbt_project.dbt_runner.run_operation(

--- a/integration_tests/tests/test_cleanup_stale_test_tables.py
+++ b/integration_tests/tests/test_cleanup_stale_test_tables.py
@@ -16,8 +16,8 @@ def test_cleanup_stale_test_tables(dbt_project: DbtProject):
     data = json.loads(result[0])
 
     assert (
-        data["tables_before_count"] >= 2
-    ), f"Expected at least 2 temp tables before cleanup, got {data['tables_before_count']}"
+        data["tables_before_count"] >= 3
+    ), f"Expected at least 3 temp tables before cleanup, got {data['tables_before_count']}"
     assert (
-        data["tables_after_count"] == 0
-    ), f"Expected 0 temp tables after cleanup, got {data['tables_after_count']}"
+        data["tables_after_count"] == 1
+    ), f"Expected 1 temp table after cleanup (limit=2), got {data['tables_after_count']}"

--- a/integration_tests/tests/test_cleanup_stale_test_tables.py
+++ b/integration_tests/tests/test_cleanup_stale_test_tables.py
@@ -2,9 +2,11 @@
 
 import json
 
+import pytest
 from dbt_project import DbtProject
 
 
+@pytest.mark.skip_targets(["spark"])
 def test_cleanup_stale_test_tables(dbt_project: DbtProject):
     result = dbt_project.dbt_runner.run_operation(
         "elementary_tests.test_cleanup_stale_test_tables",

--- a/integration_tests/tests/test_cleanup_stale_test_tables.py
+++ b/integration_tests/tests/test_cleanup_stale_test_tables.py
@@ -6,10 +6,12 @@ import pytest
 from dbt_project import DbtProject
 
 
-# Spark: no information_schema in Hive metastore, no LIKE-pattern catalog API.
-# Dremio: INFORMATION_SCHEMA.table_schema stores the full dot-separated space path
-# (e.g. "space.folder.schema"), so matching on schema name alone returns no rows.
-@pytest.mark.skip_targets(["spark", "dremio"])
+# Skipped targets do not expose table creation time in SQL, so get_stale_test_tables
+# is not implemented for them. Without time filtering the macro could delete tables
+# that are actively in use by a concurrent dbt run.
+@pytest.mark.skip_targets(
+    ["spark", "dremio", "postgres", "redshift", "athena", "trino", "duckdb"]
+)
 def test_cleanup_stale_test_tables(dbt_project: DbtProject):
     result = dbt_project.dbt_runner.run_operation(
         "elementary_tests.test_cleanup_stale_test_tables",

--- a/macros/edr/system/system_utils/clean_elementary_temp_tables.sql
+++ b/macros/edr/system/system_utils/clean_elementary_temp_tables.sql
@@ -1,3 +1,3 @@
 {% macro clean_elementary_temp_tables() %}
-    {% do elementary.clean_elementary_test_tables() %}
+    {% do elementary.clean_current_invocation_test_tables() %}
 {% endmacro %}

--- a/macros/edr/tests/test_utils/clean_elementary_test_tables.sql
+++ b/macros/edr/tests/test_utils/clean_elementary_test_tables.sql
@@ -31,13 +31,17 @@
 {% endmacro %}
 
 
-{% macro cleanup_stale_test_tables(hours=24) %}
+{% macro cleanup_stale_test_tables(hours=24, limit=2000) %}
     {% set elementary_database, elementary_schema = (
         elementary.get_package_database_and_schema()
     ) %}
     {% set table_name_pattern = "test%__tmp_%" %}
     {% set tables = elementary.get_stale_test_tables(
-        elementary_database, elementary_schema, hours, table_name_pattern
+        elementary_database,
+        elementary_schema,
+        hours,
+        table_name_pattern,
+        limit,
     ) %}
     {% if tables | length == 0 %}
         {% do elementary.edr_log(

--- a/macros/edr/tests/test_utils/clean_elementary_test_tables.sql
+++ b/macros/edr/tests/test_utils/clean_elementary_test_tables.sql
@@ -1,4 +1,4 @@
-{% macro clean_elementary_test_tables() %}
+{% macro clean_current_invocation_test_tables() %}
     {% set test_table_relations = [] %}
     {% set temp_test_table_relations_map = elementary.get_cache(
         "temp_test_table_relations_map"
@@ -9,10 +9,15 @@
                 {% do test_table_relations.append(test_relation) %}
             {% endfor %}
         {% endfor %}
+    {% endif %}
+    {% do elementary.clean_elementary_test_tables(test_table_relations) %}
+{% endmacro %}
 
+
+{% macro clean_elementary_test_tables(test_table_relations) %}
+    {% if test_table_relations %}
         {# Extra entry-point to clean up tables before dropping the relation #}
         {% do elementary.clean_up_tables(test_table_relations) %}
-
         {% do elementary.file_log(
             "Deleting temporary Elementary test tables: {}".format(
                 test_table_relations
@@ -24,6 +29,32 @@
         {% for query in queries %} {% do elementary.run_query(query) %} {% endfor %}
     {% endif %}
 {% endmacro %}
+
+
+{% macro cleanup_stale_test_tables(hours=24) %}
+    {% set elementary_database, elementary_schema = (
+        elementary.get_package_database_and_schema()
+    ) %}
+    {% set table_name_pattern = "test%__tmp_%" %}
+    {% set tables = elementary.get_stale_test_tables(
+        elementary_database, elementary_schema, hours, table_name_pattern
+    ) %}
+    {% if tables | length == 0 %}
+        {% do elementary.edr_log(
+            "No temp tables older than "
+            ~ hours
+            ~ " hours found - nothing to clean up."
+        ) %}
+    {% else %}
+        {% do elementary.edr_log(
+            "Dropping " ~ tables
+            | length ~ " temp tables older than " ~ hours ~ " hours."
+        ) %}
+        {% do elementary.clean_elementary_test_tables(tables) %}
+        {% do elementary.edr_log("Done.") %}
+    {% endif %}
+{% endmacro %}
+
 
 {% macro get_clean_elementary_test_tables_queries(test_table_relations) %}
     {% do return(

--- a/macros/edr/tests/test_utils/get_stale_test_tables.sql
+++ b/macros/edr/tests/test_utils/get_stale_test_tables.sql
@@ -323,20 +323,17 @@
     {% do return([]) %}
 {% endmacro %}
 
-
 {% macro dremio__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
-    {# Dremio does not expose table creation time - returning all matching tables.
-       Uses INFORMATION_SCHEMA.TABLES directly as schema_relation.information_schema()
-       generates an invalid path in Dremio's SQL parser. #}
+    {# Dremio does not expose table creation time - returning all matching tables #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Dremio. "
         ~ "All matching temp tables will be returned regardless of age."
     ) %}
     {% set query %}
         select table_catalog, table_schema, table_name
-        from INFORMATION_SCHEMA.TABLES
+        from INFORMATION_SCHEMA."TABLES"
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
             and lower(table_name) like '{{ table_name_pattern }}'

--- a/macros/edr/tests/test_utils/get_stale_test_tables.sql
+++ b/macros/edr/tests/test_utils/get_stale_test_tables.sql
@@ -151,23 +151,35 @@
 {% endmacro %}
 
 
-{% macro spark__get_stale_test_tables(
+{% macro fabricspark__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
-    {# Spark (Hive metastore) does not expose table creation time - returning all matching tables #}
-    {% do elementary.edr_log_warning(
-        "get_stale_test_tables: time-based filtering is not supported on Spark. "
-        ~ "All matching temp tables will be returned regardless of age."
-    ) %}
-    {% set schema_relation = api.Relation.create(
-        database=elementary_database, schema=elementary_schema
-    ).without_identifier() %}
+    {{
+        return(
+            elementary.sqlserver__get_stale_test_tables(
+                elementary_database, elementary_schema, hours, table_name_pattern
+            )
+        )
+    }}
+{% endmacro %}
+
+
+{% macro sqlserver__get_stale_test_tables(
+    elementary_database, elementary_schema, hours, table_name_pattern
+) %}
+    {# SQL Server exposes create_date in sys.tables with time-based filtering support #}
     {% set query %}
-        select table_catalog || '.' || table_schema || '.' || table_name
-        from {{ schema_relation.information_schema("TABLES") }}
+        select
+            db_name()
+            + '.'
+            + schema_name(schema_id)
+            + '.'
+            + name
+        from sys.tables
         where
-            upper(table_schema) = upper('{{ elementary_schema }}')
-            and lower(table_name) like '{{ table_name_pattern }}'
+            upper(schema_name(schema_id)) = upper('{{ elementary_schema }}')
+            and lower(name) like '{{ table_name_pattern }}'
+            and create_date < dateadd(hour, -{{ hours | int }}, getutcdate())
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -179,16 +191,26 @@
 {% endmacro %}
 
 
-{% macro fabricspark__get_stale_test_tables(
+{% macro vertica__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
-    {{
-        return(
-            elementary.spark__get_stale_test_tables(
-                elementary_database, elementary_schema, hours, table_name_pattern
-            )
-        )
-    }}
+    {# Vertica exposes create_time in v_catalog.tables with time-based filtering support #}
+    {% set query %}
+        select '{{ elementary_schema }}' || '.' || table_name
+        from v_catalog.tables
+        where
+            upper(table_schema) = upper('{{ elementary_schema }}')
+            and lower(table_name) like '{{ table_name_pattern }}'
+            and create_time
+            < (current_timestamp - interval '{{ hours | int }} hours')
+    {% endset %}
+    {% if execute %}
+        {% set results = elementary.run_query(query) %}
+        {% do return(
+            results.columns[0].values() if results.rows | length > 0 else []
+        ) %}
+    {% endif %}
+    {% do return([]) %}
 {% endmacro %}
 
 
@@ -273,17 +295,16 @@
 {% macro duckdb__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
-    {# DuckDB does not expose table creation time - returning all matching tables #}
+    {# DuckDB does not expose table creation time - returning all matching tables.
+       Uses plain information_schema.tables to avoid uppercase path issues in
+       DuckDB's in-memory catalog. #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on DuckDB. "
         ~ "All matching temp tables will be returned regardless of age."
     ) %}
-    {% set schema_relation = api.Relation.create(
-        database=elementary_database, schema=elementary_schema
-    ).without_identifier() %}
     {% set query %}
         select table_catalog || '.' || table_schema || '.' || table_name
-        from {{ schema_relation.information_schema("TABLES") }}
+        from information_schema.tables
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
             and lower(table_name) like '{{ table_name_pattern }}'

--- a/macros/edr/tests/test_utils/get_stale_test_tables.sql
+++ b/macros/edr/tests/test_utils/get_stale_test_tables.sql
@@ -73,7 +73,6 @@
 {% macro redshift__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
-    {# Redshift does not expose table creation time - returning all matching tables #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Redshift. "
         ~ "All matching temp tables will be returned regardless of age."
@@ -100,7 +99,6 @@
 {% macro postgres__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
-    {# Postgres does not expose table creation time - returning all matching tables #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Postgres. "
         ~ "All matching temp tables will be returned regardless of age."
@@ -151,6 +149,31 @@
 {% endmacro %}
 
 
+{% macro fabric__get_stale_test_tables(
+    elementary_database, elementary_schema, hours, table_name_pattern
+) %}
+    {% set query %}
+        select
+            db_name()
+            + '.'
+            + schema_name(schema_id)
+            + '.'
+            + name
+        from sys.tables
+        where
+            upper(schema_name(schema_id)) = upper('{{ elementary_schema }}')
+            and lower(name) like '{{ table_name_pattern }}'
+            and create_date < dateadd(hour, -{{ hours | int }}, getutcdate())
+    {% endset %}
+    {% if execute %}
+        {% set results = elementary.run_query(query) %}
+        {% do return(
+            results.columns[0].values() if results.rows | length > 0 else []
+        ) %}
+    {% endif %}
+    {% do return([]) %}
+{% endmacro %}
+
 {% macro fabricspark__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
@@ -167,7 +190,6 @@
 {% macro sqlserver__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
-    {# SQL Server exposes create_date in sys.tables with time-based filtering support #}
     {% set query %}
         select
             db_name()
@@ -194,7 +216,6 @@
 {% macro vertica__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
-    {# Vertica exposes create_time in v_catalog.tables with time-based filtering support #}
     {% set query %}
         select '{{ elementary_schema }}' || '.' || table_name
         from v_catalog.tables
@@ -224,7 +245,7 @@
             upper(database) = upper('{{ elementary_schema }}')
             and lower(name) like '{{ table_name_pattern }}'
             and metadata_modification_time
-            < now() - tointervalminute({{ (hours | float * 60) | int }})
+            < now() - toIntervalMinute({{ (hours | float * 60) | int }})
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -239,7 +260,6 @@
 {% macro athena__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
-    {# Athena does not expose table creation time - returning all matching tables #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Athena. "
         ~ "All matching temp tables will be returned regardless of age."
@@ -267,7 +287,6 @@
 {% macro trino__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
-    {# Trino does not expose table creation time - returning all matching tables #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Trino. "
         ~ "All matching temp tables will be returned regardless of age."
@@ -295,9 +314,6 @@
 {% macro duckdb__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
-    {# DuckDB does not expose table creation time - returning all matching tables.
-       Uses plain information_schema.tables to avoid uppercase path issues in
-       DuckDB's in-memory catalog. #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on DuckDB. "
         ~ "All matching temp tables will be returned regardless of age."
@@ -322,17 +338,13 @@
 {% macro dremio__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
-    {# Dremio does not expose table creation time - returning all matching tables #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Dremio. "
         ~ "All matching temp tables will be returned regardless of age."
     ) %}
-    {% set schema_relation = api.Relation.create(
-        database=elementary_database, schema=elementary_schema
-    ).without_identifier() %}
     {% set query %}
-        select table_catalog || '.' || table_schema || '.' || table_name
-        from {{ schema_relation.information_schema("TABLES") }}
+        select table_schema || '.' || table_name
+        from INFORMATION_SCHEMA.TABLES
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
             and lower(table_name) like '{{ table_name_pattern }}'

--- a/macros/edr/tests/test_utils/get_stale_test_tables.sql
+++ b/macros/edr/tests/test_utils/get_stale_test_tables.sql
@@ -88,56 +88,6 @@
 {% endmacro %}
 
 
-{% macro redshift__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern, limit
-) %}
-    {% do elementary.edr_log_warning(
-        "get_stale_test_tables: time-based filtering is not supported on Redshift. "
-        ~ "All matching temp tables will be returned regardless of age."
-    ) %}
-    {% set query %}
-        select current_database(), table_schema, table_name
-        from pg_catalog.svv_tables
-        where
-            upper(table_schema) = upper('{{ elementary_schema }}')
-            and lower(table_name) like '{{ table_name_pattern }}'
-            and table_type = 'BASE TABLE'
-        limit {{ limit }}
-    {% endset %}
-    {% if execute %}
-        {% set results = elementary.run_query(query) %}
-        {% do return(elementary._stale_test_table_rows_to_relations(results)) %}
-    {% endif %}
-    {% do return([]) %}
-{% endmacro %}
-
-
-{% macro postgres__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern, limit
-) %}
-    {% do elementary.edr_log_warning(
-        "get_stale_test_tables: time-based filtering is not supported on Postgres. "
-        ~ "All matching temp tables will be returned regardless of age."
-    ) %}
-    {% set schema_relation = api.Relation.create(
-        database=elementary_database, schema=elementary_schema
-    ).without_identifier() %}
-    {% set query %}
-        select table_catalog, table_schema, table_name
-        from {{ schema_relation.information_schema("TABLES") }}
-        where
-            upper(table_schema) = upper('{{ elementary_schema }}')
-            and lower(table_name) like '{{ table_name_pattern }}'
-        limit {{ limit }}
-    {% endset %}
-    {% if execute %}
-        {% set results = elementary.run_query(query) %}
-        {% do return(elementary._stale_test_table_rows_to_relations(results)) %}
-    {% endif %}
-    {% do return([]) %}
-{% endmacro %}
-
-
 {% macro databricks__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern, limit
 ) %}
@@ -250,81 +200,6 @@
             and lower(name) like '{{ table_name_pattern }}'
             and metadata_modification_time
             <= now() - toIntervalMinute({{ (hours | float * 60) | int }})
-        limit {{ limit }}
-    {% endset %}
-    {% if execute %}
-        {% set results = elementary.run_query(query) %}
-        {% do return(elementary._stale_test_table_rows_to_relations(results)) %}
-    {% endif %}
-    {% do return([]) %}
-{% endmacro %}
-
-
-{% macro athena__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern, limit
-) %}
-    {% do elementary.edr_log_warning(
-        "get_stale_test_tables: time-based filtering is not supported on Athena. "
-        ~ "All matching temp tables will be returned regardless of age."
-    ) %}
-    {% set schema_relation = api.Relation.create(
-        database=elementary_database, schema=elementary_schema
-    ).without_identifier() %}
-    {% set query %}
-        select table_catalog, table_schema, table_name
-        from {{ schema_relation.information_schema("TABLES") }}
-        where
-            upper(table_schema) = upper('{{ elementary_schema }}')
-            and lower(table_name) like '{{ table_name_pattern }}'
-        limit {{ limit }}
-    {% endset %}
-    {% if execute %}
-        {% set results = elementary.run_query(query) %}
-        {% do return(elementary._stale_test_table_rows_to_relations(results)) %}
-    {% endif %}
-    {% do return([]) %}
-{% endmacro %}
-
-
-{% macro trino__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern, limit
-) %}
-    {% do elementary.edr_log_warning(
-        "get_stale_test_tables: time-based filtering is not supported on Trino. "
-        ~ "All matching temp tables will be returned regardless of age."
-    ) %}
-    {% set schema_relation = api.Relation.create(
-        database=elementary_database, schema=elementary_schema
-    ).without_identifier() %}
-    {% set query %}
-        select table_catalog, table_schema, table_name
-        from {{ schema_relation.information_schema("TABLES") }}
-        where
-            upper(table_schema) = upper('{{ elementary_schema }}')
-            and lower(table_name) like '{{ table_name_pattern }}'
-        limit {{ limit }}
-    {% endset %}
-    {% if execute %}
-        {% set results = elementary.run_query(query) %}
-        {% do return(elementary._stale_test_table_rows_to_relations(results)) %}
-    {% endif %}
-    {% do return([]) %}
-{% endmacro %}
-
-
-{% macro duckdb__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern, limit
-) %}
-    {% do elementary.edr_log_warning(
-        "get_stale_test_tables: time-based filtering is not supported on DuckDB. "
-        ~ "All matching temp tables will be returned regardless of age."
-    ) %}
-    {% set query %}
-        select table_catalog, table_schema, table_name
-        from information_schema.tables
-        where
-            upper(table_schema) = upper('{{ elementary_schema }}')
-            and lower(table_name) like '{{ table_name_pattern }}'
         limit {{ limit }}
     {% endset %}
     {% if execute %}

--- a/macros/edr/tests/test_utils/get_stale_test_tables.sql
+++ b/macros/edr/tests/test_utils/get_stale_test_tables.sql
@@ -1,9 +1,5 @@
 {% macro get_stale_test_tables(
-    elementary_database,
-    elementary_schema,
-    hours,
-    table_name_pattern,
-    limit=2000
+    elementary_database, elementary_schema, hours, table_name_pattern, limit
 ) %}
     {% do return(
         adapter.dispatch("get_stale_test_tables", "elementary")(
@@ -18,11 +14,7 @@
 
 
 {% macro default__get_stale_test_tables(
-    elementary_database,
-    elementary_schema,
-    hours,
-    table_name_pattern,
-    limit=2000
+    elementary_database, elementary_schema, hours, table_name_pattern, limit
 ) %}
     {% do exceptions.raise_compiler_error(
         "elementary.get_stale_test_tables is not implemented for adapter: "
@@ -48,11 +40,7 @@
 
 
 {% macro snowflake__get_stale_test_tables(
-    elementary_database,
-    elementary_schema,
-    hours,
-    table_name_pattern,
-    limit=2000
+    elementary_database, elementary_schema, hours, table_name_pattern, limit
 ) %}
     {% set schema_relation = api.Relation.create(
         database=elementary_database, schema=elementary_schema
@@ -64,7 +52,7 @@
             upper(table_schema) = upper('{{ elementary_schema }}')
             and lower(table_name) like '{{ table_name_pattern }}'
             and created < dateadd(hour, -{{ hours | int }}, current_timestamp())
-        limit {{ limit | int }}
+        limit {{ limit }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -75,11 +63,7 @@
 
 
 {% macro bigquery__get_stale_test_tables(
-    elementary_database,
-    elementary_schema,
-    hours,
-    table_name_pattern,
-    limit=2000
+    elementary_database, elementary_schema, hours, table_name_pattern, limit
 ) %}
     {% set schema_relation = api.Relation.create(
         database=elementary_database, schema=elementary_schema
@@ -94,7 +78,7 @@
             < timestamp_sub(
                 current_timestamp(), interval {{ hours | int }} hour
             )
-        limit {{ limit | int }}
+        limit {{ limit }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -105,11 +89,7 @@
 
 
 {% macro redshift__get_stale_test_tables(
-    elementary_database,
-    elementary_schema,
-    hours,
-    table_name_pattern,
-    limit=2000
+    elementary_database, elementary_schema, hours, table_name_pattern, limit
 ) %}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Redshift. "
@@ -122,7 +102,7 @@
             upper(table_schema) = upper('{{ elementary_schema }}')
             and lower(table_name) like '{{ table_name_pattern }}'
             and table_type = 'BASE TABLE'
-        limit {{ limit | int }}
+        limit {{ limit }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -133,11 +113,7 @@
 
 
 {% macro postgres__get_stale_test_tables(
-    elementary_database,
-    elementary_schema,
-    hours,
-    table_name_pattern,
-    limit=2000
+    elementary_database, elementary_schema, hours, table_name_pattern, limit
 ) %}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Postgres. "
@@ -152,7 +128,7 @@
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
             and lower(table_name) like '{{ table_name_pattern }}'
-        limit {{ limit | int }}
+        limit {{ limit }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -163,11 +139,7 @@
 
 
 {% macro databricks__get_stale_test_tables(
-    elementary_database,
-    elementary_schema,
-    hours,
-    table_name_pattern,
-    limit=2000
+    elementary_database, elementary_schema, hours, table_name_pattern, limit
 ) %}
     {# Requires Unity Catalog - creation time available in information_schema.TABLES #}
     {% set schema_relation = api.Relation.create(
@@ -181,7 +153,7 @@
             and lower(table_name) like '{{ table_name_pattern }}'
             and created
             < timestampadd(hour, -{{ hours | int }}, current_timestamp())
-        limit {{ limit | int }}
+        limit {{ limit }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -192,14 +164,10 @@
 
 
 {% macro fabric__get_stale_test_tables(
-    elementary_database,
-    elementary_schema,
-    hours,
-    table_name_pattern,
-    limit=2000
+    elementary_database, elementary_schema, hours, table_name_pattern, limit
 ) %}
     {% set query %}
-        select top {{ limit | int }} db_name(), schema_name(schema_id), name
+        select top {{ limit }} db_name(), schema_name(schema_id), name
         from sys.tables
         where
             upper(schema_name(schema_id)) = upper('{{ elementary_schema }}')
@@ -215,11 +183,7 @@
 
 
 {% macro fabricspark__get_stale_test_tables(
-    elementary_database,
-    elementary_schema,
-    hours,
-    table_name_pattern,
-    limit=2000
+    elementary_database, elementary_schema, hours, table_name_pattern, limit
 ) %}
     {{
         return(
@@ -236,14 +200,10 @@
 
 
 {% macro sqlserver__get_stale_test_tables(
-    elementary_database,
-    elementary_schema,
-    hours,
-    table_name_pattern,
-    limit=2000
+    elementary_database, elementary_schema, hours, table_name_pattern, limit
 ) %}
     {% set query %}
-        select top {{ limit | int }} db_name(), schema_name(schema_id), name
+        select top {{ limit }} db_name(), schema_name(schema_id), name
         from sys.tables
         where
             upper(schema_name(schema_id)) = upper('{{ elementary_schema }}')
@@ -259,11 +219,7 @@
 
 
 {% macro vertica__get_stale_test_tables(
-    elementary_database,
-    elementary_schema,
-    hours,
-    table_name_pattern,
-    limit=2000
+    elementary_database, elementary_schema, hours, table_name_pattern, limit
 ) %}
     {% set query %}
         select null, table_schema, table_name
@@ -273,7 +229,7 @@
             and lower(table_name) like '{{ table_name_pattern }}'
             and create_time
             < (current_timestamp - interval '{{ hours | int }} hours')
-        limit {{ limit | int }}
+        limit {{ limit }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -284,11 +240,7 @@
 
 
 {% macro clickhouse__get_stale_test_tables(
-    elementary_database,
-    elementary_schema,
-    hours,
-    table_name_pattern,
-    limit=2000
+    elementary_database, elementary_schema, hours, table_name_pattern, limit
 ) %}
     {% set query %}
         select null, database, name
@@ -298,7 +250,7 @@
             and lower(name) like '{{ table_name_pattern }}'
             and metadata_modification_time
             <= now() - toIntervalMinute({{ (hours | float * 60) | int }})
-        limit {{ limit | int }}
+        limit {{ limit }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -309,11 +261,7 @@
 
 
 {% macro athena__get_stale_test_tables(
-    elementary_database,
-    elementary_schema,
-    hours,
-    table_name_pattern,
-    limit=2000
+    elementary_database, elementary_schema, hours, table_name_pattern, limit
 ) %}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Athena. "
@@ -328,7 +276,7 @@
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
             and lower(table_name) like '{{ table_name_pattern }}'
-        limit {{ limit | int }}
+        limit {{ limit }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -339,11 +287,7 @@
 
 
 {% macro trino__get_stale_test_tables(
-    elementary_database,
-    elementary_schema,
-    hours,
-    table_name_pattern,
-    limit=2000
+    elementary_database, elementary_schema, hours, table_name_pattern, limit
 ) %}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Trino. "
@@ -358,7 +302,7 @@
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
             and lower(table_name) like '{{ table_name_pattern }}'
-        limit {{ limit | int }}
+        limit {{ limit }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -369,11 +313,7 @@
 
 
 {% macro duckdb__get_stale_test_tables(
-    elementary_database,
-    elementary_schema,
-    hours,
-    table_name_pattern,
-    limit=2000
+    elementary_database, elementary_schema, hours, table_name_pattern, limit
 ) %}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on DuckDB. "
@@ -385,7 +325,7 @@
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
             and lower(table_name) like '{{ table_name_pattern }}'
-        limit {{ limit | int }}
+        limit {{ limit }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -396,11 +336,7 @@
 
 
 {% macro dremio__get_stale_test_tables(
-    elementary_database,
-    elementary_schema,
-    hours,
-    table_name_pattern,
-    limit=2000
+    elementary_database, elementary_schema, hours, table_name_pattern, limit
 ) %}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Dremio. "
@@ -412,7 +348,7 @@
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
             and lower(table_name) like '{{ table_name_pattern }}'
-        limit {{ limit | int }}
+        limit {{ limit }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}

--- a/macros/edr/tests/test_utils/get_stale_test_tables.sql
+++ b/macros/edr/tests/test_utils/get_stale_test_tables.sql
@@ -1,16 +1,28 @@
 {% macro get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern
+    elementary_database,
+    elementary_schema,
+    hours,
+    table_name_pattern,
+    limit=2000
 ) %}
     {% do return(
         adapter.dispatch("get_stale_test_tables", "elementary")(
-            elementary_database, elementary_schema, hours, table_name_pattern
+            elementary_database,
+            elementary_schema,
+            hours,
+            table_name_pattern,
+            limit,
         )
     ) %}
 {% endmacro %}
 
 
 {% macro default__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern
+    elementary_database,
+    elementary_schema,
+    hours,
+    table_name_pattern,
+    limit=2000
 ) %}
     {% do exceptions.raise_compiler_error(
         "elementary.get_stale_test_tables is not implemented for adapter: "
@@ -36,7 +48,11 @@
 
 
 {% macro snowflake__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern
+    elementary_database,
+    elementary_schema,
+    hours,
+    table_name_pattern,
+    limit=2000
 ) %}
     {% set schema_relation = api.Relation.create(
         database=elementary_database, schema=elementary_schema
@@ -48,6 +64,7 @@
             upper(table_schema) = upper('{{ elementary_schema }}')
             and lower(table_name) like '{{ table_name_pattern }}'
             and created < dateadd(hour, -{{ hours | int }}, current_timestamp())
+        limit {{ limit | int }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -58,7 +75,11 @@
 
 
 {% macro bigquery__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern
+    elementary_database,
+    elementary_schema,
+    hours,
+    table_name_pattern,
+    limit=2000
 ) %}
     {% set schema_relation = api.Relation.create(
         database=elementary_database, schema=elementary_schema
@@ -73,6 +94,7 @@
             < timestamp_sub(
                 current_timestamp(), interval {{ hours | int }} hour
             )
+        limit {{ limit | int }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -83,9 +105,12 @@
 
 
 {% macro redshift__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern
+    elementary_database,
+    elementary_schema,
+    hours,
+    table_name_pattern,
+    limit=2000
 ) %}
-    {# Redshift does not expose table creation time - returning all matching tables #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Redshift. "
         ~ "All matching temp tables will be returned regardless of age."
@@ -97,6 +122,7 @@
             upper(table_schema) = upper('{{ elementary_schema }}')
             and lower(table_name) like '{{ table_name_pattern }}'
             and table_type = 'BASE TABLE'
+        limit {{ limit | int }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -107,9 +133,12 @@
 
 
 {% macro postgres__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern
+    elementary_database,
+    elementary_schema,
+    hours,
+    table_name_pattern,
+    limit=2000
 ) %}
-    {# Postgres does not expose table creation time - returning all matching tables #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Postgres. "
         ~ "All matching temp tables will be returned regardless of age."
@@ -123,6 +152,7 @@
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
             and lower(table_name) like '{{ table_name_pattern }}'
+        limit {{ limit | int }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -133,7 +163,11 @@
 
 
 {% macro databricks__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern
+    elementary_database,
+    elementary_schema,
+    hours,
+    table_name_pattern,
+    limit=2000
 ) %}
     {# Requires Unity Catalog - creation time available in information_schema.TABLES #}
     {% set schema_relation = api.Relation.create(
@@ -147,6 +181,7 @@
             and lower(table_name) like '{{ table_name_pattern }}'
             and created
             < timestampadd(hour, -{{ hours | int }}, current_timestamp())
+        limit {{ limit | int }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -157,10 +192,14 @@
 
 
 {% macro fabric__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern
+    elementary_database,
+    elementary_schema,
+    hours,
+    table_name_pattern,
+    limit=2000
 ) %}
     {% set query %}
-        select db_name(), schema_name(schema_id), name
+        select top {{ limit | int }} db_name(), schema_name(schema_id), name
         from sys.tables
         where
             upper(schema_name(schema_id)) = upper('{{ elementary_schema }}')
@@ -176,12 +215,20 @@
 
 
 {% macro fabricspark__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern
+    elementary_database,
+    elementary_schema,
+    hours,
+    table_name_pattern,
+    limit=2000
 ) %}
     {{
         return(
             elementary.fabric__get_stale_test_tables(
-                elementary_database, elementary_schema, hours, table_name_pattern
+                elementary_database,
+                elementary_schema,
+                hours,
+                table_name_pattern,
+                limit,
             )
         )
     }}
@@ -189,10 +236,14 @@
 
 
 {% macro sqlserver__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern
+    elementary_database,
+    elementary_schema,
+    hours,
+    table_name_pattern,
+    limit=2000
 ) %}
     {% set query %}
-        select db_name(), schema_name(schema_id), name
+        select top {{ limit | int }} db_name(), schema_name(schema_id), name
         from sys.tables
         where
             upper(schema_name(schema_id)) = upper('{{ elementary_schema }}')
@@ -208,7 +259,11 @@
 
 
 {% macro vertica__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern
+    elementary_database,
+    elementary_schema,
+    hours,
+    table_name_pattern,
+    limit=2000
 ) %}
     {% set query %}
         select null, table_schema, table_name
@@ -218,6 +273,7 @@
             and lower(table_name) like '{{ table_name_pattern }}'
             and create_time
             < (current_timestamp - interval '{{ hours | int }} hours')
+        limit {{ limit | int }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -228,7 +284,11 @@
 
 
 {% macro clickhouse__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern
+    elementary_database,
+    elementary_schema,
+    hours,
+    table_name_pattern,
+    limit=2000
 ) %}
     {% set query %}
         select null, database, name
@@ -238,6 +298,7 @@
             and lower(name) like '{{ table_name_pattern }}'
             and metadata_modification_time
             <= now() - toIntervalMinute({{ (hours | float * 60) | int }})
+        limit {{ limit | int }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -248,9 +309,12 @@
 
 
 {% macro athena__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern
+    elementary_database,
+    elementary_schema,
+    hours,
+    table_name_pattern,
+    limit=2000
 ) %}
-    {# Athena does not expose table creation time - returning all matching tables #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Athena. "
         ~ "All matching temp tables will be returned regardless of age."
@@ -264,6 +328,7 @@
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
             and lower(table_name) like '{{ table_name_pattern }}'
+        limit {{ limit | int }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -274,9 +339,12 @@
 
 
 {% macro trino__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern
+    elementary_database,
+    elementary_schema,
+    hours,
+    table_name_pattern,
+    limit=2000
 ) %}
-    {# Trino does not expose table creation time - returning all matching tables #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Trino. "
         ~ "All matching temp tables will be returned regardless of age."
@@ -290,6 +358,7 @@
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
             and lower(table_name) like '{{ table_name_pattern }}'
+        limit {{ limit | int }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -300,11 +369,12 @@
 
 
 {% macro duckdb__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern
+    elementary_database,
+    elementary_schema,
+    hours,
+    table_name_pattern,
+    limit=2000
 ) %}
-    {# DuckDB does not expose table creation time - returning all matching tables.
-       Uses plain information_schema.tables to avoid uppercase path issues in
-       DuckDB's in-memory catalog. #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on DuckDB. "
         ~ "All matching temp tables will be returned regardless of age."
@@ -315,6 +385,7 @@
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
             and lower(table_name) like '{{ table_name_pattern }}'
+        limit {{ limit | int }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
@@ -323,10 +394,14 @@
     {% do return([]) %}
 {% endmacro %}
 
+
 {% macro dremio__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern
+    elementary_database,
+    elementary_schema,
+    hours,
+    table_name_pattern,
+    limit=2000
 ) %}
-    {# Dremio does not expose table creation time - returning all matching tables #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Dremio. "
         ~ "All matching temp tables will be returned regardless of age."
@@ -337,6 +412,7 @@
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
             and lower(table_name) like '{{ table_name_pattern }}'
+        limit {{ limit | int }}
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}

--- a/macros/edr/tests/test_utils/get_stale_test_tables.sql
+++ b/macros/edr/tests/test_utils/get_stale_test_tables.sql
@@ -333,26 +333,3 @@
     {% endif %}
     {% do return([]) %}
 {% endmacro %}
-
-
-{% macro dremio__get_stale_test_tables(
-    elementary_database, elementary_schema, hours, table_name_pattern, limit
-) %}
-    {% do elementary.edr_log_warning(
-        "get_stale_test_tables: time-based filtering is not supported on Dremio. "
-        ~ "All matching temp tables will be returned regardless of age."
-    ) %}
-    {% set query %}
-        select table_catalog, table_schema, table_name
-        from INFORMATION_SCHEMA."TABLES"
-        where
-            upper(table_schema) = upper('{{ elementary_schema }}')
-            and lower(table_name) like '{{ table_name_pattern }}'
-        limit {{ limit }}
-    {% endset %}
-    {% if execute %}
-        {% set results = elementary.run_query(query) %}
-        {% do return(elementary._stale_test_table_rows_to_relations(results)) %}
-    {% endif %}
-    {% do return([]) %}
-{% endmacro %}

--- a/macros/edr/tests/test_utils/get_stale_test_tables.sql
+++ b/macros/edr/tests/test_utils/get_stale_test_tables.sql
@@ -19,6 +19,22 @@
 {% endmacro %}
 
 
+{% macro _stale_test_table_rows_to_relations(results) %}
+    {% set relations = [] %}
+    {% for row in results.rows %}
+        {% do relations.append(
+            api.Relation.create(
+                database=row[0] if row[0] is not none else none,
+                schema=row[1],
+                identifier=row[2],
+                type="table",
+            )
+        ) %}
+    {% endfor %}
+    {% do return(relations) %}
+{% endmacro %}
+
+
 {% macro snowflake__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
@@ -26,7 +42,7 @@
         database=elementary_database, schema=elementary_schema
     ).without_identifier() %}
     {% set query %}
-        select table_catalog || '.' || table_schema || '.' || table_name
+        select table_catalog, table_schema, table_name
         from {{ schema_relation.information_schema("TABLES") }}
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
@@ -35,9 +51,7 @@
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
-        {% do return(
-            results.columns[0].values() if results.rows | length > 0 else []
-        ) %}
+        {% do return(elementary._stale_test_table_rows_to_relations(results)) %}
     {% endif %}
     {% do return([]) %}
 {% endmacro %}
@@ -50,7 +64,7 @@
         database=elementary_database, schema=elementary_schema
     ).without_identifier() %}
     {% set query %}
-        select table_catalog || '.' || table_schema || '.' || table_name
+        select table_catalog, table_schema, table_name
         from {{ schema_relation.information_schema("TABLES") }}
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
@@ -62,9 +76,7 @@
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
-        {% do return(
-            results.columns[0].values() if results.rows | length > 0 else []
-        ) %}
+        {% do return(elementary._stale_test_table_rows_to_relations(results)) %}
     {% endif %}
     {% do return([]) %}
 {% endmacro %}
@@ -73,13 +85,13 @@
 {% macro redshift__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
+    {# Redshift does not expose table creation time - returning all matching tables #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Redshift. "
         ~ "All matching temp tables will be returned regardless of age."
     ) %}
     {% set query %}
-        select
-            current_database() || '.' || table_schema || '.' || table_name
+        select current_database(), table_schema, table_name
         from pg_catalog.svv_tables
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
@@ -88,9 +100,7 @@
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
-        {% do return(
-            results.columns[0].values() if results.rows | length > 0 else []
-        ) %}
+        {% do return(elementary._stale_test_table_rows_to_relations(results)) %}
     {% endif %}
     {% do return([]) %}
 {% endmacro %}
@@ -99,6 +109,7 @@
 {% macro postgres__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
+    {# Postgres does not expose table creation time - returning all matching tables #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Postgres. "
         ~ "All matching temp tables will be returned regardless of age."
@@ -107,7 +118,7 @@
         database=elementary_database, schema=elementary_schema
     ).without_identifier() %}
     {% set query %}
-        select table_catalog || '.' || table_schema || '.' || table_name
+        select table_catalog, table_schema, table_name
         from {{ schema_relation.information_schema("TABLES") }}
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
@@ -115,9 +126,7 @@
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
-        {% do return(
-            results.columns[0].values() if results.rows | length > 0 else []
-        ) %}
+        {% do return(elementary._stale_test_table_rows_to_relations(results)) %}
     {% endif %}
     {% do return([]) %}
 {% endmacro %}
@@ -131,7 +140,7 @@
         database=elementary_database, schema=elementary_schema
     ).without_identifier() %}
     {% set query %}
-        select table_catalog || '.' || table_schema || '.' || table_name
+        select table_catalog, table_schema, table_name
         from {{ schema_relation.information_schema("TABLES") }}
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
@@ -141,9 +150,7 @@
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
-        {% do return(
-            results.columns[0].values() if results.rows | length > 0 else []
-        ) %}
+        {% do return(elementary._stale_test_table_rows_to_relations(results)) %}
     {% endif %}
     {% do return([]) %}
 {% endmacro %}
@@ -153,12 +160,7 @@
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
     {% set query %}
-        select
-            db_name()
-            + '.'
-            + schema_name(schema_id)
-            + '.'
-            + name
+        select db_name(), schema_name(schema_id), name
         from sys.tables
         where
             upper(schema_name(schema_id)) = upper('{{ elementary_schema }}')
@@ -167,19 +169,18 @@
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
-        {% do return(
-            results.columns[0].values() if results.rows | length > 0 else []
-        ) %}
+        {% do return(elementary._stale_test_table_rows_to_relations(results)) %}
     {% endif %}
     {% do return([]) %}
 {% endmacro %}
+
 
 {% macro fabricspark__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
     {{
         return(
-            elementary.sqlserver__get_stale_test_tables(
+            elementary.fabric__get_stale_test_tables(
                 elementary_database, elementary_schema, hours, table_name_pattern
             )
         )
@@ -191,12 +192,7 @@
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
     {% set query %}
-        select
-            db_name()
-            + '.'
-            + schema_name(schema_id)
-            + '.'
-            + name
+        select db_name(), schema_name(schema_id), name
         from sys.tables
         where
             upper(schema_name(schema_id)) = upper('{{ elementary_schema }}')
@@ -205,9 +201,7 @@
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
-        {% do return(
-            results.columns[0].values() if results.rows | length > 0 else []
-        ) %}
+        {% do return(elementary._stale_test_table_rows_to_relations(results)) %}
     {% endif %}
     {% do return([]) %}
 {% endmacro %}
@@ -217,7 +211,7 @@
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
     {% set query %}
-        select '{{ elementary_schema }}' || '.' || table_name
+        select null, table_schema, table_name
         from v_catalog.tables
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
@@ -227,9 +221,7 @@
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
-        {% do return(
-            results.columns[0].values() if results.rows | length > 0 else []
-        ) %}
+        {% do return(elementary._stale_test_table_rows_to_relations(results)) %}
     {% endif %}
     {% do return([]) %}
 {% endmacro %}
@@ -239,19 +231,17 @@
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
     {% set query %}
-        select database || '.' || name
+        select null, database, name
         from system.tables
         where
             upper(database) = upper('{{ elementary_schema }}')
             and lower(name) like '{{ table_name_pattern }}'
             and metadata_modification_time
-            < now() - toIntervalMinute({{ (hours | float * 60) | int }})
+            <= now() - toIntervalMinute({{ (hours | float * 60) | int }})
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
-        {% do return(
-            results.columns[0].values() if results.rows | length > 0 else []
-        ) %}
+        {% do return(elementary._stale_test_table_rows_to_relations(results)) %}
     {% endif %}
     {% do return([]) %}
 {% endmacro %}
@@ -260,6 +250,7 @@
 {% macro athena__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
+    {# Athena does not expose table creation time - returning all matching tables #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Athena. "
         ~ "All matching temp tables will be returned regardless of age."
@@ -268,7 +259,7 @@
         database=elementary_database, schema=elementary_schema
     ).without_identifier() %}
     {% set query %}
-        select table_catalog || '.' || table_schema || '.' || table_name
+        select table_catalog, table_schema, table_name
         from {{ schema_relation.information_schema("TABLES") }}
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
@@ -276,9 +267,7 @@
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
-        {% do return(
-            results.columns[0].values() if results.rows | length > 0 else []
-        ) %}
+        {% do return(elementary._stale_test_table_rows_to_relations(results)) %}
     {% endif %}
     {% do return([]) %}
 {% endmacro %}
@@ -287,6 +276,7 @@
 {% macro trino__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
+    {# Trino does not expose table creation time - returning all matching tables #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Trino. "
         ~ "All matching temp tables will be returned regardless of age."
@@ -295,7 +285,7 @@
         database=elementary_database, schema=elementary_schema
     ).without_identifier() %}
     {% set query %}
-        select table_catalog || '.' || table_schema || '.' || table_name
+        select table_catalog, table_schema, table_name
         from {{ schema_relation.information_schema("TABLES") }}
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
@@ -303,9 +293,7 @@
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
-        {% do return(
-            results.columns[0].values() if results.rows | length > 0 else []
-        ) %}
+        {% do return(elementary._stale_test_table_rows_to_relations(results)) %}
     {% endif %}
     {% do return([]) %}
 {% endmacro %}
@@ -314,12 +302,15 @@
 {% macro duckdb__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
+    {# DuckDB does not expose table creation time - returning all matching tables.
+       Uses plain information_schema.tables to avoid uppercase path issues in
+       DuckDB's in-memory catalog. #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on DuckDB. "
         ~ "All matching temp tables will be returned regardless of age."
     ) %}
     {% set query %}
-        select table_catalog || '.' || table_schema || '.' || table_name
+        select table_catalog, table_schema, table_name
         from information_schema.tables
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
@@ -327,9 +318,7 @@
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
-        {% do return(
-            results.columns[0].values() if results.rows | length > 0 else []
-        ) %}
+        {% do return(elementary._stale_test_table_rows_to_relations(results)) %}
     {% endif %}
     {% do return([]) %}
 {% endmacro %}
@@ -338,12 +327,15 @@
 {% macro dremio__get_stale_test_tables(
     elementary_database, elementary_schema, hours, table_name_pattern
 ) %}
+    {# Dremio does not expose table creation time - returning all matching tables.
+       Uses INFORMATION_SCHEMA.TABLES directly as schema_relation.information_schema()
+       generates an invalid path in Dremio's SQL parser. #}
     {% do elementary.edr_log_warning(
         "get_stale_test_tables: time-based filtering is not supported on Dremio. "
         ~ "All matching temp tables will be returned regardless of age."
     ) %}
     {% set query %}
-        select table_schema || '.' || table_name
+        select table_catalog, table_schema, table_name
         from INFORMATION_SCHEMA.TABLES
         where
             upper(table_schema) = upper('{{ elementary_schema }}')
@@ -351,9 +343,7 @@
     {% endset %}
     {% if execute %}
         {% set results = elementary.run_query(query) %}
-        {% do return(
-            results.columns[0].values() if results.rows | length > 0 else []
-        ) %}
+        {% do return(elementary._stale_test_table_rows_to_relations(results)) %}
     {% endif %}
     {% do return([]) %}
 {% endmacro %}

--- a/macros/edr/tests/test_utils/get_stale_test_tables.sql
+++ b/macros/edr/tests/test_utils/get_stale_test_tables.sql
@@ -1,0 +1,326 @@
+{% macro get_stale_test_tables(
+    elementary_database, elementary_schema, hours, table_name_pattern
+) %}
+    {% do return(
+        adapter.dispatch("get_stale_test_tables", "elementary")(
+            elementary_database, elementary_schema, hours, table_name_pattern
+        )
+    ) %}
+{% endmacro %}
+
+
+{% macro default__get_stale_test_tables(
+    elementary_database, elementary_schema, hours, table_name_pattern
+) %}
+    {% do exceptions.raise_compiler_error(
+        "elementary.get_stale_test_tables is not implemented for adapter: "
+        ~ adapter.type()
+    ) %}
+{% endmacro %}
+
+
+{% macro snowflake__get_stale_test_tables(
+    elementary_database, elementary_schema, hours, table_name_pattern
+) %}
+    {% set schema_relation = api.Relation.create(
+        database=elementary_database, schema=elementary_schema
+    ).without_identifier() %}
+    {% set query %}
+        select table_catalog || '.' || table_schema || '.' || table_name
+        from {{ schema_relation.information_schema("TABLES") }}
+        where
+            upper(table_schema) = upper('{{ elementary_schema }}')
+            and lower(table_name) like '{{ table_name_pattern }}'
+            and created < dateadd(hour, -{{ hours | int }}, current_timestamp())
+    {% endset %}
+    {% if execute %}
+        {% set results = elementary.run_query(query) %}
+        {% do return(
+            results.columns[0].values() if results.rows | length > 0 else []
+        ) %}
+    {% endif %}
+    {% do return([]) %}
+{% endmacro %}
+
+
+{% macro bigquery__get_stale_test_tables(
+    elementary_database, elementary_schema, hours, table_name_pattern
+) %}
+    {% set schema_relation = api.Relation.create(
+        database=elementary_database, schema=elementary_schema
+    ).without_identifier() %}
+    {% set query %}
+        select table_catalog || '.' || table_schema || '.' || table_name
+        from {{ schema_relation.information_schema("TABLES") }}
+        where
+            upper(table_schema) = upper('{{ elementary_schema }}')
+            and lower(table_name) like '{{ table_name_pattern }}'
+            and creation_time
+            < timestamp_sub(
+                current_timestamp(), interval {{ hours | int }} hour
+            )
+    {% endset %}
+    {% if execute %}
+        {% set results = elementary.run_query(query) %}
+        {% do return(
+            results.columns[0].values() if results.rows | length > 0 else []
+        ) %}
+    {% endif %}
+    {% do return([]) %}
+{% endmacro %}
+
+
+{% macro redshift__get_stale_test_tables(
+    elementary_database, elementary_schema, hours, table_name_pattern
+) %}
+    {# Redshift does not expose table creation time - returning all matching tables #}
+    {% do elementary.edr_log_warning(
+        "get_stale_test_tables: time-based filtering is not supported on Redshift. "
+        ~ "All matching temp tables will be returned regardless of age."
+    ) %}
+    {% set query %}
+        select
+            current_database() || '.' || table_schema || '.' || table_name
+        from pg_catalog.svv_tables
+        where
+            upper(table_schema) = upper('{{ elementary_schema }}')
+            and lower(table_name) like '{{ table_name_pattern }}'
+            and table_type = 'BASE TABLE'
+    {% endset %}
+    {% if execute %}
+        {% set results = elementary.run_query(query) %}
+        {% do return(
+            results.columns[0].values() if results.rows | length > 0 else []
+        ) %}
+    {% endif %}
+    {% do return([]) %}
+{% endmacro %}
+
+
+{% macro postgres__get_stale_test_tables(
+    elementary_database, elementary_schema, hours, table_name_pattern
+) %}
+    {# Postgres does not expose table creation time - returning all matching tables #}
+    {% do elementary.edr_log_warning(
+        "get_stale_test_tables: time-based filtering is not supported on Postgres. "
+        ~ "All matching temp tables will be returned regardless of age."
+    ) %}
+    {% set schema_relation = api.Relation.create(
+        database=elementary_database, schema=elementary_schema
+    ).without_identifier() %}
+    {% set query %}
+        select table_catalog || '.' || table_schema || '.' || table_name
+        from {{ schema_relation.information_schema("TABLES") }}
+        where
+            upper(table_schema) = upper('{{ elementary_schema }}')
+            and lower(table_name) like '{{ table_name_pattern }}'
+    {% endset %}
+    {% if execute %}
+        {% set results = elementary.run_query(query) %}
+        {% do return(
+            results.columns[0].values() if results.rows | length > 0 else []
+        ) %}
+    {% endif %}
+    {% do return([]) %}
+{% endmacro %}
+
+
+{% macro databricks__get_stale_test_tables(
+    elementary_database, elementary_schema, hours, table_name_pattern
+) %}
+    {# Requires Unity Catalog - creation time available in information_schema.TABLES #}
+    {% set schema_relation = api.Relation.create(
+        database=elementary_database, schema=elementary_schema
+    ).without_identifier() %}
+    {% set query %}
+        select table_catalog || '.' || table_schema || '.' || table_name
+        from {{ schema_relation.information_schema("TABLES") }}
+        where
+            upper(table_schema) = upper('{{ elementary_schema }}')
+            and lower(table_name) like '{{ table_name_pattern }}'
+            and created
+            < timestampadd(hour, -{{ hours | int }}, current_timestamp())
+    {% endset %}
+    {% if execute %}
+        {% set results = elementary.run_query(query) %}
+        {% do return(
+            results.columns[0].values() if results.rows | length > 0 else []
+        ) %}
+    {% endif %}
+    {% do return([]) %}
+{% endmacro %}
+
+
+{% macro spark__get_stale_test_tables(
+    elementary_database, elementary_schema, hours, table_name_pattern
+) %}
+    {# Spark (Hive metastore) does not expose table creation time - returning all matching tables #}
+    {% do elementary.edr_log_warning(
+        "get_stale_test_tables: time-based filtering is not supported on Spark. "
+        ~ "All matching temp tables will be returned regardless of age."
+    ) %}
+    {% set schema_relation = api.Relation.create(
+        database=elementary_database, schema=elementary_schema
+    ).without_identifier() %}
+    {% set query %}
+        select table_catalog || '.' || table_schema || '.' || table_name
+        from {{ schema_relation.information_schema("TABLES") }}
+        where
+            upper(table_schema) = upper('{{ elementary_schema }}')
+            and lower(table_name) like '{{ table_name_pattern }}'
+    {% endset %}
+    {% if execute %}
+        {% set results = elementary.run_query(query) %}
+        {% do return(
+            results.columns[0].values() if results.rows | length > 0 else []
+        ) %}
+    {% endif %}
+    {% do return([]) %}
+{% endmacro %}
+
+
+{% macro fabricspark__get_stale_test_tables(
+    elementary_database, elementary_schema, hours, table_name_pattern
+) %}
+    {{
+        return(
+            elementary.spark__get_stale_test_tables(
+                elementary_database, elementary_schema, hours, table_name_pattern
+            )
+        )
+    }}
+{% endmacro %}
+
+
+{% macro clickhouse__get_stale_test_tables(
+    elementary_database, elementary_schema, hours, table_name_pattern
+) %}
+    {% set query %}
+        select database || '.' || name
+        from system.tables
+        where
+            upper(database) = upper('{{ elementary_schema }}')
+            and lower(name) like '{{ table_name_pattern }}'
+            and metadata_modification_time
+            < now() - tointervalminute({{ (hours | float * 60) | int }})
+    {% endset %}
+    {% if execute %}
+        {% set results = elementary.run_query(query) %}
+        {% do return(
+            results.columns[0].values() if results.rows | length > 0 else []
+        ) %}
+    {% endif %}
+    {% do return([]) %}
+{% endmacro %}
+
+
+{% macro athena__get_stale_test_tables(
+    elementary_database, elementary_schema, hours, table_name_pattern
+) %}
+    {# Athena does not expose table creation time - returning all matching tables #}
+    {% do elementary.edr_log_warning(
+        "get_stale_test_tables: time-based filtering is not supported on Athena. "
+        ~ "All matching temp tables will be returned regardless of age."
+    ) %}
+    {% set schema_relation = api.Relation.create(
+        database=elementary_database, schema=elementary_schema
+    ).without_identifier() %}
+    {% set query %}
+        select table_catalog || '.' || table_schema || '.' || table_name
+        from {{ schema_relation.information_schema("TABLES") }}
+        where
+            upper(table_schema) = upper('{{ elementary_schema }}')
+            and lower(table_name) like '{{ table_name_pattern }}'
+    {% endset %}
+    {% if execute %}
+        {% set results = elementary.run_query(query) %}
+        {% do return(
+            results.columns[0].values() if results.rows | length > 0 else []
+        ) %}
+    {% endif %}
+    {% do return([]) %}
+{% endmacro %}
+
+
+{% macro trino__get_stale_test_tables(
+    elementary_database, elementary_schema, hours, table_name_pattern
+) %}
+    {# Trino does not expose table creation time - returning all matching tables #}
+    {% do elementary.edr_log_warning(
+        "get_stale_test_tables: time-based filtering is not supported on Trino. "
+        ~ "All matching temp tables will be returned regardless of age."
+    ) %}
+    {% set schema_relation = api.Relation.create(
+        database=elementary_database, schema=elementary_schema
+    ).without_identifier() %}
+    {% set query %}
+        select table_catalog || '.' || table_schema || '.' || table_name
+        from {{ schema_relation.information_schema("TABLES") }}
+        where
+            upper(table_schema) = upper('{{ elementary_schema }}')
+            and lower(table_name) like '{{ table_name_pattern }}'
+    {% endset %}
+    {% if execute %}
+        {% set results = elementary.run_query(query) %}
+        {% do return(
+            results.columns[0].values() if results.rows | length > 0 else []
+        ) %}
+    {% endif %}
+    {% do return([]) %}
+{% endmacro %}
+
+
+{% macro duckdb__get_stale_test_tables(
+    elementary_database, elementary_schema, hours, table_name_pattern
+) %}
+    {# DuckDB does not expose table creation time - returning all matching tables #}
+    {% do elementary.edr_log_warning(
+        "get_stale_test_tables: time-based filtering is not supported on DuckDB. "
+        ~ "All matching temp tables will be returned regardless of age."
+    ) %}
+    {% set schema_relation = api.Relation.create(
+        database=elementary_database, schema=elementary_schema
+    ).without_identifier() %}
+    {% set query %}
+        select table_catalog || '.' || table_schema || '.' || table_name
+        from {{ schema_relation.information_schema("TABLES") }}
+        where
+            upper(table_schema) = upper('{{ elementary_schema }}')
+            and lower(table_name) like '{{ table_name_pattern }}'
+    {% endset %}
+    {% if execute %}
+        {% set results = elementary.run_query(query) %}
+        {% do return(
+            results.columns[0].values() if results.rows | length > 0 else []
+        ) %}
+    {% endif %}
+    {% do return([]) %}
+{% endmacro %}
+
+
+{% macro dremio__get_stale_test_tables(
+    elementary_database, elementary_schema, hours, table_name_pattern
+) %}
+    {# Dremio does not expose table creation time - returning all matching tables #}
+    {% do elementary.edr_log_warning(
+        "get_stale_test_tables: time-based filtering is not supported on Dremio. "
+        ~ "All matching temp tables will be returned regardless of age."
+    ) %}
+    {% set schema_relation = api.Relation.create(
+        database=elementary_database, schema=elementary_schema
+    ).without_identifier() %}
+    {% set query %}
+        select table_catalog || '.' || table_schema || '.' || table_name
+        from {{ schema_relation.information_schema("TABLES") }}
+        where
+            upper(table_schema) = upper('{{ elementary_schema }}')
+            and lower(table_name) like '{{ table_name_pattern }}'
+    {% endset %}
+    {% if execute %}
+        {% set results = elementary.run_query(query) %}
+        {% do return(
+            results.columns[0].values() if results.rows | length > 0 else []
+        ) %}
+    {% endif %}
+    {% do return([]) %}
+{% endmacro %}


### PR DESCRIPTION
## Problem

When a pipeline runs many Elementary tests, Elementary creates temporary tables during test execution and cleans them up in `on_run_end`. With a large number of tests (e.g. many sources monitored with `elementary_source_schema_changes`), this cleanup step can add significant time to every pipeline run.

A solution is to disable the automatic cleanup and run it in a dedicated scheduled job instead:

**Step 1:** `clean_elementary_temp_tables` is an existing flag — set it to `false` in `dbt_project.yml`:
```yaml
vars:
  clean_elementary_temp_tables: false
```

**Step 2:** In a separate scheduled job, run:
```bash
dbt run-operation elementary.cleanup_stale_test_tables --args '{"hours": 24}'
```

## What this PR adds

- `cleanup_stale_test_tables(hours, limit)` — new operation that finds and drops temp test tables older than N hours, with an optional row limit (default 2000) to cap each run
- `get_stale_test_tables` — adapter-dispatched macro that queries the warehouse catalog for matching tables; implemented for Snowflake, BigQuery, Databricks, Fabric, SQL Server, Vertica, and ClickHouse (adapters without creation-time support are excluded to avoid accidentally deleting tables from active runs)
- Refactored `clean_elementary_test_tables` to accept an explicit relation list, enabling reuse from both `on_run_end` and the new cleanup operation