### PR TITLE
fix: rename get_incremental_microbatch_sql to capture_microbatch_compiled_code_sql

### DIFF
--- a/integration_tests/tests/test_dbt_artifacts/test_microbatch_compiled_code.py
+++ b/integration_tests/tests/test_dbt_artifacts/test_microbatch_compiled_code.py
@@ -100,7 +100,7 @@ def _with_microbatch_macro_file(dbt_project: DbtProject, macro_name: str):
     macro_path = dbt_project.project_dir_path / "macros" / "microbatch.sql"
     macro_sql = """
 {% macro __MACRO_NAME__(arg_dict) %}
-  {{ return(elementary.capture_microbatch_compiled_code_sql(arg_dict)) }}
+  {{ return(elementary.capture_and_execute_microbatch_compiled_code_sql(arg_dict)) }}
 {% endmacro %}
 """.replace(
         "__MACRO_NAME__", macro_name

--- a/integration_tests/tests/test_dbt_artifacts/test_microbatch_compiled_code.py
+++ b/integration_tests/tests/test_dbt_artifacts/test_microbatch_compiled_code.py
@@ -100,7 +100,7 @@ def _with_microbatch_macro_file(dbt_project: DbtProject, macro_name: str):
     macro_path = dbt_project.project_dir_path / "macros" / "microbatch.sql"
     macro_sql = """
 {% macro __MACRO_NAME__(arg_dict) %}
-  {{ return(elementary.get_incremental_microbatch_sql(arg_dict)) }}
+  {{ return(elementary.capture_microbatch_compiled_code_sql(arg_dict)) }}
 {% endmacro %}
 """.replace(
         "__MACRO_NAME__", macro_name

--- a/macros/edr/dbt_artifacts/microbatch/capture_microbatch_compiled_code.sql
+++ b/macros/edr/dbt_artifacts/microbatch/capture_microbatch_compiled_code.sql
@@ -4,7 +4,7 @@
     incremental strategy resolution in all projects.
     To apply this behavior, users should:
       1) Override `get_incremental_microbatch_sql` in their own project and delegate to
-         `elementary.capture_microbatch_compiled_code_sql(arg_dict)`.
+         `elementary.capture_and_execute_microbatch_compiled_code_sql(arg_dict)`.
       2) Enable dbt behavior flag `require_batched_execution_for_custom_microbatch_strategy`.
 
     This flow is currently not supported for adapters:
@@ -17,7 +17,7 @@
 
     This flow is currently not supported for dbt Fusion.
 -#}
-{% macro capture_microbatch_compiled_code_sql(arg_dict) %}
+{% macro capture_and_execute_microbatch_compiled_code_sql(arg_dict) %}
     {% if execute and model is defined %}
         {% do elementary.capture_microbatch_compiled_code_for_model() %}
     {% endif %}
@@ -46,4 +46,3 @@
     {% endif %}
     {% do compiled_code_by_unique_id.update({model_unique_id: model_compiled_code}) %}
 {% endmacro %}
-

--- a/macros/edr/dbt_artifacts/microbatch/capture_microbatch_compiled_code.sql
+++ b/macros/edr/dbt_artifacts/microbatch/capture_microbatch_compiled_code.sql
@@ -4,7 +4,7 @@
     incremental strategy resolution in all projects.
     To apply this behavior, users should:
       1) Override `get_incremental_microbatch_sql` in their own project and delegate to
-         `elementary.get_incremental_microbatch_sql(arg_dict)`.
+         `elementary.capture_microbatch_compiled_code_sql(arg_dict)`.
       2) Enable dbt behavior flag `require_batched_execution_for_custom_microbatch_strategy`.
 
     This flow is currently not supported for adapters:
@@ -17,7 +17,7 @@
 
     This flow is currently not supported for dbt Fusion.
 -#}
-{% macro get_incremental_microbatch_sql(arg_dict) %}
+{% macro capture_microbatch_compiled_code_sql(arg_dict) %}
     {% if execute and model is defined %}
         {% do elementary.capture_microbatch_compiled_code_for_model() %}
     {% endif %}
@@ -46,3 +46,4 @@
     {% endif %}
     {% do compiled_code_by_unique_id.update({model_unique_id: model_compiled_code}) %}
 {% endmacro %}
+


### PR DESCRIPTION
## Problem

Installing Elementary inadvertently broke microbatch execution for all users, even those who never set up the compiled code capture feature.

**Root cause:** dbt 1.9+ has two separate lookups for the `get_incremental_microbatch_sql` macro:
1. **Strategy execution** — only searches root project + dbt-core (packages are NOT searched). This is why users need to create a root project wrapper.
2. **`_microbatch_macro_is_core()` check** — searches ALL packages. If it finds the macro anywhere with non-Core locality, it returns `False`, causing `use_microbatch_batches()` to return `False`.

Because Elementary's package defined `get_incremental_microbatch_sql` (unprefixed), the `_microbatch_macro_is_core()` check found it with `locality=Imported` and disabled batched execution for **any user with Elementary installed** who hadn't set `require_batched_execution_for_custom_microbatch_strategy: True` — even if they weren't using the compiled code feature at all.

Our e2e tests missed this because we globally set `require_batched_execution_for_custom_microbatch_strategy: True` in the integration test `dbt_project.yml`, which bypasses the `_microbatch_macro_is_core()` gate entirely.

## Fix

Rename the package-level macro from `get_incremental_microbatch_sql` to `capture_microbatch_compiled_code_sql`. This means:
- Elementary no longer defines a macro with the reserved name `get_incremental_microbatch_sql` at the package level
- `_microbatch_macro_is_core()` no longer finds Elementary's macro for users who haven't opted in → microbatch works normally
- Users who opt in still create a root project wrapper (name unchanged: `get_incremental_microbatch_sql`) that calls `elementary.capture_microbatch_compiled_code_sql` — same behavior, no functional regression

## Changes
- `macros/edr/dbt_artifacts/microbatch/capture_microbatch_compiled_code.sql`: rename macro
- `integration_tests/tests/test_dbt_artifacts/test_microbatch_compiled_code.py`: update call to new macro name

## Breaking change
Users who already set up the compiled code feature need to update their root project macro to call `elementary.capture_microbatch_compiled_code_sql` instead of `elementary.get_incremental_microbatch_sql`. This feature is very new so we expect minimal impact. Docs PR: elementary-data/elementary (docs branch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the microbatch compilation macro to clearer naming that matches its capture-and-execute purpose.
  * Updated the integration test harness to use the new macro name.

* **Bug Fixes**
  * Corrected the handling of `compiled_code` population in the “with override” scenario versus the “without override” scenario.

* **Documentation**
  * Refreshed guidance explaining how to override the delegation macro for capturing microbatch compiled code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->