### PR TITLE
perf: eliminate schema_changes_alerts temp table to reduce concurrent DDL

### DIFF
--- a/macros/edr/tests/test_schema_changes.sql
+++ b/macros/edr/tests/test_schema_changes.sql
@@ -62,25 +62,14 @@
                 "schema_changes_alert_query - \n" ~ schema_changes_alert_query
             )
         }}
-        {% set alerts_temp_table_relation = elementary.create_elementary_test_table(
-            database_name,
-            tests_schema_name,
-            test_table_name,
-            "schema_changes_alerts",
-            schema_changes_alert_query,
-        ) %}
-
         {% set flattened_test = elementary.flatten_test(elementary.get_test_model()) %}
-        {% set schema_changes_sql = "select * from {}".format(
-            alerts_temp_table_relation
-        ) %}
         {% do elementary.store_schema_snapshot_tables_in_cache() %}
         {% do elementary.store_schema_test_results(
-            flattened_test, schema_changes_sql
+            flattened_test, schema_changes_alert_query
         ) %}
 
         {# return schema changes query as standard test query #}
-        {{ schema_changes_sql }}
+        {{ schema_changes_alert_query }}
 
     {% else %}
 


### PR DESCRIPTION
## Summary

Each `schema_changes` test was creating a `__schema_changes_alerts__tmp` persistent table solely as an intermediary — `store_schema_test_results` read from it immediately and the test assertion selected from it directly. This table served no purpose beyond being a short-lived middleman.

With many monitored sources running in parallel (e.g. 37 sources × 2 tables = 74 simultaneous `CREATE OR REPLACE TABLE` DDL operations on the shared `ELEMENTARY` schema), Snowflake's internal metadata catalog becomes overloaded. This triggered a non-actionable Snowflake fault with a **245-second retry** on one query, confirmed via `fault_handling_time` in `ACCOUNT_USAGE.QUERY_HISTORY`:

| Metric | Value |
|---|---|
| `total_elapsed_time` | 246.86s |
| `execution_time` | 1.24s |
| `fault_handling_time` | **245.11s** |
| `partitions_scanned > partitions_total` | confirms multi-attempt retry |
| Concurrent DDL count at fault moment | **31** |

## Fix

Run the alert query inline instead of materializing it into a temp table — matching the pattern already used by `test_schema_changes_from_baseline`, which has always worked this way.

- **Before:** `CREATE OR REPLACE TABLE __schema_changes_alerts__tmp AS {alert_query}` → `SELECT * FROM that_table`
- **After:** pass `schema_changes_alert_query` directly to `store_schema_test_results` and return it as the test assertion

`store_schema_test_results` already calls `run_query(sql)` internally, so it handles a raw query string just as well as a `SELECT * FROM table`.

## Impact

- DDL operations per run: **74 → 37** (halved)
- No functional change — same query results, same caching behaviour, same test pass/fail logic
- Minimal diff: 13 lines removed, 2 lines changed

## Related

- Linear: [CORE-1042](https://linear.app/elementary/issue/CORE-1042) (sub-issue of [CORE-1041](https://linear.app/elementary/issue/CORE-1041))

## Test plan

- [ ] Run `test_schema_changes` integration test — should detect column_added, column_removed, type_changed as before
- [ ] Verify `elementary_test_results` is populated correctly in `on_run_end`
- [ ] Verify no `__schema_changes_alerts__tmp` tables are created in the Elementary schema

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized schema change detection test for improved efficiency and streamlined result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->