### PR TITLE
Add Dependency Review GitHub Action

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -4,6 +4,7 @@ allow-licenses:
   - MIT-0
   - Apache-2.0
   - BSD-2-Clause
+  - BSD-2-Clause-Views
   - BSD-3-Clause
   - ISC
   - PSF-2.0
@@ -44,4 +45,8 @@ allow-dependencies-licenses:
   - pkg:pypi/lxml
   - pkg:pypi/python-gitlab
   - pkg:pypi/text-unidecode
+  - pkg:pypi/python-daemon
+  - pkg:pypi/rfc3987-syntax
+  - pkg:pypi/types-sqlalchemy-utils
   - pkg:pypi/typing-extensions
+  - pkg:pypi/wirerope

--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,47 @@
+# Permissive licenses
+allow-licenses:
+  - MIT
+  - MIT-0
+  - Apache-2.0
+  - BSD-2-Clause
+  - BSD-3-Clause
+  - ISC
+  - PSF-2.0
+  - Python-2.0
+  - CNRI-Python
+  - 0BSD
+  - BlueOak-1.0.0
+  - CC0-1.0
+  - CC-BY-3.0
+  - CC-BY-4.0
+  - Unlicense
+  - NCSA
+  - ZPL-2.1
+  - HPND-Markus-Kuhn
+  - Artistic-2.0
+  - Artistic-1.0-Perl
+  # Permissive licenses without official SPDX IDs (ScanCode identifiers)
+  - LicenseRef-scancode-public-domain
+  - LicenseRef-scancode-public-domain-disclaimer
+  - LicenseRef-scancode-protobuf
+  # Weak copyleft (LGPL/MPL) — safe as libraries in commercial software
+  - MPL-2.0
+  - LGPL-2.1-only
+  - LGPL-2.1-or-later
+  - LGPL-3.0-only
+  - LGPL-3.0-or-later
+  - LGPL-3.0
+
+fail-on-severity: high
+
+# Packages with GPL in compound license expressions that are actually
+# safe (dual-licensed, LGPL, or CPython license boilerplate).
+# These are exempted individually so that genuinely GPL-only packages
+# are still blocked.
+allow-dependencies-licenses:
+  - pkg:pypi/aiohappyeyeballs
+  - pkg:pypi/gitdb
+  - pkg:pypi/lxml
+  - pkg:pypi/python-gitlab
+  - pkg:pypi/text-unidecode
+  - pkg:pypi/typing-extensions

--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -34,19 +34,3 @@ allow-licenses:
   - LGPL-3.0
 
 fail-on-severity: high
-
-# Packages with GPL in compound license expressions that are actually
-# safe (dual-licensed, LGPL, or CPython license boilerplate).
-# These are exempted individually so that genuinely GPL-only packages
-# are still blocked.
-allow-dependencies-licenses:
-  - pkg:pypi/aiohappyeyeballs
-  - pkg:pypi/gitdb
-  - pkg:pypi/lxml
-  - pkg:pypi/python-gitlab
-  - pkg:pypi/text-unidecode
-  - pkg:pypi/python-daemon
-  - pkg:pypi/rfc3987-syntax
-  - pkg:pypi/types-sqlalchemy-utils
-  - pkg:pypi/typing-extensions
-  - pkg:pypi/wirerope

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -36,10 +36,16 @@ jobs:
             MPL-2.0, NCSA, ZPL-2.1, HPND-Markus-Kuhn,
             LGPL-2.1-only, LGPL-2.1-or-later,
             LGPL-3.0-only, LGPL-3.0-or-later, LGPL-3.0,
-            GPL-1.0-only, GPL-1.0-or-later,
-            GPL-2.0-only, GPL-2.0-or-later,
-            GPL-3.0-only, GPL-3.0-or-later,
             Artistic-2.0, Artistic-1.0-Perl,
             LicenseRef-scancode-public-domain,
             LicenseRef-scancode-public-domain-disclaimer,
             LicenseRef-scancode-protobuf
+          # Packages with GPL in compound license expressions that are actually
+          # safe (dual-licensed, LGPL, or CPython license boilerplate).
+          allow-dependencies-licenses: >-
+            pkg:pypi/aiohappyeyeballs,
+            pkg:pypi/gitdb,
+            pkg:pypi/lxml,
+            pkg:pypi/python-gitlab,
+            pkg:pypi/text-unidecode,
+            pkg:pypi/typing-extensions

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -30,10 +30,20 @@ jobs:
           base-ref: ${{ inputs.base-ref || '' }}
           head-ref: ${{ inputs.head-ref || '' }}
           allow-licenses: >-
-            MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC,
-            PSF-2.0, Python-2.0, 0BSD, BlueOak-1.0.0,
+            MIT, MIT-0, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC,
+            PSF-2.0, Python-2.0, CNRI-Python, 0BSD, BlueOak-1.0.0,
             CC0-1.0, CC-BY-3.0, CC-BY-4.0, Unlicense,
-            MPL-2.0,
+            MPL-2.0, NCSA, ZPL-2.1, HPND-Markus-Kuhn,
             LGPL-2.1-only, LGPL-2.1-or-later,
-            LGPL-3.0-only, LGPL-3.0-or-later,
-            Artistic-2.0
+            LGPL-3.0-only, LGPL-3.0-or-later, LGPL-3.0,
+            GPL-1.0-only, GPL-1.0-or-later,
+            GPL-2.0-only, GPL-2.0-or-later,
+            GPL-3.0-only, GPL-3.0-or-later,
+            Artistic-2.0, Artistic-1.0-Perl,
+            LicenseRef-scancode-public-domain,
+            LicenseRef-scancode-public-domain-disclaimer,
+            LicenseRef-scancode-protobuf
+          deny-licenses: >-
+            AGPL-3.0-only, AGPL-3.0-or-later,
+            SSPL-1.0, BUSL-1.1,
+            Elastic-2.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
         with:
+          fail-on-severity: high
           base-ref: ${{ inputs.base-ref || '' }}
           head-ref: ${{ inputs.head-ref || '' }}
           allow-licenses: >-

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -29,19 +29,25 @@ jobs:
           fail-on-severity: high
           base-ref: ${{ inputs.base-ref || '' }}
           head-ref: ${{ inputs.head-ref || '' }}
+          # Permissive licenses
+          # Weak copyleft (LGPL/MPL) — safe for commercial use, even BYOC
+          # LicenseRef-scancode-* — permissive licenses without official SPDX IDs
           allow-licenses: >-
             MIT, MIT-0, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC,
             PSF-2.0, Python-2.0, CNRI-Python, 0BSD, BlueOak-1.0.0,
             CC0-1.0, CC-BY-3.0, CC-BY-4.0, Unlicense,
-            MPL-2.0, NCSA, ZPL-2.1, HPND-Markus-Kuhn,
-            LGPL-2.1-only, LGPL-2.1-or-later,
-            LGPL-3.0-only, LGPL-3.0-or-later, LGPL-3.0,
+            NCSA, ZPL-2.1, HPND-Markus-Kuhn,
             Artistic-2.0, Artistic-1.0-Perl,
             LicenseRef-scancode-public-domain,
             LicenseRef-scancode-public-domain-disclaimer,
-            LicenseRef-scancode-protobuf
+            LicenseRef-scancode-protobuf,
+            MPL-2.0,
+            LGPL-2.1-only, LGPL-2.1-or-later,
+            LGPL-3.0-only, LGPL-3.0-or-later, LGPL-3.0
           # Packages with GPL in compound license expressions that are actually
           # safe (dual-licensed, LGPL, or CPython license boilerplate).
+          # These are exempted individually so that genuinely GPL-only packages
+          # are still blocked.
           allow-dependencies-licenses: >-
             pkg:pypi/aiohappyeyeballs,
             pkg:pypi/gitdb,

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,5 +1,15 @@
 name: Dependency Review
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      base-ref:
+        description: Base git ref for comparison (e.g. a tag or commit SHA)
+        required: true
+      head-ref:
+        description: Head git ref for comparison (defaults to HEAD)
+        required: false
+        default: HEAD
 
 permissions: {}
 
@@ -16,6 +26,8 @@ jobs:
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
         with:
+          base-ref: ${{ inputs.base-ref || '' }}
+          head-ref: ${{ inputs.head-ref || '' }}
           allow-licenses: >-
             MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC,
             PSF-2.0, Python-2.0, 0BSD, BlueOak-1.0.0,

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,5 +1,5 @@
 name: Dependency Review
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 
 permissions: {}
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -43,7 +43,3 @@ jobs:
             LicenseRef-scancode-public-domain,
             LicenseRef-scancode-public-domain-disclaimer,
             LicenseRef-scancode-protobuf
-          deny-licenses: >-
-            AGPL-3.0-only, AGPL-3.0-or-later,
-            SSPL-1.0, BUSL-1.1,
-            Elastic-2.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,3 +15,12 @@ jobs:
           persist-credentials: false
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
+        with:
+          allow-licenses: >-
+            MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC,
+            PSF-2.0, Python-2.0, 0BSD, BlueOak-1.0.0,
+            CC0-1.0, CC-BY-3.0, CC-BY-4.0, Unlicense,
+            MPL-2.0,
+            LGPL-2.1-only, LGPL-2.1-or-later,
+            LGPL-3.0-only, LGPL-3.0-or-later,
+            Artistic-2.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -26,32 +26,6 @@ jobs:
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
         with:
-          fail-on-severity: high
           base-ref: ${{ inputs.base-ref || '' }}
           head-ref: ${{ inputs.head-ref || '' }}
-          # Permissive licenses
-          # Weak copyleft (LGPL/MPL) — safe for commercial use, even BYOC
-          # LicenseRef-scancode-* — permissive licenses without official SPDX IDs
-          allow-licenses: >-
-            MIT, MIT-0, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC,
-            PSF-2.0, Python-2.0, CNRI-Python, 0BSD, BlueOak-1.0.0,
-            CC0-1.0, CC-BY-3.0, CC-BY-4.0, Unlicense,
-            NCSA, ZPL-2.1, HPND-Markus-Kuhn,
-            Artistic-2.0, Artistic-1.0-Perl,
-            LicenseRef-scancode-public-domain,
-            LicenseRef-scancode-public-domain-disclaimer,
-            LicenseRef-scancode-protobuf,
-            MPL-2.0,
-            LGPL-2.1-only, LGPL-2.1-or-later,
-            LGPL-3.0-only, LGPL-3.0-or-later, LGPL-3.0
-          # Packages with GPL in compound license expressions that are actually
-          # safe (dual-licensed, LGPL, or CPython license boilerplate).
-          # These are exempted individually so that genuinely GPL-only packages
-          # are still blocked.
-          allow-dependencies-licenses: >-
-            pkg:pypi/aiohappyeyeballs,
-            pkg:pypi/gitdb,
-            pkg:pypi/lxml,
-            pkg:pypi/python-gitlab,
-            pkg:pypi/text-unidecode,
-            pkg:pypi/typing-extensions
+          config-file: ./.github/dependency-review-config.yml

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,5 +11,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Dependency Review
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,15 @@
+name: Dependency Review
+on: [pull_request]
+
+permissions: {}
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4


### PR DESCRIPTION
## Summary

Adds `actions/dependency-review-action@v4` workflow to scan PRs for vulnerable or improperly-licensed dependency changes.

- Triggers on `pull_request` and `workflow_dispatch` (manual runs require `base-ref` input, e.g. a tag or commit SHA, to define the comparison range; `head-ref` defaults to HEAD)
- `fail-on-severity: high` — only blocks PRs on HIGH/CRITICAL vulnerabilities (moderate/low reported but don't fail)
- `persist-credentials: false` on checkout for security
- License enforcement via `allow-licenses` allowlist covering permissive (MIT, Apache-2.0, BSD, ISC, etc.) and weak copyleft (LGPL, MPL-2.0) — blocks strong copyleft (GPL, AGPL), proprietary, SSPL, BUSL, Elastic, and any other unlisted license

Link to Devin session: https://app.devin.ai/sessions/0f830b140bd8488797ab340ef05dc88f
Requested by: @haritamar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated dependency review checks for pull requests.
  * Introduced configurable dependency/license policy settings to help keep dependency changes compliant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->