### PR TITLE
fix: include all failing dimension values in anomaly alert description

### DIFF
--- a/integration_tests/tests/test_column_anomalies.py
+++ b/integration_tests/tests/test_column_anomalies.py
@@ -317,6 +317,10 @@ def test_column_anomalies_group_by(test_id: str, dbt_project: DbtProject):
 
     assert test_result["status"] == "fail"
     assert test_result["failures"] == 1
+    description = test_result["test_results_description"].lower()
+    assert "1 anomalous" in description
+    assert "for dimension dimension" in description
+    assert "dim1" in description
 
     data += [
         {
@@ -336,6 +340,11 @@ def test_column_anomalies_group_by(test_id: str, dbt_project: DbtProject):
 
     assert test_result["status"] == "fail"
     assert test_result["failures"] == 2
+    description = test_result["test_results_description"].lower()
+    assert "2 anomalous" in description
+    assert "for dimension dimension" in description
+    assert "dim1" in description
+    assert "dim2" in description
 
 
 def test_anomalyless_column_anomalies_group_by_none_dimension(

--- a/macros/edr/data_monitoring/anomaly_detection/store_anomaly_test_results.sql
+++ b/macros/edr/data_monitoring/anomaly_detection/store_anomaly_test_results.sql
@@ -91,8 +91,18 @@
         {% set first_scored_row = rows_with_score[0] %}
         {% set dimension = elementary.insensitive_get_dict_value(first_scored_row, 'dimension') %}
         {% if dimension and anomalous_rows %}
+          {% set seen_dim_vals = [] %}
+          {% set unique_anomalous_rows = [] %}
+          {% for row in anomalous_rows | reverse %}
+            {% set dim_val = elementary.insensitive_get_dict_value(row, 'dimension_value') %}
+            {% set dim_key = dim_val if dim_val is not none else '__NULL__' %}
+            {% if dim_key not in seen_dim_vals %}
+              {% do seen_dim_vals.append(dim_key) %}
+              {% do unique_anomalous_rows.append(row) %}
+            {% endif %}
+          {% endfor %}
           {% set max_shown = 5 %}
-          {% set shown_rows = anomalous_rows[:max_shown] %}
+          {% set shown_rows = unique_anomalous_rows[:max_shown] %}
           {% set dim_parts = [] %}
           {% for row in shown_rows %}
             {% set dim_val = elementary.insensitive_get_dict_value(row, 'dimension_value') %}
@@ -103,7 +113,7 @@
             {% set t_str = (t_val | float | round(3)) if t_val is not none else 'N/A' %}
             {% do dim_parts.append(dim_val_str ~ " (" ~ m_str ~ ", avg " ~ t_str ~ ")") %}
           {% endfor %}
-          {% set total = anomalous_rows | length %}
+          {% set total = unique_anomalous_rows | length %}
           {% if column_name %}In column {{ column_name | upper }}, {% endif %}{{ total }} anomalous {{ metric_name }} value{% if total > 1 %}s{% endif %} for dimension {{ dimension }}: {{ dim_parts | join(", ") }}{% if total > max_shown %}, and {{ total - max_shown }} more{% endif %}.
         {% else %}
           {{ elementary.insensitive_get_dict_value(rows_with_score[-1], 'anomaly_description') }}

--- a/macros/edr/data_monitoring/anomaly_detection/store_anomaly_test_results.sql
+++ b/macros/edr/data_monitoring/anomaly_detection/store_anomaly_test_results.sql
@@ -74,23 +74,44 @@
           and upper(column_name) = upper({{ elementary.const_as_string(column_name) }})
         {%- endif %}
     {%- endset -%}
-    {% set test_results_description %}
-      {% if rows_with_score %}
-          {{ elementary.insensitive_get_dict_value(rows_with_score[-1], 'anomaly_description') }}
-      {% else %}
-          Not enough data to calculate anomaly score.
-      {% endif %}
-    {% endset %}
     {% set failures = namespace(data=0) %}
     {% set filtered_anomaly_scores_rows = [] %}
+    {% set anomalous_rows = [] %}
     {% for row in anomaly_scores_rows %}
         {% if row.anomaly_score is not none %}
             {% do filtered_anomaly_scores_rows.append(row) %}
             {% if row.is_anomalous %}
                 {% set failures.data = failures.data + 1 %}
+                {% do anomalous_rows.append(row) %}
             {% endif %}
         {% endif %}
     {% endfor %}
+    {% set test_results_description %}
+      {% if rows_with_score %}
+        {% set first_scored_row = rows_with_score[0] %}
+        {% set dimension = elementary.insensitive_get_dict_value(first_scored_row, 'dimension') %}
+        {% if dimension and anomalous_rows %}
+          {% set max_shown = 5 %}
+          {% set shown_rows = anomalous_rows[:max_shown] %}
+          {% set dim_parts = [] %}
+          {% for row in shown_rows %}
+            {% set dim_val = elementary.insensitive_get_dict_value(row, 'dimension_value') %}
+            {% set dim_val_str = dim_val if dim_val is not none else 'NULL' %}
+            {% set m_val = elementary.insensitive_get_dict_value(row, 'metric_value') %}
+            {% set t_val = elementary.insensitive_get_dict_value(row, 'training_avg') %}
+            {% set m_str = (m_val | float | round(3)) if m_val is not none else 'N/A' %}
+            {% set t_str = (t_val | float | round(3)) if t_val is not none else 'N/A' %}
+            {% do dim_parts.append(dim_val_str ~ " (" ~ m_str ~ ", avg " ~ t_str ~ ")") %}
+          {% endfor %}
+          {% set total = anomalous_rows | length %}
+          {% if column_name %}In column {{ column_name | upper }}, {% endif %}{{ total }} anomalous {{ metric_name }} value{% if total > 1 %}s{% endif %} for dimension {{ dimension }}: {{ dim_parts | join(", ") }}{% if total > max_shown %}, and {{ total - max_shown }} more{% endif %}.
+        {% else %}
+          {{ elementary.insensitive_get_dict_value(rows_with_score[-1], 'anomaly_description') }}
+        {% endif %}
+      {% else %}
+          Not enough data to calculate anomaly score.
+      {% endif %}
+    {% endset %}
     {% set test_result_dict = {
         "id": elementary.insensitive_get_dict_value(latest_row, "id"),
         "data_issue_id": elementary.insensitive_get_dict_value(

--- a/macros/edr/data_monitoring/anomaly_detection/store_anomaly_test_results.sql
+++ b/macros/edr/data_monitoring/anomaly_detection/store_anomaly_test_results.sql
@@ -88,19 +88,13 @@
     {% endfor %}
     {% set test_results_description %}
       {% if rows_with_score %}
-        {% set first_scored_row = rows_with_score[0] %}
-        {% set dimension = elementary.insensitive_get_dict_value(first_scored_row, 'dimension') %}
-        {% if dimension and anomalous_rows %}
-          {% set seen_dim_vals = [] %}
-          {% set unique_anomalous_rows = [] %}
-          {% for row in anomalous_rows | reverse %}
-            {% set dim_val = elementary.insensitive_get_dict_value(row, 'dimension_value') %}
-            {% set dim_key = dim_val if dim_val is not none else '__NULL__' %}
-            {% if dim_key not in seen_dim_vals %}
-              {% do seen_dim_vals.append(dim_key) %}
-              {% do unique_anomalous_rows.append(row) %}
-            {% endif %}
-          {% endfor %}
+        {% set dimension = elementary.insensitive_get_dict_value(anomalous_rows[0], 'dimension') if anomalous_rows else none %}
+        {% if dimension %}
+          {# The anomaly scores query has no "order by", so sort explicitly to keep the latest bucket per dimension value #}
+          {% set unique_anomalous_rows = anomalous_rows
+              | sort(attribute='bucket_end', reverse=true)
+              | unique(case_sensitive=true, attribute='dimension_value')
+              | list %}
           {% set max_shown = 5 %}
           {% set shown_rows = unique_anomalous_rows[:max_shown] %}
           {% set dim_parts = [] %}
@@ -109,6 +103,7 @@
             {% set dim_val_str = dim_val if dim_val is not none else 'NULL' %}
             {% set m_val = elementary.insensitive_get_dict_value(row, 'metric_value') %}
             {% set t_val = elementary.insensitive_get_dict_value(row, 'training_avg') %}
+            {# Rounding must stay consistent with anomaly_detection_description(), which formats the per-row descriptions in SQL #}
             {% set m_str = (m_val | float | round(3)) if m_val is not none else 'N/A' %}
             {% set t_str = (t_val | float | round(3)) if t_val is not none else 'N/A' %}
             {% do dim_parts.append(dim_val_str ~ " (" ~ m_str ~ ", avg " ~ t_str ~ ")") %}


### PR DESCRIPTION
## Summary

- Anomaly alerts for dimension-based tests (e.g. `column_anomalies` with `dimensions`) previously showed only a single arbitrary dimension value in the result message
- Now the alert lists all failing dimension values with their metric value and average, truncated to 5 with an "and N more" suffix when there are many failures
- Dimension values are deduplicated (rows are bucket-based so the same dimension value can appear across multiple time buckets; we keep the latest row per value)
- Example new format: `In column INCIDENTS_OPENED, 2 anomalous max values for dimension account_name: Joejuice (214.0, avg 21.0), Acme (15.0, avg 6.3).`
- Non-dimension tests are unaffected (fall back to existing single-row description)

## Test plan

- [x] Added assertions to `test_column_anomalies_group_by` to verify the description format for 1 and 2 failing dimension values
- [x] Verified locally against a real `column_anomalies` test with `dimensions` -- alert now shows all failing dimension values

before and after screenshots:
<img width="842" height="522" alt="Screenshot 2026-06-28 at 14 14 54" src="https://github.com/user-attachments/assets/7b224f77-e9ea-4158-8acc-83c231342b85" />
<img width="884" height="520" alt="Screenshot 2026-06-28 at 14 14 40" src="https://github.com/user-attachments/assets/edc062d0-24f2-4ebe-9d76-018a4fe3cb36" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved anomaly test result summaries to provide clearer, dimension-aware details (including anomalous count and relevant dimension values, with metric comparison context).
  * Updated the summary generation logic to include a richer description when dimension-based anomalies are present, with a sensible fallback otherwise.
* **Tests**
  * Expanded the column anomalies grouping test with more granular assertions to verify the updated description content under different anomaly sensitivity settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->