### PR TITLE
feat: Use ClickHouse lightweight deletes

### DIFF
--- a/macros/utils/table_operations/delete_and_insert.sql
+++ b/macros/utils/table_operations/delete_and_insert.sql
@@ -84,7 +84,7 @@
 
     {% if delete_relation %}
         {% set delete_query %}
-            alter table {{ relation }} {{ on_cluster_clause(relation) }} delete where
+            delete from {{ relation }} {{ on_cluster_clause(relation) }} where
             {{ delete_column_key }} is null
             or {{ delete_column_key }} in (select {{ delete_column_key }} from {{ delete_relation }})
             {{ adapter.get_model_query_settings(model) }};


### PR DESCRIPTION
# feat: Use lightweight deletes in ClickHouse

## Summary

Replaces `ALTER TABLE ... DELETE WHERE` with `DELETE FROM ... WHERE` (lightweight delete) in the ClickHouse `delete_and_insert` macro.

### Background

Elementary's `delete_and_insert` macro previously deleted rows in ClickHouse using `ALTER TABLE ... DELETE WHERE`, which triggers a heavy background mutation. Mutations are resource-intensive — they rewrite entire data parts and can lag behind inserts on large tables, causing contention and slow Elementary runs.

Lightweight deletes (`DELETE FROM ... WHERE`) became GA in ClickHouse 23.3. They work differently: rows are marked with a bitmask and resolved lazily at merge time, making the delete step significantly faster. Since dbt-clickhouse only supports ClickHouse 25.3+, every supported version has lightweight deletes on by default — no server configuration needed.

## Changes

- **`macros/utils/table_operations/delete_and_insert.sql`** — `ALTER TABLE ... DELETE WHERE` → `DELETE FROM ... ON CLUSTER ... WHERE`.

## Testing

- Tested against a ClickHouse instance running Elementary monitoring tables


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated ClickHouse row deletion operations to use standard `DELETE FROM` statements while preserving existing row-matching behavior.
  * Insert operations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->