### PR TITLE
CORE-1210: optimize insert_rows / render_row_to_sql Jinja path (Fusion artifact upload slowdown)

### DIFF
--- a/integration_tests/dbt_project/macros/test_render_insert_rows_queries.sql
+++ b/integration_tests/dbt_project/macros/test_render_insert_rows_queries.sql
@@ -1,0 +1,37 @@
+{% macro test_render_insert_rows_queries(query_max_size=none, chunk_size=5000) %}
+    {% set columns = [
+        {"name": "name", "dtype": "varchar"},
+        {"name": "int_col", "dtype": "integer"},
+        {"name": "float_col", "dtype": "float"},
+        {"name": "bool_col", "dtype": "boolean"},
+        {"name": "json_col", "dtype": "varchar"},
+        {"name": "null_col", "dtype": "varchar"},
+        {"name": "created_at", "dtype": "timestamp"},
+    ] %}
+    {% set rows = [
+        {
+            "name": "O'Brien",
+            "int_col": 42,
+            "float_col": 3.14,
+            "bool_col": true,
+            "json_col": {"a": 1, "b": [1, 2]},
+            "null_col": none,
+        },
+        {
+            "name": "second",
+            "int_col": 0,
+            "float_col": -1.5,
+            "bool_col": false,
+            "json_col": [1, "x"],
+            "null_col": "here",
+        },
+    ] %}
+    {% set queries = elementary.get_insert_rows_queries(
+        "my_table",
+        columns,
+        rows,
+        query_max_size=query_max_size,
+        chunk_size=chunk_size,
+    ) %}
+    {% do return(queries) %}
+{% endmacro %}

--- a/integration_tests/dbt_project/macros/test_render_insert_rows_queries.sql
+++ b/integration_tests/dbt_project/macros/test_render_insert_rows_queries.sql
@@ -33,5 +33,12 @@
         query_max_size=query_max_size,
         chunk_size=chunk_size,
     ) %}
-    {% do return(queries) %}
+    {# Return the adapter-escaped literal alongside the queries so assertions can
+       stay adapter-aware (escaping differs per warehouse, e.g. '' vs \'). #}
+    {% do return(
+        {
+            "queries": queries,
+            "escaped_quote_name": elementary.escape_special_chars("O'Brien"),
+        }
+    ) %}
 {% endmacro %}

--- a/integration_tests/dbt_project/macros/test_render_insert_rows_queries.sql
+++ b/integration_tests/dbt_project/macros/test_render_insert_rows_queries.sql
@@ -1,31 +1,6 @@
-{% macro test_render_insert_rows_queries(query_max_size=none, chunk_size=5000) %}
-    {% set columns = [
-        {"name": "name", "dtype": "varchar"},
-        {"name": "int_col", "dtype": "integer"},
-        {"name": "float_col", "dtype": "float"},
-        {"name": "bool_col", "dtype": "boolean"},
-        {"name": "json_col", "dtype": "varchar"},
-        {"name": "null_col", "dtype": "varchar"},
-        {"name": "created_at", "dtype": "timestamp"},
-    ] %}
-    {% set rows = [
-        {
-            "name": "O'Brien",
-            "int_col": 42,
-            "float_col": 3.14,
-            "bool_col": true,
-            "json_col": {"a": 1, "b": [1, 2]},
-            "null_col": none,
-        },
-        {
-            "name": "second",
-            "int_col": 0,
-            "float_col": -1.5,
-            "bool_col": false,
-            "json_col": [1, "x"],
-            "null_col": "here",
-        },
-    ] %}
+{% macro test_render_insert_rows_queries(
+    columns, rows, escape_sample, query_max_size=none, chunk_size=5000
+) %}
     {% set queries = elementary.get_insert_rows_queries(
         "my_table",
         columns,
@@ -38,7 +13,9 @@
     {% do return(
         {
             "queries": queries,
-            "escaped_quote_name": elementary.escape_special_chars("O'Brien"),
+            "escaped_quote_name": elementary.escape_special_chars(
+                escape_sample
+            ),
         }
     ) %}
 {% endmacro %}

--- a/integration_tests/tests/test_dbt_artifacts/test_insert_rows.py
+++ b/integration_tests/tests/test_dbt_artifacts/test_insert_rows.py
@@ -1,0 +1,40 @@
+import json
+
+from dbt_project import DbtProject
+
+
+def _get_queries(dbt_project: DbtProject, **macro_args):
+    result = dbt_project.dbt_runner.run_operation(
+        "elementary_tests.test_render_insert_rows_queries",
+        macro_args=macro_args,
+    )
+    return json.loads(result[0])
+
+
+def test_render_insert_rows_queries_values(dbt_project: DbtProject):
+    queries = _get_queries(dbt_project)
+
+    # Large default query_max_size / chunk_size -> everything fits in one query.
+    assert len(queries) == 1
+    query = queries[0]
+
+    # String with a single quote is escaped and quoted.
+    assert "'O''Brien'" in query
+    # Numbers render without quotes.
+    assert "42" in query
+    assert "-1.5" in query
+    # NULL for a none value, rendered unquoted.
+    assert "null" in query.lower()
+    # Nested mapping / sequence serialized via tojson into a quoted string.
+    assert '\'{"a": 1, "b": [1, 2]}\'' in query
+    assert "'[1, \"x\"]'" in query
+    # Both rows are present, joined into a single VALUES list.
+    assert query.count("'second'") == 1
+
+
+def test_render_insert_rows_queries_chunking(dbt_project: DbtProject):
+    # chunk_size=1 forces each row into its own query.
+    queries = _get_queries(dbt_project, chunk_size=1)
+    assert len(queries) == 2
+    assert "'O''Brien'" in queries[0]
+    assert "'second'" in queries[1]

--- a/integration_tests/tests/test_dbt_artifacts/test_insert_rows.py
+++ b/integration_tests/tests/test_dbt_artifacts/test_insert_rows.py
@@ -3,23 +3,27 @@ import json
 from dbt_project import DbtProject
 
 
-def _get_queries(dbt_project: DbtProject, **macro_args):
+def _render(dbt_project: DbtProject, **macro_args):
     result = dbt_project.dbt_runner.run_operation(
         "elementary_tests.test_render_insert_rows_queries",
         macro_args=macro_args,
     )
-    return json.loads(result[0])
+    output = json.loads(result[0])
+    # Escaping differs per adapter ('' vs \'), so derive the expected quoted
+    # literal from the adapter instead of hardcoding it.
+    name_literal = "'{}'".format(output["escaped_quote_name"])
+    return output["queries"], name_literal
 
 
 def test_render_insert_rows_queries_values(dbt_project: DbtProject):
-    queries = _get_queries(dbt_project)
+    queries, name_literal = _render(dbt_project)
 
     # Large default query_max_size / chunk_size -> everything fits in one query.
     assert len(queries) == 1
     query = queries[0]
 
-    # String with a single quote is escaped and quoted.
-    assert "'O''Brien'" in query
+    # String with a single quote is escaped (adapter-specific) and quoted.
+    assert name_literal in query
     # Numbers render without quotes.
     assert "42" in query
     assert "-1.5" in query
@@ -34,7 +38,7 @@ def test_render_insert_rows_queries_values(dbt_project: DbtProject):
 
 def test_render_insert_rows_queries_chunking(dbt_project: DbtProject):
     # chunk_size=1 forces each row into its own query.
-    queries = _get_queries(dbt_project, chunk_size=1)
+    queries, name_literal = _render(dbt_project, chunk_size=1)
     assert len(queries) == 2
-    assert "'O''Brien'" in queries[0]
+    assert name_literal in queries[0]
     assert "'second'" in queries[1]

--- a/integration_tests/tests/test_dbt_artifacts/test_insert_rows.py
+++ b/integration_tests/tests/test_dbt_artifacts/test_insert_rows.py
@@ -2,11 +2,48 @@ import json
 
 from dbt_project import DbtProject
 
+NAME_WITH_QUOTE = "O'Brien"
+
+# Mock schema mixing every type the renderer must handle distinctly.
+COLUMNS = [
+    {"name": "name", "dtype": "varchar"},
+    {"name": "int_col", "dtype": "integer"},
+    {"name": "float_col", "dtype": "float"},
+    {"name": "bool_col", "dtype": "boolean"},
+    {"name": "json_col", "dtype": "varchar"},
+    {"name": "null_col", "dtype": "varchar"},
+    {"name": "created_at", "dtype": "timestamp"},
+]
+
+ROWS = [
+    {
+        "name": NAME_WITH_QUOTE,
+        "int_col": 42,
+        "float_col": 3.14,
+        "bool_col": True,
+        "json_col": {"a": 1, "b": [1, 2]},
+        "null_col": None,
+    },
+    {
+        "name": "second",
+        "int_col": 0,
+        "float_col": -1.5,
+        "bool_col": False,
+        "json_col": [1, "x"],
+        "null_col": "here",
+    },
+]
+
 
 def _render(dbt_project: DbtProject, **macro_args):
     result = dbt_project.dbt_runner.run_operation(
         "elementary_tests.test_render_insert_rows_queries",
-        macro_args=macro_args,
+        macro_args={
+            "columns": COLUMNS,
+            "rows": ROWS,
+            "escape_sample": NAME_WITH_QUOTE,
+            **macro_args,
+        },
     )
     output = json.loads(result[0])
     # Escaping differs per adapter ('' vs \'), so derive the expected quoted

--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -124,20 +124,13 @@
     {% endset %}
     {% do elementary.end_duration_measure_context("base_query_calc") %}
 
-    {# Precompute per-column rendering metadata and adapter implementations once,
-       hoisted out of the per-row loop (dtypes / created_at handling / dispatch
-       results are identical for every row). #}
-    {% set column_meta = elementary.get_row_render_metadata(
+    {% set column_meta = elementary.get_columns_metadata(
         columns, rows[0] if rows else none
     ) %}
     {% set created_at_sql = elementary.edr_current_timestamp() %}
     {% set render_value_impl = adapter.dispatch("render_value", "elementary") %}
     {% set escaper = adapter.dispatch("escape_special_chars", "elementary") %}
 
-    {# Accumulate each chunk's rendered rows in a list and join once when the
-       chunk is finalized, instead of repeatedly concatenating a growing query
-       string (which is O(n^2)). A namespace is required so reassignments made
-       inside the loop persist across iterations. #}
     {% set base_len = base_insert_query | length %}
     {% set chunk = namespace(rows=[], len=base_len, count=0) %}
     {% for row in rows %}
@@ -208,11 +201,7 @@
     {{ return(insert_queries) }}
 {%- endmacro %}
 
-{# Precompute per-column rendering metadata once per insert so the hot per-row
-   loop only does a dict lookup + value render. `sample_row` (the first row) is
-   used to resolve the actual dict key for each column, replacing the per-cell
-   case-insensitive lookup - flatten macros emit consistent keys across rows. #}
-{% macro get_row_render_metadata(columns, sample_row) %}
+{% macro get_columns_metadata(columns, sample_row) %}
     {% set column_meta = [] %}
     {% for column in columns %}
         {% set is_created_at = column.name | lower == "created_at" %}
@@ -347,7 +336,7 @@
 
 {# `escaper` lets callers pass a pre-resolved escape_special_chars implementation
    so the hot insert path avoids an adapter.dispatch per rendered cell. When it's
-   not provided (other callers) it is resolved once here, matching prior behavior. #}
+   not provided it is resolved once here. #}
 {%- macro render_value(value, data_type, escaper=none) -%}
     {{- adapter.dispatch("render_value", "elementary")(value, data_type, escaper) -}}
 {%- endmacro -%}

--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -124,19 +124,35 @@
     {% endset %}
     {% do elementary.end_duration_measure_context("base_query_calc") %}
 
-    {% set current_query = namespace(data=base_insert_query) %}
-    {% set current_chunk_size = namespace(data=0) %}
-    {% for row in rows %}
-        {% set row_sql = elementary.render_row_to_sql(row, columns) %}
-        {% set query_with_row = (
-            current_query.data + ("," if not loop.first else "") + row_sql
-        ) %}
+    {# Precompute per-column rendering metadata and adapter implementations once,
+       hoisted out of the per-row loop (dtypes / created_at handling / dispatch
+       results are identical for every row). #}
+    {% set column_meta = elementary.get_row_render_metadata(
+        columns, rows[0] if rows else none
+    ) %}
+    {% set created_at_sql = elementary.edr_current_timestamp() %}
+    {% set render_value_impl = adapter.dispatch("render_value", "elementary") %}
+    {% set escaper = adapter.dispatch("escape_special_chars", "elementary") %}
 
-        {% if query_with_row | length > query_max_size or current_chunk_size.data >= chunk_size %}
-            {% set new_insert_query = base_insert_query + row_sql %}
+    {# Accumulate each chunk's rendered rows in a list and join once when the
+       chunk is finalized, instead of repeatedly concatenating a growing query
+       string (which is O(n^2)). A namespace is required so reassignments made
+       inside the loop persist across iterations. #}
+    {% set base_len = base_insert_query | length %}
+    {% set chunk = namespace(rows=[], len=base_len, count=0) %}
+    {% for row in rows %}
+        {% set row_sql = elementary.render_row_to_sql(
+            row, column_meta, created_at_sql, render_value_impl, escaper
+        ) %}
+        {% set row_len = row_sql | length %}
+        {% set separator_len = 0 if chunk.count == 0 else 1 %}
+        {% set projected_len = chunk.len + separator_len + row_len %}
+
+        {% if projected_len > query_max_size or chunk.count >= chunk_size %}
+            {% set new_query_len = base_len + row_len %}
 
             {# Check if row is too large to fit into an insert query. #}
-            {% if new_insert_query | length > query_max_size %}
+            {% if new_query_len > query_max_size %}
                 {% if on_query_exceed %}
                     {% do elementary.begin_duration_measure_context(
                         "on_query_exceed"
@@ -144,14 +160,21 @@
                     {% do on_query_exceed(row) %}
                     {% do elementary.end_duration_measure_context("on_query_exceed") %}
 
-                    {% set row_sql = elementary.render_row_to_sql(row, columns) %}
-                    {% set new_insert_query = base_insert_query + row_sql %}
+                    {% set row_sql = elementary.render_row_to_sql(
+                        row,
+                        column_meta,
+                        created_at_sql,
+                        render_value_impl,
+                        escaper,
+                    ) %}
+                    {% set row_len = row_sql | length %}
+                    {% set new_query_len = base_len + row_len %}
                 {% endif %}
 
-                {% if new_insert_query | length > query_max_size %}
+                {% if new_query_len > query_max_size %}
                     {% do elementary.file_log(
                         "Oversized row for insert_rows: {}".format(
-                            query_with_row
+                            base_insert_query + row_sql
                         )
                     ) %}
                     {% do exceptions.warn(
@@ -160,18 +183,24 @@
                 {% endif %}
             {% endif %}
 
-            {% if current_query.data != base_insert_query %}
-                {% do insert_queries.append(current_query.data) %}
+            {% if chunk.count > 0 %}
+                {% do insert_queries.append(
+                    base_insert_query + (chunk.rows | join(","))
+                ) %}
             {% endif %}
-            {% set current_query.data = new_insert_query %}
-            {% set current_chunk_size.data = 1 %}
+            {% set chunk.rows = [row_sql] %}
+            {% set chunk.len = new_query_len %}
+            {% set chunk.count = 1 %}
 
         {% else %}
-            {% set current_query.data = query_with_row %}
-            {% set current_chunk_size.data = current_chunk_size.data + 1 %}
+            {% do chunk.rows.append(row_sql) %}
+            {% set chunk.len = projected_len %}
+            {% set chunk.count = chunk.count + 1 %}
         {% endif %}
         {% if loop.last %}
-            {% do insert_queries.append(current_query.data) %}
+            {% do insert_queries.append(
+                base_insert_query + (chunk.rows | join(","))
+            ) %}
         {% endif %}
     {% endfor %}
 
@@ -179,31 +208,57 @@
     {{ return(insert_queries) }}
 {%- endmacro %}
 
-{% macro render_row_to_sql(row, columns) %}
-    {% do elementary.begin_duration_measure_context("render_row_to_sql") %}
-
-    {% set rendered_column_values = [] %}
+{# Precompute per-column rendering metadata once per insert so the hot per-row
+   loop only does a dict lookup + value render. `sample_row` (the first row) is
+   used to resolve the actual dict key for each column, replacing the per-cell
+   case-insensitive lookup - flatten macros emit consistent keys across rows. #}
+{% macro get_row_render_metadata(columns, sample_row) %}
+    {% set column_meta = [] %}
     {% for column in columns %}
-        {% if column.name.lower() == "created_at" %}
-            {% set column_value = elementary.edr_current_timestamp() %}
-            {% do rendered_column_values.append(column_value) %}
+        {% set is_created_at = column.name | lower == "created_at" %}
+        {% set row_key = none %}
+        {% if not is_created_at and sample_row is not none %}
+            {% if column.name in sample_row %} {% set row_key = column.name %}
+            {% elif column.name | lower in sample_row %}
+                {% set row_key = column.name | lower %}
+            {% elif column.name | upper in sample_row %}
+                {% set row_key = column.name | upper %}
+            {% endif %}
+        {% endif %}
+        {% do column_meta.append(
+            {
+                "is_created_at": is_created_at,
+                "row_key": row_key,
+                "normalized_type": elementary.normalize_data_type(
+                    column.dtype
+                ),
+            }
+        ) %}
+    {% endfor %}
+    {% do return(column_meta) %}
+{% endmacro %}
+
+{% macro render_row_to_sql(
+    row, column_meta, created_at_sql, render_value_impl, escaper
+) %}
+    {% set rendered_column_values = [] %}
+    {% for column in column_meta %}
+        {% if column.is_created_at %}
+            {% do rendered_column_values.append(created_at_sql) %}
         {% else %}
-            {% set column_value = elementary.insensitive_get_dict_value(
-                row, column.name
-            ) %}
-            {% set normalized_data_type = elementary.normalize_data_type(
-                column.dtype
+            {% set column_value = (
+                row.get(column.row_key)
+                if column.row_key is not none
+                else none
             ) %}
             {% do rendered_column_values.append(
-                elementary.render_value(column_value, normalized_data_type)
+                render_value_impl(
+                    column_value, column.normalized_type, escaper
+                )
             ) %}
-
         {% endif %}
     {% endfor %}
-    {% set row_sql = "({})".format(rendered_column_values | join(",")) %}
-
-    {% do elementary.end_duration_measure_context("render_row_to_sql") %}
-    {% do return(row_sql) %}
+    {% do return("({})".format(rendered_column_values | join(","))) %}
 {% endmacro %}
 
 {% macro escape_special_chars(string_value) %}
@@ -290,11 +345,17 @@
     -}}
 {%- endmacro -%}
 
-{%- macro render_value(value, data_type) -%}
-    {{- adapter.dispatch("render_value", "elementary")(value, data_type) -}}
+{# `escaper` lets callers pass a pre-resolved escape_special_chars implementation
+   so the hot insert path avoids an adapter.dispatch per rendered cell. When it's
+   not provided (other callers) it is resolved once here, matching prior behavior. #}
+{%- macro render_value(value, data_type, escaper=none) -%}
+    {{- adapter.dispatch("render_value", "elementary")(value, data_type, escaper) -}}
 {%- endmacro -%}
 
-{%- macro default__render_value(value, data_type) -%}
+{%- macro default__render_value(value, data_type, escaper=none) -%}
+    {%- if escaper is none -%}
+        {%- set escaper = adapter.dispatch("escape_special_chars", "elementary") -%}
+    {%- endif -%}
     {%- if value is defined and value is not none -%}
         {%- if value is boolean -%} {{- elementary.edr_boolean_literal(value) -}}
         {%- elif value is number -%} {{- value -}}
@@ -304,9 +365,9 @@
                     elementary.edr_datetime_to_sql(value)
                 )
             -}}
-        {%- elif value is string -%} '{{- elementary.escape_special_chars(value) -}}'
+        {%- elif value is string -%} '{{- escaper(value) -}}'
         {%- elif value is mapping or value is sequence -%}
-            '{{- elementary.escape_special_chars(tojson(value)) -}}'
+            '{{- escaper(tojson(value)) -}}'
         {%- else -%} null
         {%- endif -%}
     {%- else -%} null

--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -336,7 +336,7 @@
 
 {# `escaper` lets callers pass a pre-resolved escape_special_chars implementation
    so the hot insert path avoids an adapter.dispatch per rendered cell. When it's
-   not provided it is resolved once here. #}
+   not provided, the adapter's render_value resolves it (see default__render_value). #}
 {%- macro render_value(value, data_type, escaper=none) -%}
     {{- adapter.dispatch("render_value", "elementary")(value, data_type, escaper) -}}
 {%- endmacro -%}

--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -124,6 +124,9 @@
     {% endset %}
     {% do elementary.end_duration_measure_context("base_query_calc") %}
 
+    {# Column keys are resolved once from the first row, so every row in the
+       batch is expected to use the same key casing (all callers feed rows from
+       the flatten_* artifact macros, which emit consistent literal keys). #}
     {% set column_meta = elementary.get_columns_metadata(
         columns, rows[0] if rows else none
     ) %}


### PR DESCRIPTION
## Summary

Artifact upload (`DBT_COLUMNS`, ~65k rows) spends minutes in Jinja building `INSERT … VALUES`, dramatically worse under dbt Fusion (MiniJinja FFI overhead per macro/dict boundary). Customer trace: ~8m15s in `render_row_to_sql` across 65,126 rows while the warehouse inserts took only ~45s.

This reworks the hot path in `macros/utils/table_operations/insert_rows.sql` so the per-row loop does only a dict lookup + value render, moving all repeated work out of the loop. No change to the emitted SQL shape (still `INSERT … VALUES`) or to insert semantics across adapters.

### What changed

**(1) Remove per-row duration instrumentation.** `render_row_to_sql` no longer calls `begin/end_duration_measure_context` (was ~65k stack push/pop + `utcnow()` + long name concat per row). Measurement stays at `get_insert_rows_queries` / `insert_rows` level.

**(2) Hoist column-level work out of the loop** into a new `get_row_render_metadata(columns, sample_row)`, computed once per insert:
```
column_meta[i] = {
  is_created_at:  column.name|lower == "created_at",
  row_key:        <actual dict key resolved once from the first row>,
  normalized_type: normalize_data_type(column.dtype),   # was called per cell
}
created_at_sql = edr_current_timestamp()                 # was called per created_at cell
```
This removes ~900k `normalize_data_type → data_type_list` `adapter.dispatch` calls for the customer case.

**(3) Drop `insensitive_get_dict_value` in this path.** `row_key` is resolved once (exact / lower / upper against the first row — flatten emits consistent keys), then the loop does a direct `row.get(row_key)`.

**(4) Resolve `adapter.dispatch` once per insert.** `render_value` and `escape_special_chars` impls are resolved once and reused. `render_value` / `default__render_value` gained an optional `escaper` param so the pre-resolved escaper is threaded through instead of re-dispatching per string cell (default behavior unchanged when `escaper` is omitted, for other callers).

**(5) Fix quadratic chunk assembly.** Instead of `current_query.data + "," + row_sql` on a growing multi-MB string, each chunk accumulates row SQL in a list and joins once:
```
base_insert_query + (chunk.rows | join(","))
```
Length tracking is done incrementally (namespace counter) so no giant string is rebuilt to check `query_max_size`. Existing chunking semantics preserved: `query_max_size`, `chunk_size`, and `on_query_exceed` oversized-row handling.

### Correctness / tests

- Existing `integration_tests/tests/test_dbt_artifacts` suite passes on Postgres (46 passed, 4 skipped), including `test_artifacts_collection_in_multiple_row_batches` (forces small `query_max_size` → multiple chunks).
- Added `test_insert_rows.py` + `test_render_insert_rows_queries` macro covering the rendered VALUES output: single-quote escaping, numbers, nulls, nested mapping/sequence via `tojson`, and chunk splitting.
- The full warehouse matrix (incl. Fusion on Snowflake/BigQuery/Databricks) runs in CI on this PR.


Link to Devin session: https://app.devin.ai/sessions/11d70ed2cdfe4ae182c112e4135de8d3
Requested by: @haritamar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved insert-row SQL rendering for mixed values, including adapter-aware quoting/escaping and proper handling of nulls and nested/JSON-like structures.
  - Added/expanded macro coverage to support configurable escaping samples and consistent chunking behavior for large inserts.

- **Bug Fixes**
  - Strengthened escaping/value rendering to ensure correct string literals (including special characters) and consistent literal serialization across adapters.
  - More reliable chunk splitting, producing correct multiple-query output when row size limits are exceeded.

- **Tests**
  - Added integration tests validating rendered values, escaping behavior, and chunked query splitting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->