### PR TITLE
fix: partition metrics_anomaly_score training stats by dimension

### DIFF
--- a/models/edr/data_monitoring/anomaly_detection/metrics_anomaly_score.sql
+++ b/models/edr/data_monitoring/anomaly_detection/metrics_anomaly_score.sql
@@ -19,27 +19,52 @@ with
             bucket_duration_hours,
             updated_at,
             avg(metric_value) over (
-                partition by metric_name, full_table_name, column_name
+                partition by
+                    metric_name,
+                    full_table_name,
+                    column_name,
+                    dimension,
+                    dimension_value
                 order by bucket_start asc
                 rows between unbounded preceding and current row
             ) as training_avg,
             {{ elementary.standard_deviation("metric_value") }} over (
-                partition by metric_name, full_table_name, column_name
+                partition by
+                    metric_name,
+                    full_table_name,
+                    column_name,
+                    dimension,
+                    dimension_value
                 order by bucket_start asc
                 rows between unbounded preceding and current row
             ) as training_stddev,
             count(metric_value) over (
-                partition by metric_name, full_table_name, column_name
+                partition by
+                    metric_name,
+                    full_table_name,
+                    column_name,
+                    dimension,
+                    dimension_value
                 order by bucket_start asc
                 rows between unbounded preceding and current row
             ) as training_set_size,
             last_value(bucket_end) over (
-                partition by metric_name, full_table_name, column_name
+                partition by
+                    metric_name,
+                    full_table_name,
+                    column_name,
+                    dimension,
+                    dimension_value
                 order by bucket_start asc
                 rows between unbounded preceding and current row
             ) training_end,
             first_value(bucket_end) over (
-                partition by metric_name, full_table_name, column_name
+                partition by
+                    metric_name,
+                    full_table_name,
+                    column_name,
+                    dimension,
+                    dimension_value
                 order by bucket_start asc
                 rows between unbounded preceding and current row
             ) as training_start


### PR DESCRIPTION
Fixes elementary-data/elementary#1729, and addresses the `training_avg` half of elementary-data/elementary#2172.

(Both issues are filed on the `elementary` repo, but the code they describe lives here.)

## Problem

In `models/edr/data_monitoring/anomaly_detection/metrics_anomaly_score.sql`, all five window functions partition by `metric_name, full_table_name, column_name` only:

```sql
avg(metric_value) over (
    partition by metric_name, full_table_name, column_name
    order by bucket_start asc
    rows between unbounded preceding and current row
) as training_avg,
```

`dimension` and `dimension_value` are selected in the CTE and in the `group by`, but they're missing from the partitions. For dimension-based metrics that pools every dimension value into one training set, so `training_avg`, `training_stddev`, `training_set_size`, `training_start` and `training_end` describe the table as a whole rather than the individual dimension value.

The distortion scales with how uneven the dimension values are. Using the example from #2172 — daily counts per `row_type`:

| | D1 | D2 | D3 | D4 |
|---|---|---|---|---|
| X | 1000 | 1001 | 1010 | 1002 |
| Y | 200 | 200 | 201 | 7000 |
| Z | 10 | 10 | 9 | 10 |

**Before:** every row is scored against a pooled average of ~400. X, which has been flat at ~1000 for its entire history, sits far above that mean and reads as anomalous on every bucket. The genuine Y spike at D4 is diluted by the same pooling.

**After:** X is scored against X's history, Y against Y's, Z against Z's. X reads as stable, and Y's D4 spike stands out against its own ~200 baseline.

This matches the reported symptom in #2172 — `latest_metric_value` correct when grouped by the dimension, but `training_avg` far below that dimension's real historical values.

## Change

Added `dimension, dimension_value` to the `partition by` of all five window functions.

This brings the model in line with `macros/edr/data_monitoring/anomaly_detection/get_anomaly_scores_query.sql`, which already partitions the equivalent statistics by `metric_name, full_table_name, column_name, dimension, dimension_value` (see `partition_by_keys`, line 62). The model was simply never updated to match.

Including `dimension` as well as `dimension_value` also handles the case @wbarth11 raised in #1729, where the same value string appears under two different dimensions.

## Scope

- **Non-dimension metrics are unaffected.** `dimension` and `dimension_value` are null for them, and `partition by` treats nulls as a single group, so those rows stay in one partition exactly as before.
- **The test path is unaffected.** `get_anomaly_scores_query` already partitioned correctly; this only changes the `metrics_anomaly_score` view, which is what users query directly and what feeds `anomaly_threshold_sensitivity`.
- `sqlfmt` (v0.29.0, matching `.pre-commit-config.yaml`) passes on the changed file.

## Testing

Verified by inspection and `sqlfmt`. I don't have a warehouse to run the integration suite against — the existing `integration_tests/tests/test_dimension_anomalies.py` cases exercise the test-time path via `get_anomaly_scores_query`, so they don't cover this view. Happy to add coverage for `metrics_anomaly_score` if you can point me at the right place for it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved anomaly detection accuracy by computing historical training statistics separately for each metric dimension and dimension value.
  * This prevents unrelated dimensions from affecting anomaly scores, resulting in more reliable scoring across varied metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
