### PR TITLE
fix: describe the anomalous bucket in non-dimension anomaly alerts

### DIFF
--- a/integration_tests/tests/test_volume_anomalies.py
+++ b/integration_tests/tests/test_volume_anomalies.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime, timedelta
 from typing import Any, Dict, List
 
@@ -66,9 +67,10 @@ def test_volume_anomalies_description_reports_anomalous_bucket(
     assert test_result["status"] == "fail"
 
     # The description must describe the anomalous bucket, not whichever scored
-    # bucket the anomaly scores query happened to return last.
+    # bucket the anomaly scores query happened to return last. Warehouses render
+    # the rounded value differently ("6" vs "6.000"), so match either.
     description = test_result["test_results_description"].lower()
-    assert "6.000" in description
+    assert re.search(r"row_count value is 6(\.0+)?\b", description), description
 
 
 @Parametrization.autodetect_parameters()

--- a/integration_tests/tests/test_volume_anomalies.py
+++ b/integration_tests/tests/test_volume_anomalies.py
@@ -47,6 +47,30 @@ def test_full_drop_table_volume_anomalies(test_id: str, dbt_project: DbtProject)
     assert test_result["status"] == "fail"
 
 
+def test_volume_anomalies_description_reports_anomalous_bucket(
+    test_id: str, dbt_project: DbtProject
+):
+    utc_today = datetime.utcnow().date()
+    test_date, *training_dates = generate_dates(base_date=utc_today - timedelta(days=1))
+
+    # Training buckets hold a single row each, the detected bucket spikes to six.
+    data: List[Dict[str, Any]] = [
+        {TIMESTAMP_COLUMN: test_date.strftime(DATE_FORMAT)} for _ in range(6)
+    ]
+    data += [
+        {TIMESTAMP_COLUMN: cur_date.strftime(DATE_FORMAT)}
+        for cur_date in training_dates
+    ]
+
+    test_result = dbt_project.test(test_id, DBT_TEST_NAME, DBT_TEST_ARGS, data=data)
+    assert test_result["status"] == "fail"
+
+    # The description must describe the anomalous bucket, not whichever scored
+    # bucket the anomaly scores query happened to return last.
+    description = test_result["test_results_description"].lower()
+    assert "6.000" in description
+
+
 @Parametrization.autodetect_parameters()
 @Parametrization.case(name="source", as_model=False)
 @Parametrization.case(name="model", as_model=True)

--- a/macros/edr/data_monitoring/anomaly_detection/store_anomaly_test_results.sql
+++ b/macros/edr/data_monitoring/anomaly_detection/store_anomaly_test_results.sql
@@ -111,7 +111,14 @@
           {% set total = unique_anomalous_rows | length %}
           {% if column_name %}In column {{ column_name | upper }}, {% endif %}{{ total }} anomalous {{ metric_name }} value{% if total > 1 %}s{% endif %} for dimension {{ dimension }}: {{ dim_parts | join(", ") }}{% if total > max_shown %}, and {{ total - max_shown }} more{% endif %}.
         {% else %}
-          {{ elementary.insensitive_get_dict_value(rows_with_score[-1], 'anomaly_description') }}
+          {# Describe an anomalous bucket when there is one, otherwise fall back to
+             the scored buckets. The anomaly scores query has no "order by", so sort
+             explicitly to keep the latest bucket rather than an arbitrary row. #}
+          {% set description_candidates = anomalous_rows if anomalous_rows else rows_with_score %}
+          {% set latest_description_row = (
+              description_candidates | sort(attribute='bucket_end')
+          ) | last %}
+          {{ elementary.insensitive_get_dict_value(latest_description_row, 'anomaly_description') }}
         {% endif %}
       {% else %}
           Not enough data to calculate anomaly score.


### PR DESCRIPTION
## Problem tl;dr

In our alert and test overview description, we pick the bucket that was last non anomalous. This is actually wrong behaviour. We should take the anomalous value (see screenshot). It says "The last row_count value is 0.000.", but it should say in this case "The last row_count value is 6.000."

<img width="685" height="740" alt="Screenshot 2026-08-06 at 11 54 28" src="https://github.com/user-attachments/assets/472da38e-9f26-4477-a21d-0ef6fe0730a2" />

## More info

The non-dimension branch of the anomaly test description picks `rows_with_score[-1]`:

https://github.com/elementary-data/dbt-data-reliability/blob/master/macros/edr/data_monitoring/anomaly_detection/store_anomaly_test_results.sql#L114

Two defects stack on each other:

1. **Wrong candidate set.** `rows_with_score` is every bucket with a non-null `anomaly_score`, not the anomalous ones. The macro already builds `anomalous_rows` a few lines above and uses it in the dimension branch, but the `{% else %}` branch ignores it, so the description can describe a bucket that passed.
2. **`[-1]` on an unordered result.** The anomaly scores query has no `order by`, so `[-1]` is whichever row the warehouse returned last, not the latest bucket. **The comment on the dimension branch already notes this.**

## Observed impact

On a `volume_anomalies` test the execution returned 140 scored buckets with exactly one `is_anomalous = true`:

| field | value |
|---|---|
| bucket | 2026-08-05 → 2026-08-06 |
| `metric_value` | 6 |
| `training_avg` | 1.095 |
| `anomaly_score` | 3.476 (threshold 3) |
| row's own `anomaly_description` | "The last row_count value is 6.000. The average for this metric is 1.095." |

The alert that was rendered and sent to Slack said instead:

> The last row_count value is 0.000. The average for this metric is 1.238.

Those numbers belong to the 2026-08-03 → 2026-08-04 bucket, which had `anomaly_score = -1.05` and `is_anomalous = false`. It was the only row in the set with `training_avg = 1.238`, so the source is unambiguous.

The practical consequence is that the alert **inverted the story**: a spike was reported as a drop to zero. Anyone triaging from Slack goes looking for a broken ingestion pipeline that isn't broken.

## Fix

Prefer `anomalous_rows` when the test failed, fall back to `rows_with_score` when it passed, and sort by `bucket_end` in both cases so `[-1]` means "latest bucket". This mirrors what #1032 already did for the dimension branch, which fixed the same class of bug but only inside `{% if dimension %}`.

## Testing

- Added `test_volume_anomalies_description_reports_anomalous_bucket` covering the reported shape: single-row training buckets, detected bucket spikes to six, description must report the spike.
- `pre-commit run` passes on both changed files (black, isort, flake8, prettier, typos, sqlfmt).
- I could not run the integration suite locally, it needs a warehouse connection. Please let CI exercise it.

Existing description assertions live in `test_column_anomalies.py` and all target the dimension branch or the "not enough data" path, so nothing asserted the old unsorted behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved anomaly failure descriptions to report the metric value from the anomalous bucket.
  * Added a fallback for cases without anomalous buckets, selecting the most recent scored bucket for clearer reporting.
  * Ensured volume anomaly messages no longer display unrelated anomaly-score values.

* **Tests**
  * Added integration coverage to verify accurate volume anomaly descriptions and reported row counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
