### PR TITLE
perf: make the append-only elementary tables actually append-only

### DIFF
--- a/models/edr/data_monitoring/data_monitoring/data_monitoring_metrics.sql
+++ b/models/edr/data_monitoring/data_monitoring/data_monitoring_metrics.sql
@@ -1,7 +1,6 @@
 {{
     config(
         materialized="incremental",
-        unique_key="id",
         on_schema_change="append_new_columns",
         indexes=elementary.get_indexes_for_model(
             "data_monitoring_metrics",
@@ -11,6 +10,7 @@
         ),
         full_refresh=elementary.get_config_var("elementary_full_refresh"),
         meta={
+            "dedup_by_column": "id",
             "timestamp_column": "created_at",
             "prev_timestamp_column": "updated_at",
         },
@@ -19,7 +19,7 @@
             columns=["full_table_name", "metric_name"]
         ),
         table_type=elementary.get_default_table_type(),
-        incremental_strategy=elementary.get_default_incremental_strategy(),
+        incremental_strategy=elementary.get_append_only_incremental_strategy(),
     )
 }}
 

--- a/models/edr/data_monitoring/schema_changes/schema_columns_snapshot.sql
+++ b/models/edr/data_monitoring/schema_changes/schema_columns_snapshot.sql
@@ -1,15 +1,15 @@
 {{
     config(
         materialized="incremental",
-        unique_key="column_state_id",
         on_schema_change="append_new_columns",
         full_refresh=elementary.get_config_var("elementary_full_refresh"),
         meta={
+            "dedup_by_column": "column_state_id",
             "timestamp_column": "created_at",
             "prev_timestamp_column": "detected_at",
         },
         table_type=elementary.get_default_table_type(),
-        incremental_strategy=elementary.get_default_incremental_strategy(),
+        incremental_strategy=elementary.get_append_only_incremental_strategy(),
     )
 }}
 

--- a/models/edr/dbt_artifacts/dbt_run_results.sql
+++ b/models/edr/dbt_artifacts/dbt_run_results.sql
@@ -2,7 +2,6 @@
     config(
         materialized="incremental",
         transient=False,
-        unique_key="model_execution_id",
         on_schema_change="append_new_columns",
         indexes=elementary.get_indexes_for_model(
             "dbt_run_results",
@@ -20,7 +19,7 @@
             "prev_timestamp_column": "generated_at",
         },
         table_type=elementary.get_default_table_type(),
-        incremental_strategy=elementary.get_default_incremental_strategy(),
+        incremental_strategy=elementary.get_append_only_incremental_strategy(),
     )
 }}
 

--- a/models/edr/run_results/dbt_source_freshness_results.sql
+++ b/models/edr/run_results/dbt_source_freshness_results.sql
@@ -1,15 +1,15 @@
 {{
     config(
         materialized="incremental",
-        unique_key="source_freshness_execution_id",
         on_schema_change="append_new_columns",
         full_refresh=elementary.get_config_var("elementary_full_refresh"),
         meta={
+            "dedup_by_column": "source_freshness_execution_id",
             "timestamp_column": "created_at",
             "prev_timestamp_column": "generated_at",
         },
         table_type=elementary.get_default_table_type(),
-        incremental_strategy=elementary.get_default_incremental_strategy(),
+        incremental_strategy=elementary.get_append_only_incremental_strategy(),
         indexes=elementary.get_indexes_for_model(
             "dbt_source_freshness_results",
             [

--- a/models/edr/run_results/elementary_test_results.sql
+++ b/models/edr/run_results/elementary_test_results.sql
@@ -1,15 +1,15 @@
 {{
     config(
         materialized="incremental",
-        unique_key="id",
         on_schema_change="append_new_columns",
         full_refresh=elementary.get_config_var("elementary_full_refresh"),
         meta={
+            "dedup_by_column": "id",
             "timestamp_column": "created_at",
             "prev_timestamp_column": "detected_at",
         },
         table_type=elementary.get_default_table_type(),
-        incremental_strategy=elementary.get_default_incremental_strategy(),
+        incremental_strategy=elementary.get_append_only_incremental_strategy(),
         indexes=elementary.get_indexes_for_model(
             "elementary_test_results",
             [


### PR DESCRIPTION
## Summary

`dbt_run_results`, `elementary_test_results`, `dbt_source_freshness_results`, `data_monitoring_metrics` and `schema_columns_snapshot` never get rows from their model body — it is an empty `select ... where 1=0`, and the actual rows are inserted by the `on-run-end` hooks. But each was configured `materialized="incremental"` with a `unique_key`, so every `dbt run` emitted a merge with a `when matched then update` clause against an empty source:

```sql
merge into dbt_run_results DBT_INTERNAL_DEST
using (<0 rows>) DBT_INTERNAL_SOURCE
    on DBT_INTERNAL_SOURCE.model_execution_id = DBT_INTERNAL_DEST.model_execution_id
when matched then update set ...
when not matched then insert ...
```

The `when matched` clause plus an ON predicate with no partition filter makes BigQuery scan the entire target table — cost grows linearly with history and is paid on every run, for zero rows written. This is the most expensive statement in some users' projects (reported by an OSS user; also option 3 in elementary-data/elementary#1959, which was closed as stale).

Per model:

```diff
-        unique_key="<key>",
         meta={
+            "dedup_by_column": "<key>",
             ...
         },
-        incremental_strategy=elementary.get_default_incremental_strategy(),
+        incremental_strategy=elementary.get_append_only_incremental_strategy(),
```

Without a `unique_key`, dbt generates `on (FALSE) ... when not matched then insert`, which doesn't read the target at all (same as `test_result_rows` today). Nothing is lost: uniqueness was never enforced by the materialization (rows bypass it via direct inserts) and dedup happens at read/dump time via `meta.dedup_by_column`, which is now set on all five models.

One behavior change to be aware of: `dump_table` dedups by `meta.dedup_by_column`, defaulting to `unique_id`. For `dbt_source_freshness_results` (the only newly-annotated model that has both `unique_id` and `generated_at`) dumps now dedup by `source_freshness_execution_id`, i.e. every freshness execution is kept rather than the latest per source. The other models have no `unique_id`/`generated_at`, so no dedup was happening and none starts.

The snapshot-style artifact tables (`dbt_models`, `dbt_tests`, `dbt_sources`, ...) are deliberately untouched: they are written with delete+insert / full replace and are bounded by project size rather than history, so the merge there is cheap and its upsert semantics are meaningful.

Elementary Cloud's synced-schema loader must read the upsert key from `meta.dedup_by_column` (elementary-data/elementary-internal#7249) and be deployed before this is released, otherwise these tables fall back to a time-range replace on sync.

Note for existing users: tables also need a `--full-refresh` to pick up the `created_at` partitioning added in #939/#972.


Link to Devin session: https://app.devin.ai/sessions/28a642e68cf64b94950aea4e21610310
Requested by: @haritamar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incremental processing across monitoring, snapshot, freshness, test, and run-result data to reliably append new records without replacing existing data.
  * Added record-level deduplication to maintain accurate results while preserving historical information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->