### PR TITLE
ci: opt in to allow-unsafe-pr-checkout for fork PR warehouse tests

### DIFF
--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -86,6 +86,13 @@ jobs:
         with:
           path: dbt-data-reliability
           ref: ${{ inputs.dbt-data-reliability-ref }}
+          # Fork PRs are tested via pull_request_target intentionally: the
+          # integration tests need the CI secrets of our test warehouses, which
+          # a pull_request run of a fork cannot access. The caller
+          # (test-all-warehouses.yml) gates fork PRs behind the
+          # elementary_test_env environment, so a maintainer must approve the
+          # run before this fork code is checked out and executed.
+          allow-unsafe-pr-checkout: true
 
       - name: Configure AWS credentials
         if: inputs.warehouse-type == 'athena'

--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -80,12 +80,16 @@ jobs:
           repository: elementary-data/elementary
           path: elementary
           ref: ${{ inputs.elementary-ref }}
+          persist-credentials: false
 
       - name: Checkout dbt package
         uses: actions/checkout@v6
         with:
           path: dbt-data-reliability
           ref: ${{ inputs.dbt-data-reliability-ref }}
+          # Don't leave the base repo's token in the git config: the checked out
+          # code is fork-controlled (see below) and nothing here pushes.
+          persist-credentials: false
           # Fork PRs are tested via pull_request_target intentionally: the
           # integration tests need the CI secrets of our test warehouses, which
           # a pull_request run of a fork cannot access. The caller


### PR DESCRIPTION
## Summary

`actions/checkout` now refuses to check out fork PR code under `pull_request_target` unless `allow-unsafe-pr-checkout: true` is set (see the equivalent failure in `elementary`: [run 31641925693](https://github.com/elementary-data/elementary/actions/runs/31641925693/job/94266473658)), which breaks the cloud warehouse test jobs for fork PRs here too.

Our `pull_request_target` usage is intentional: the cloud integration tests need the CI secrets of our test warehouses, which a fork's `pull_request` run cannot access. `test-all-warehouses.yml` gates fork PRs behind the `elementary_test_env` environment (`approve-fork` job), so a maintainer must approve the run before the fork code is checked out and executed.

So the checkout of the PR head (`Checkout dbt package`) opts in explicitly, with a comment recording the rationale. Paired with elementary-data/elementary#2317.


Link to Devin session: https://app.devin.ai/sessions/9cfcaa3435b64897992abc30956db12a
Requested by: @haritamar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved pull request validation workflows to support package checkout in approved fork-based builds.
  * Added safeguards and guidance requiring approved CI credentials before code from forked pull requests can execute.
  * Clarified the intended validation flow for contributions submitted from external repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->