### PR TITLE
fix(schema_changes): wrap exceptions.raise_compiler_error in double c…

### DIFF
--- a/macros/edr/data_monitoring/schema_changes/get_columns_snapshot_query.sql
+++ b/macros/edr/data_monitoring/schema_changes/get_columns_snapshot_query.sql
@@ -22,7 +22,7 @@
         {% set no_columns_error -%}
             Failed to detect columns for {{ model_relation }}. Ensure it exists and authorized.
         {%- endset %}
-        exceptions.raise_compiler_error(no_columns_error)
+        {{ exceptions.raise_compiler_error(no_columns_error) }}
     {% endif %}
 
     with


### PR DESCRIPTION
## Description
Fixes an issue where `exceptions.raise_compiler_error()` inside `get_columns_snapshot_query.sql` was rendered as literal string text instead of being evaluated by Jinja when columns are missing.

Wrapping the call in double curly braces (`{{ }}`) ensures the compiler error triggers properly and produces a clear, helpful error message rather than a confusing SQL syntax error.

Closes #1047

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected error handling when no columns are detected, ensuring compilation now stops with a clear error instead of generating invalid SQL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->