### PR TITLE
fix: execute INSERTs with fetch=false

### DIFF
--- a/macros/edr/tests/on_run_end/handle_tests_results.sql
+++ b/macros/edr/tests/on_run_end/handle_tests_results.sql
@@ -220,7 +220,7 @@
     {%- do elementary.edr_create_table_as(
         true, temp_relation, test_tables_union_query
     ) %}
-    {% do elementary.run_query(insert_query) %}
+    {% do elementary.execute_no_fetch(insert_query) %}
 
     {# DuckDB: commit so insert survives dbt's post-on-run-end ROLLBACK #}
     {% if target.type == "duckdb" %} {% do adapter.commit() %} {% endif %}
@@ -280,7 +280,7 @@
     {%- do elementary.edr_create_table_as(
         true, temp_relation, test_tables_union_query
     ) %}
-    {% do elementary.run_query(insert_query) %}
+    {% do elementary.execute_no_fetch(insert_query) %}
 
     {# DuckDB: commit so insert survives dbt's post-on-run-end ROLLBACK #}
     {% if target.type == "duckdb" %} {% do adapter.commit() %} {% endif %}

--- a/macros/utils/run_queries/run_query.sql
+++ b/macros/utils/run_queries/run_query.sql
@@ -11,6 +11,14 @@
     {% do return(query_result) %}
 {% endmacro %}
 
+{# DML/DDL must not use dbt.run_query: Fusion's BigQuery path Storage-Reads the
+   destination table when fetch=true, which OOMs on large elementary tables. #}
+{% macro execute_no_fetch(query) %}
+    {% do adapter.execute(
+        elementary.format_query_with_metadata(query), fetch=false
+    ) %}
+{% endmacro %}
+
 {% macro format_query_with_metadata(query) %}
     {% do return(
         adapter.dispatch("format_query_with_metadata", "elementary")(query)

--- a/macros/utils/run_queries/run_query.sql
+++ b/macros/utils/run_queries/run_query.sql
@@ -11,8 +11,8 @@
     {% do return(query_result) %}
 {% endmacro %}
 
-{# DML/DDL must not use dbt.run_query: Fusion's BigQuery path Storage-Reads the
-   destination table when fetch=true, which OOMs on large elementary tables. #}
+{# Execute without fetching a result set. Use this for DML/DDL whose callers
+   discard the result; dbt.run_query always fetches. #}
 {% macro execute_no_fetch(query) %}
     {% do adapter.execute(
         elementary.format_query_with_metadata(query), fetch=false

--- a/macros/utils/run_queries/run_query.sql
+++ b/macros/utils/run_queries/run_query.sql
@@ -14,9 +14,7 @@
 {# Execute without fetching a result set. Use this for DML/DDL whose callers
    discard the result; dbt.run_query always fetches. #}
 {% macro execute_no_fetch(query) %}
-    {% do adapter.execute(
-        elementary.format_query_with_metadata(query), fetch=false
-    ) %}
+    {% do adapter.execute(elementary.format_query_with_metadata(query), fetch=false) %}
 {% endmacro %}
 
 {% macro format_query_with_metadata(query) %}

--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -69,7 +69,7 @@
             "[{}/{}] Running insert query.".format(loop.index, queries_len)
         ) %}
         {% do elementary.begin_duration_measure_context("run_insert_rows_query") %}
-        {% do elementary.run_query(insert_query) %}
+        {% do elementary.execute_no_fetch(insert_query) %}
         {% do elementary.end_duration_measure_context("run_insert_rows_query") %}
     {% endfor %}
 


### PR DESCRIPTION
## Summary

- Add `elementary.execute_no_fetch`, which calls `adapter.execute(..., fetch=false)` after the usual metadata comment wrapping.
- Switch `insert_rows` and the `on-run-end` test-result INSERTs in `handle_tests_results` to that helper instead of `dbt.run_query`.

## Why

Callers already discarded INSERT results. `dbt.run_query` always fetches (`statement(..., fetch_result=true)`).

`adapter.execute(sql, fetch=false)` is the existing dbt adapter API (`fetch=False` is the default on dbt-core 1.x). This is not a Fusion-only flag and should not change 1.x behavior: run the INSERT, do not materialize a result table.

On Fusion this becomes effective once dbt-labs/dbt-core#16064 lands (Fusion currently still drains the Arrow reader on BigQuery even when `fetch=false`).

## Test plan

- [ ] `dbt run` / `dbt test` with Elementary enabled
- [ ] Confirm `on-run-end` still writes run/test results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background data recording by avoiding unnecessary retrieval of query results.
  * Enhanced efficiency when saving metrics, schema snapshots, test results, and other generated records.
  * Preserved metadata formatting during background insert operations.
  * Reduced processing overhead during automated test-result handling and routine data updates.
  * Improved reliability for operations that record generated results without requiring returned query data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->