### PR TITLE
fix: preserve newlines in Spark/Databricks compiled_code (create Spark temp tables with an explicit file format)

### DIFF
--- a/integration_tests/dbt_project/models/one.sql
+++ b/integration_tests/dbt_project/models/one.sql
@@ -1,3 +1,4 @@
+-- Leading comment used by test_compiled_code_preserves_newlines
 {{
     config(
         materialized="table",

--- a/integration_tests/tests/test_dbt_artifacts/test_artifacts.py
+++ b/integration_tests/tests/test_dbt_artifacts/test_artifacts.py
@@ -211,12 +211,13 @@ def test_timings(dbt_project: DbtProject):
 
 
 @pytest.mark.skip_targets(["spark", "fabricspark"])
+@pytest.mark.skip_for_dbt_fusion
 def test_compiled_code_preserves_newlines(dbt_project: DbtProject):
     dbt_project.dbt_runner.vars["disable_dbt_artifacts_autoupload"] = False
     dbt_project.dbt_runner.vars["disable_run_results"] = False
     dbt_project.dbt_runner.run(select=TEST_MODEL)
     results = dbt_project.run_query(
-        """select compiled_code from {{ ref("dbt_run_results") }} where name='%s' and compiled_code is not null"""
+        """select compiled_code from {{ ref("dbt_run_results") }} where name='%s'"""
         % TEST_MODEL
     )
     assert len(results) >= 1

--- a/integration_tests/tests/test_dbt_artifacts/test_artifacts.py
+++ b/integration_tests/tests/test_dbt_artifacts/test_artifacts.py
@@ -210,6 +210,22 @@ def test_timings(dbt_project: DbtProject):
     assert results[0]["execute_started_at"]
 
 
+def test_compiled_code_preserves_newlines(dbt_project: DbtProject):
+    dbt_project.dbt_runner.vars["disable_dbt_artifacts_autoupload"] = False
+    dbt_project.dbt_runner.vars["disable_run_results"] = False
+    dbt_project.dbt_runner.run(select=TEST_MODEL)
+    results = dbt_project.run_query(
+        """select compiled_code from {{ ref("dbt_run_results") }} where name='%s'"""
+        % TEST_MODEL
+    )
+    assert len(results) >= 1
+    for row in results:
+        compiled_code = row["compiled_code"]
+        comment_line, _, rest = compiled_code.lstrip().partition("\n")
+        assert comment_line.startswith("-- Leading comment"), compiled_code
+        assert "select 1" in rest.lower(), compiled_code
+
+
 @pytest.mark.only_on_targets(["bigquery"])
 def test_run_results_partitioned(dbt_project: DbtProject):
     # BigQuery partitioning is enabled by default. Verify the model works and data is readable.

--- a/integration_tests/tests/test_dbt_artifacts/test_artifacts.py
+++ b/integration_tests/tests/test_dbt_artifacts/test_artifacts.py
@@ -216,7 +216,7 @@ def test_compiled_code_preserves_newlines(dbt_project: DbtProject):
     dbt_project.dbt_runner.vars["disable_run_results"] = False
     dbt_project.dbt_runner.run(select=TEST_MODEL)
     results = dbt_project.run_query(
-        """select compiled_code from {{ ref("dbt_run_results") }} where name='%s'"""
+        """select compiled_code from {{ ref("dbt_run_results") }} where name='%s' and compiled_code is not null"""
         % TEST_MODEL
     )
     assert len(results) >= 1

--- a/integration_tests/tests/test_dbt_artifacts/test_artifacts.py
+++ b/integration_tests/tests/test_dbt_artifacts/test_artifacts.py
@@ -210,6 +210,7 @@ def test_timings(dbt_project: DbtProject):
     assert results[0]["execute_started_at"]
 
 
+@pytest.mark.skip_targets(["spark", "fabricspark"])
 def test_compiled_code_preserves_newlines(dbt_project: DbtProject):
     dbt_project.dbt_runner.vars["disable_dbt_artifacts_autoupload"] = False
     dbt_project.dbt_runner.vars["disable_run_results"] = False

--- a/integration_tests/tests/test_dbt_artifacts/test_artifacts.py
+++ b/integration_tests/tests/test_dbt_artifacts/test_artifacts.py
@@ -210,7 +210,6 @@ def test_timings(dbt_project: DbtProject):
     assert results[0]["execute_started_at"]
 
 
-@pytest.mark.skip_targets(["spark", "fabricspark"])
 @pytest.mark.skip_for_dbt_fusion
 def test_compiled_code_preserves_newlines(dbt_project: DbtProject):
     dbt_project.dbt_runner.vars["disable_dbt_artifacts_autoupload"] = False

--- a/macros/edr/system/system_utils/get_config_var.sql
+++ b/macros/edr/system/system_utils/get_config_var.sql
@@ -169,6 +169,16 @@
     {{- return(default_config) -}}
 {%- endmacro -%}
 
+{%- macro spark__get_default_config() -%}
+    {% set default_config = elementary.default__get_default_config() %}
+    {% do default_config.update({"spark_file_format": "parquet"}) %}
+    {{- return(default_config) -}}
+{%- endmacro -%}
+
+{%- macro fabricspark__get_default_config() -%}
+    {{ return(elementary.spark__get_default_config()) }}
+{%- endmacro -%}
+
 {%- macro bigquery__get_default_config() -%}
     {% set default_config = elementary.default__get_default_config() %}
     {% do default_config.update({"query_max_size": 250000}) %}

--- a/macros/utils/table_operations/create_table_as.sql
+++ b/macros/utils/table_operations/create_table_as.sql
@@ -135,7 +135,9 @@
     create or replace temporary view {{ relation }}
     as {{ sql_query }}
     {% else %}
-    create table {{ relation }}
+        {# Without USING, Spark defaults to a Hive text table, which splits rows
+       on newline values when they are read. dbt-spark defaults file_format to parquet. #}
+    create table {{ relation }} using {{ elementary.get_config_var("spark_file_format") }}
     as {{ sql_query }}
     {% endif %}
 {% endmacro %}

--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -321,22 +321,6 @@
     {{- return(string_value | replace("'", "''")) -}}
 {%- endmacro -%}
 
-{# spark__escape_special_chars: Newlines and carriage returns are replaced with
-   spaces (not escape sequences) because Spark SQL does not support multi-line
-   string literals inside INSERT VALUES. Backslashes and single quotes use
-   C-style escaping (\\, \') which is the Spark SQL convention. #}
-{%- macro spark__escape_special_chars(string_value) -%}
-    {{-
-        return(
-            string_value
-            | replace("\\", "\\\\")
-            | replace("'", "\\'")
-            | replace("\n", " ")
-            | replace("\r", " ")
-        )
-    -}}
-{%- endmacro -%}
-
 {# `escaper` lets callers pass a pre-resolved escape_special_chars implementation
    so the hot insert path avoids an adapter.dispatch per rendered cell. When it's
    not provided, the adapter's render_value resolves it (see default__render_value). #}

--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -321,6 +321,28 @@
     {{- return(string_value | replace("'", "''")) -}}
 {%- endmacro -%}
 
+{# spark__escape_special_chars: Newlines and carriage returns are replaced with
+   spaces (not escape sequences) because Spark SQL does not support multi-line
+   string literals inside INSERT VALUES. Backslashes and single quotes use
+   C-style escaping (\\, \') which is the Spark SQL convention. #}
+{%- macro spark__escape_special_chars(string_value) -%}
+    {{-
+        return(
+            string_value
+            | replace("\\", "\\\\")
+            | replace("'", "\\'")
+            | replace("\n", " ")
+            | replace("\r", " ")
+        )
+    -}}
+{%- endmacro -%}
+
+{# Databricks does not have the Spark Thrift INSERT VALUES issue above and needs
+   real newlines preserved in compiled_code for column-level lineage parsing. #}
+{%- macro databricks__escape_special_chars(string_value) -%}
+    {%- do return(elementary.default__escape_special_chars(string_value)) -%}
+{%- endmacro -%}
+
 {# `escaper` lets callers pass a pre-resolved escape_special_chars implementation
    so the hot insert path avoids an adapter.dispatch per rendered cell. When it's
    not provided, the adapter's render_value resolves it (see default__render_value). #}

--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -321,28 +321,6 @@
     {{- return(string_value | replace("'", "''")) -}}
 {%- endmacro -%}
 
-{# spark__escape_special_chars: Newlines and carriage returns are replaced with
-   spaces (not escape sequences) because Spark SQL does not support multi-line
-   string literals inside INSERT VALUES. Backslashes and single quotes use
-   C-style escaping (\\, \') which is the Spark SQL convention. #}
-{%- macro spark__escape_special_chars(string_value) -%}
-    {{-
-        return(
-            string_value
-            | replace("\\", "\\\\")
-            | replace("'", "\\'")
-            | replace("\n", " ")
-            | replace("\r", " ")
-        )
-    -}}
-{%- endmacro -%}
-
-{# Databricks does not have the Spark Thrift INSERT VALUES issue above and needs
-   real newlines preserved in compiled_code for column-level lineage parsing. #}
-{%- macro databricks__escape_special_chars(string_value) -%}
-    {%- do return(elementary.default__escape_special_chars(string_value)) -%}
-{%- endmacro -%}
-
 {# `escaper` lets callers pass a pre-resolved escape_special_chars implementation
    so the hot insert path avoids an adapter.dispatch per rendered cell. When it's
    not provided, the adapter's render_value resolves it (see default__render_value). #}
@@ -370,10 +348,6 @@
         {%- endif -%}
     {%- else -%} null
     {%- endif -%}
-{%- endmacro -%}
-
-{%- macro fabricspark__escape_special_chars(string_value) -%}
-    {{- return(elementary.spark__escape_special_chars(string_value)) -}}
 {%- endmacro -%}
 
 {# Note: Python booleans pass Jinja's "is number" test, so we check

--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -321,6 +321,24 @@
     {{- return(string_value | replace("'", "''")) -}}
 {%- endmacro -%}
 
+{# Hive text-serde tables cannot hold newlines inside a value (rows split on
+   read), so only when the user opts into `spark_file_format: hive` do we
+   flatten them to spaces; every other format keeps the default escaping. #}
+{%- macro spark__escape_special_chars(string_value) -%}
+    {%- if elementary.get_config_var("spark_file_format") == "hive" -%}
+        {{-
+            return(
+                string_value
+                | replace("\\", "\\\\")
+                | replace("'", "\\'")
+                | replace("\n", " ")
+                | replace("\r", " ")
+            )
+        -}}
+    {%- endif -%}
+    {{- return(elementary.default__escape_special_chars(string_value)) -}}
+{%- endmacro -%}
+
 {# `escaper` lets callers pass a pre-resolved escape_special_chars implementation
    so the hot insert path avoids an adapter.dispatch per rendered cell. When it's
    not provided, the adapter's render_value resolves it (see default__render_value). #}
@@ -348,6 +366,10 @@
         {%- endif -%}
     {%- else -%} null
     {%- endif -%}
+{%- endmacro -%}
+
+{%- macro fabricspark__escape_special_chars(string_value) -%}
+    {{- return(elementary.spark__escape_special_chars(string_value)) -}}
 {%- endmacro -%}
 
 {# Note: Python booleans pass Jinja's "is number" test, so we check


### PR DESCRIPTION
## Summary

Since 0.23.0 (#946), `spark__escape_special_chars` replaced `\n`/`\r` with spaces. dbt-databricks dispatches `databricks → spark → default`, so every Databricks customer's `compiled_code` in `dbt_run_results` was flattened to one line; any model starting with a `--` comment then fails to parse in Elementary Cloud column-level lineage (`ParseError: No expression was parsed from '-- ...'`), and inline `--` comments silently truncate lineage.

#946 attributed the OSS Spark row corruption to `INSERT VALUES` not supporting `\n` escapes. That was a misdiagnosis. The actual cause is how the intermediate table is created:

```sql
-- spark__edr_get_create_table_as_sql (non-temporary, used for artifact staging on dbt-spark)
create table <tmp> as select ... where 1=0     -- no USING
```

With Spark 3's default `spark.sql.legacy.createHiveTableByDefault=true` this is a Hive **TEXTFILE** table (`LazySimpleSerDe`/`TextInputFormat`, confirmed via `describe extended`). A text serde cannot hold a newline inside a value, so every escaped `\n` splits a row on read (the 37-tuple insert → 55 rows). The same insert into a `using parquet`/`using delta` table round-trips newlines correctly.

Fix (root cause, not a workaround):

```diff
- create table {{ relation }} as {{ sql_query }}
+ create table {{ relation }} using {{ elementary.get_config_var("spark_file_format") }} as {{ sql_query }}
```

with a new `spark__get_default_config` (`spark_file_format: parquet`, dbt-spark's own default; `fabricspark` delegates). `spark__escape_special_chars` now flattens newlines **only when** `spark_file_format == "hive"` (the one format that can't hold them) and otherwise delegates to `default__escape_special_chars`; `databricks__escape_special_chars` is removed so dbt-databricks uses the default `\\n` escaping. This also covers customers running the `dbt-spark` adapter against Databricks (target type `spark`), which a Databricks-only override would have missed.

Regression test: `test_compiled_code_preserves_newlines` runs a model whose compiled SQL starts with a `-- comment` line (`models/one.sql`) and asserts the persisted `compiled_code` keeps that comment on its own line with the query after it. Runs on all targets incl. spark/fabricspark; skipped on dbt-fusion, which currently writes no `compiled_code` rows in this path.

Verified locally on the Docker Spark Thrift setup: full `test_artifacts.py` (16 passed incl. `test_artifacts_collection_in_multiple_row_batches` and the new test), insert-rows/long-string tests, `dbt parse --target spark`, pre-commit. Also checked `spark_file_format: hive` one-off: multi-batch test still 37/37 (flattening protects the text table), newline test fails there as expected.

Note for Cloud: affected customers need the package upgrade + a dbt run; flattened models will recompute automatically since the compiled-code hash changes.

Link to Devin session: https://app.devin.ai/sessions/7c9a2683e2d446428a12decba40a004b
Open in Devin Desktop: https://app.devin.ai/desktop/session/7c9a2683e2d446428a12decba40a004b?variant=devin
Requested by: @haritamar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Spark and Fabric Spark defaults, including Parquet as the default Spark file format.
  * Spark-created non-temporary tables now explicitly use the configured file format.

* **Bug Fixes**
  * Fixed compiled SQL formatting so leading comments and newline characters are preserved.
  * Expanded compiled-code validation for Spark and Fabric Spark.
  * Standardized special-character escaping across Spark-based adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->