### PR TITLE
fix: render datetime values in render_value (fixes Fusion test_timings)

### DIFF
--- a/macros/utils/data_types/edr_is_datetime.sql
+++ b/macros/utils/data_types/edr_is_datetime.sql
@@ -1,0 +1,9 @@
+{% macro edr_is_datetime(val) %}
+    {# Duck-typed check for date/datetime objects (works on both dbt-core and Fusion) #}
+    {% do return(
+        val is not none
+        and val is not string
+        and val is not mapping
+        and val.year is defined
+    ) %}
+{% endmacro %}

--- a/macros/utils/graph/get_run_result_dict.sql
+++ b/macros/utils/graph/get_run_result_dict.sql
@@ -9,7 +9,11 @@
         {% set timing_dicts = [] %}
         {% if run_result.timing %}
             {% for item in run_result.timing %}
-                {% do timing_dicts.append(elementary.dbt_object_to_dict(item)) %}
+                {% do timing_dicts.append(
+                    elementary.normalize_timing_dict(
+                        elementary.dbt_object_to_dict(item)
+                    )
+                ) %}
             {% endfor %}
         {% endif %}
 
@@ -30,4 +34,21 @@
             }
         ) %}
     {% endif %}
+{% endmacro %}
+
+{# dbt Fusion exposes timing timestamps as datetime objects rather than ISO
+   strings; render_value would otherwise insert them as null. #}
+{% macro normalize_timing_dict(timing) %}
+    {% if timing is not mapping %} {% do return(timing) %} {% endif %}
+    {% set normalized = {} %}
+    {% for key, value in timing.items() %}
+        {% if key in [
+            "started_at",
+            "completed_at",
+        ] and value is not none and value is not string %}
+            {% do normalized.update({key: value.isoformat()}) %}
+        {% else %} {% do normalized.update({key: value}) %}
+        {% endif %}
+    {% endfor %}
+    {% do return(normalized) %}
 {% endmacro %}

--- a/macros/utils/graph/get_run_result_dict.sql
+++ b/macros/utils/graph/get_run_result_dict.sql
@@ -9,11 +9,7 @@
         {% set timing_dicts = [] %}
         {% if run_result.timing %}
             {% for item in run_result.timing %}
-                {% do timing_dicts.append(
-                    elementary.normalize_timing_dict(
-                        elementary.dbt_object_to_dict(item)
-                    )
-                ) %}
+                {% do timing_dicts.append(elementary.dbt_object_to_dict(item)) %}
             {% endfor %}
         {% endif %}
 
@@ -34,21 +30,4 @@
             }
         ) %}
     {% endif %}
-{% endmacro %}
-
-{# dbt Fusion exposes timing timestamps as datetime objects rather than ISO
-   strings; render_value would otherwise insert them as null. #}
-{% macro normalize_timing_dict(timing) %}
-    {% if timing is not mapping %} {% do return(timing) %} {% endif %}
-    {% set normalized = {} %}
-    {% for key, value in timing.items() %}
-        {% if key in [
-            "started_at",
-            "completed_at",
-        ] and value is not none and value is not string %}
-            {% do normalized.update({key: value.isoformat()}) %}
-        {% else %} {% do normalized.update({key: value}) %}
-        {% endif %}
-    {% endfor %}
-    {% do return(normalized) %}
 {% endmacro %}

--- a/macros/utils/run_queries/agate_to_dicts.sql
+++ b/macros/utils/run_queries/agate_to_dicts.sql
@@ -29,16 +29,6 @@
     {% do return(val) %}
 {% endmacro %}
 
-{% macro edr_is_datetime(val) %}
-    {# Duck-typed check for date/datetime objects (works on both dbt-core and Fusion) #}
-    {% do return(
-        val is not none
-        and val is not string
-        and val is not mapping
-        and val.year is defined
-    ) %}
-{% endmacro %}
-
 {% macro edr_is_decimal(val) %}
     {# A hacky way to check if a value is of type Decimal, as there isn't a straightforward way to check that #}
     {% do return(

--- a/macros/utils/run_queries/agate_to_dicts.sql
+++ b/macros/utils/run_queries/agate_to_dicts.sql
@@ -20,11 +20,23 @@
 {% endmacro %}
 
 {% macro agate_val_serialize(val) %}
-    {% if val.year is defined %} {% do return(val.isoformat()) %} {% endif %}
+    {% if elementary.edr_is_datetime(val) %}
+        {% do return(val.isoformat()) %}
+    {% endif %}
     {% if elementary.edr_is_decimal(val) %}
         {% do return(elementary.edr_serialize_decimal(val)) %}
     {% endif %}
     {% do return(val) %}
+{% endmacro %}
+
+{% macro edr_is_datetime(val) %}
+    {# Duck-typed check for date/datetime objects (works on both dbt-core and Fusion) #}
+    {% do return(
+        val is not none
+        and val is not string
+        and val is not mapping
+        and val.year is defined
+    ) %}
 {% endmacro %}
 
 {% macro edr_is_decimal(val) %}

--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -349,6 +349,9 @@
         {%- set escaper = adapter.dispatch("escape_special_chars", "elementary") -%}
     {%- endif -%}
     {%- if value is defined and value is not none -%}
+        {%- if value is not string and value.year is defined -%}
+            {%- set value = value.isoformat() -%}
+        {%- endif -%}
         {%- if value is boolean -%} {{- elementary.edr_boolean_literal(value) -}}
         {%- elif value is number -%} {{- value -}}
         {%- elif value is string and data_type == "timestamp" -%}

--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -350,9 +350,8 @@
     {%- endif -%}
     {%- if value is defined and value is not none -%}
         {%- if elementary.edr_is_datetime(value) -%}
-            {%- set value = value.isoformat() -%}
-        {%- endif -%}
-        {%- if value is boolean -%} {{- elementary.edr_boolean_literal(value) -}}
+            {{- elementary.render_value(value.isoformat(), data_type, escaper) -}}
+        {%- elif value is boolean -%} {{- elementary.edr_boolean_literal(value) -}}
         {%- elif value is number -%} {{- value -}}
         {%- elif value is string and data_type == "timestamp" -%}
             {{-

--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -349,7 +349,7 @@
         {%- set escaper = adapter.dispatch("escape_special_chars", "elementary") -%}
     {%- endif -%}
     {%- if value is defined and value is not none -%}
-        {%- if value is not string and value.year is defined -%}
+        {%- if value is not string and value is not mapping and value.year is defined -%}
             {%- set value = value.isoformat() -%}
         {%- endif -%}
         {%- if value is boolean -%} {{- elementary.edr_boolean_literal(value) -}}

--- a/macros/utils/table_operations/insert_rows.sql
+++ b/macros/utils/table_operations/insert_rows.sql
@@ -349,7 +349,7 @@
         {%- set escaper = adapter.dispatch("escape_special_chars", "elementary") -%}
     {%- endif -%}
     {%- if value is defined and value is not none -%}
-        {%- if value is not string and value is not mapping and value.year is defined -%}
+        {%- if elementary.edr_is_datetime(value) -%}
             {%- set value = value.isoformat() -%}
         {%- endif -%}
         {%- if value is boolean -%} {{- elementary.edr_boolean_literal(value) -}}


### PR DESCRIPTION
## Summary

Fusion `test_timings` has been failing in every recent run (`assert results[0]["execute_started_at"]` → `None`).

**Root cause:** CI installs the latest Fusion on each run. Since `2.0.0-preview.218` (last green was `preview.205`), `run_result.timing[*].started_at/completed_at` are exposed to Jinja as datetime objects rather than ISO strings. `default__render_value` had no datetime branch, so these fell through to the `null` fallback and all `*_started_at/_completed_at` columns in `dbt_run_results` were inserted as NULL. Timing extraction in `flatten_run_result` was correct — the loss happened at SQL-literal rendering.

**Fix:** add datetime support directly in `render_value`, via a new shared `edr_is_datetime` macro (also used by `agate_val_serialize`, which previously inlined the same duck-typed check):

```jinja
{% macro edr_is_datetime(val) %}
    {% do return(val is not none and val is not string and val is not mapping and val.year is defined) %}
{% endmacro %}

{# default__render_value #}
{%- if elementary.edr_is_datetime(value) -%}
    {%- set value = value.isoformat() -%}
{%- endif -%}
{# ...existing string/timestamp branches handle the ISO string as before #}
```

Notes:
- Duck-typing on `.year` (not `.isoformat`) is required: under Fusion's Jinja, `value.isoformat is defined` is `False` for datetime objects even though `value.isoformat()` is callable.
- `is not mapping` guards against dicts with a `year` key resolving via attribute lookup.

**Verified locally** on Fusion `2.0.0-preview.218` (experimental postgres adapter) — `dbt_run_results` timestamps populated — and on dbt-core postgres (`test_timings`, `test_insert_rows`, `test_artifacts` pass).

Link to Devin session: https://app.devin.ai/sessions/6726671cbb9f449c8089476ee27d6f73
Open in Devin Desktop: https://app.devin.ai/desktop/session/6726671cbb9f449c8089476ee27d6f73?variant=devin
Requested by: @haritamar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved datetime detection during value rendering and serialization for more consistent results.
  - Datetime values continue to be serialized in ISO format.
  - Mapping values are preserved rather than converted to ISO-formatted strings when they expose a `year` attribute.
  - Decimal values and other fallback serialization behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->