### PR TITLE
fix: make metric_stability run on BigQuery and ClickHouse (follow-up to #1050)

### DIFF
--- a/integration_tests/tests/test_metric_stability.py
+++ b/integration_tests/tests/test_metric_stability.py
@@ -258,12 +258,19 @@ def test_metric_stability_ignores_measurements_taken_while_settling(
     # Backdate this run's measurements into the settling window and move their
     # values far away. Were they still eligible as a baseline, the next run
     # would compare 100 against 10 and report a 900% change.
+    if dbt_project.target == "clickhouse":
+        # ClickHouse only supports updates as (asynchronous) mutations.
+        update_clause = "ALTER TABLE {{ ref('data_monitoring_metrics') }} UPDATE"
+        update_suffix = "SETTINGS mutations_sync = 1"
+    else:
+        update_clause = "UPDATE {{ ref('data_monitoring_metrics') }} SET"
+        update_suffix = ""
     dbt_project.run_query(
         f"""
-        UPDATE {{{{ ref('data_monitoring_metrics') }}}}
-        SET metric_value = 10, updated_at = bucket_end
+        {update_clause} metric_value = 10, updated_at = bucket_end
         WHERE full_table_name LIKE '%{test_id.upper()}'
         AND metric_name = 'sum'
+        {update_suffix}
         """
     )
 

--- a/macros/edr/data_monitoring/monitors_query/metric_stability_query.sql
+++ b/macros/edr/data_monitoring/monitors_query/metric_stability_query.sql
@@ -78,8 +78,13 @@
         find is buried under it. Measurements are therefore bounded by the same
         age as the buckets. The current run's own measurement always qualifies:
         a bucket is only eligible once bucket_end + min_bucket_age has passed. -#}
-    {%- set settled_measurement_window = "updated_at >= " ~ elementary.edr_timeadd(
-        min_bucket_age.period, min_bucket_age.count, "bucket_end"
+    {%- set settled_measurement_window = (
+        "updated_at >= "
+        ~ elementary.edr_cast_as_timestamp(
+            elementary.edr_timeadd(
+                min_bucket_age.period, min_bucket_age.count, "bucket_end"
+            )
+        )
     ) %}
     {%- set history_window = bucket_window ~ " and " ~ settled_measurement_window %}
 


### PR DESCRIPTION
## Summary

Fixes the two CI failures on #1050 (this branch is #1050 + one commit on top; it can be merged as-is or the commit cherry-picked into #1050).

**BigQuery** – `test_metric_stability_detects_restatement_with_weekly_buckets` errored with `No matching signature for operator >= for argument types: TIMESTAMP, DATE`. `bigquery__edr_timeadd` returns a `DATE` for `week`/`month`/`quarter`/`year` parts (it uses `date_add(cast(... as date), ...)`), so the settled-measurement bound compared a `TIMESTAMP` column against a `DATE`:

```diff
-updated_at >= {{ edr_timeadd(min_bucket_age.period, min_bucket_age.count, "bucket_end") }}
+updated_at >= {{ edr_cast_as_timestamp(edr_timeadd(min_bucket_age.period, min_bucket_age.count, "bucket_end")) }}
```

Same pattern as `get_start_bucket_in_data`. Day-based ages were unaffected, which is why only the weekly test caught it.

**ClickHouse** – `test_metric_stability_ignores_measurements_taken_while_settling` issues a plain `UPDATE` on `data_monitoring_metrics`, which ClickHouse rejects (`Lightweight updates are not supported`). On that target the test now runs `ALTER TABLE ... UPDATE ... SETTINGS mutations_sync = 1` instead (synchronous so the next run sees the mutated rows).

Verified locally: both tests pass on postgres; the settling test passes on ClickHouse. No BQ credentials locally — relying on CI here.

The remaining `test_dbt_artifacts/test_artifacts.py::test_timings` failures on the fusion jobs in #1050 are unrelated to this feature (a separate fix landed via `devin/1788692120-fusion-timing-datetime`).

Link to Devin session: https://app.devin.ai/sessions/2c8e65abe19f4bae97f105d9638d1065
Open in Devin Desktop: https://app.devin.ai/desktop/session/2c8e65abe19f4bae97f105d9638d1065?variant=devin
Requested by: @haritamar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metric stability monitoring to detect unexpected changes in settled historical metric values.
  * Supports comparisons against initial or most recent measurements, configurable change thresholds, time buckets, and multiple metric columns.
  * Retains measurement history to identify gradual drift and later restatements.
  * Excludes unsettled or still-settling measurements and validates supported bucket configurations.

* **Tests**
  * Added comprehensive integration coverage for detection, thresholds, history retention, time buckets, and adapter-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->