### PR TITLE
ci: raise warehouse test job timeout to 90 minutes

### DIFF
--- a/.github/workflows/test-warehouse.yml
+++ b/.github/workflows/test-warehouse.yml
@@ -60,7 +60,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       contents: read
       # Mint an OIDC token to assume the shared elementary-oss AWS role.


### PR DESCRIPTION
## Summary
`test-warehouse.yml` `timeout-minutes: 60 -> 90`.

The `latest_official, databricks_catalog` job already runs 47–60 min on recent branches (a pass at 59m46s on #1050's earlier run), and #1050 adds 19 `test_metric_stability` tests at ~1–4 min each on Databricks, which pushed it to 99% complete when cancelled in https://github.com/elementary-data/dbt-data-reliability/actions/runs/34201868801. The Spark job in the same run also hit the limit, but that was a 50‑minute hang in the Spark Docker build's `wget` downloads (infra flake), not test runtime.

Link to Devin session: https://app.devin.ai/sessions/d520e797006a405d96e2fed89117a356
Open in Devin Desktop: https://app.devin.ai/desktop/session/d520e797006a405d96e2fed89117a356?variant=devin
Requested by: @haritamar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Extended the automated test workflow timeout to 90 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->