### PR TITLE
perf: partition elementary_test_results and test_result_rows on created_at

### DIFF
--- a/models/edr/run_results/elementary_test_results.sql
+++ b/models/edr/run_results/elementary_test_results.sql
@@ -2,6 +2,7 @@
     config(
         materialized="incremental",
         on_schema_change="append_new_columns",
+        partition_by=elementary.get_partition_by(),
         full_refresh=elementary.get_config_var("elementary_full_refresh"),
         meta={
             "dedup_by_column": "id",

--- a/models/edr/run_results/model_run_results.sql
+++ b/models/edr/run_results/model_run_results.sql
@@ -25,6 +25,7 @@ select
     run_results.query_id,
     run_results.name,
     run_results.generated_at,
+    run_results.created_at,
     run_results.status,
     run_results.full_refresh,
     run_results.message,

--- a/models/edr/run_results/test_result_rows.sql
+++ b/models/edr/run_results/test_result_rows.sql
@@ -10,6 +10,7 @@
                 {"columns": ["detected_at"]},
             ],
         ),
+        partition_by=elementary.get_partition_by(),
         full_refresh=elementary.get_config_var("elementary_full_refresh"),
         meta={
             "timestamp_column": "created_at",


### PR DESCRIPTION
## What

Two changes, both one-liners:

1. `partition_by=elementary.get_partition_by()` on `elementary_test_results` and `test_result_rows` — the package's existing `created_at` default, matching how `dbt_run_results` and `dbt_invocations` already declare it.
2. `run_results.created_at` added to the `model_run_results` view's select list.

## Why

These are the two largest tables the package creates, both append-only, both read with a `days_back` lookback — and neither declares `partition_by`, so on BigQuery every read scans all history. On one warehouse they are 26M rows / 41GB and 12M rows / 13GB.

`created_at` rather than `detected_at` because it is each table's declared `meta.timestamp_column`, and because it is monotonic with insertion: `insert_rows` stamps it from `edr_current_timestamp()` at insert and never reads it from the row payload, so on an append-only table writes always land in the newest partition. A business timestamp could be backdated and scatter writes across old partitions.

### The view change

`model_run_results` selects an explicit column list and omits `created_at`, so consumers of the view have no prunable column at all: its other timestamps (`generated_at`, `execute_completed_at`) are stored as strings, so any predicate on them needs a cast, and a cast defeats pruning. Adding the column is a prerequisite for fixing the CLI's `get_models_runs`, which reads this view and currently scans the whole table on every report.

The view is rebuilt on every run and this only adds a column, so nothing downstream breaks.

## Effect on existing installations

None automatically, and nothing breaks. dbt applies partitioning only when a table is created, so existing tables keep their current layout and their queries remain valid — they simply do not gain pruning until the table is rebuilt.

Worth being explicit that **`--full-refresh` is not the way to get it**: these models compile to an empty table and are populated by `on-run-end` hooks, so a full refresh would discard all history. The package already prevents this — `elementary_full_refresh` defaults to `false` — but anyone who has enabled that var should not reach for it here. The safe route is a one-off rebuild that preserves rows:

```sql
CREATE TABLE `<project>.<elementary_schema>.elementary_test_results__partitioned`
PARTITION BY timestamp_trunc(created_at, DAY)
AS SELECT * FROM `<project>.<elementary_schema>.elementary_test_results`;
-- verify row counts match, then drop the original and rename this into place
```

(BigQuery rejects `CREATE OR REPLACE` across a partitioning change, hence build-and-swap.)

## Non-BigQuery adapters

No-op. `default__get_partition_by` returns `none`, and `bigquery__get_partition_by` also returns `none` when `bigquery_disable_partitioning` is set, so the existing opt-out is respected.

## Testing

`sqlfmt` reports no changes on all three files. The partition column exists on both models — `empty_table.sql` declares `created_at` as a `timestamp` for each.

I have not run the full integration suite across all five platforms; these are config-only additions that are inert off BigQuery, and I am happy to run the BigQuery suite or make changes if you would like.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved partitioning configuration for test result data processing.
  * Added `created_at` timestamps to model run results, providing more complete run metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->